### PR TITLE
App crashing on opening Download folder in lg g3

### DIFF
--- a/app/src/main/res/layout/rowlayout.xml
+++ b/app/src/main/res/layout/rowlayout.xml
@@ -116,7 +116,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:gravity="center_vertical"
-            android:maxLines="1"
+            android:singleLine="true"
             android:ellipsize="middle"
             android:clickable="false"
             android:textSize="17sp" />


### PR DESCRIPTION
Replaced maxline with single line. There is an issue with ellipsize if used along with maxline in the old android versions.

https://issuetracker.google.com/issues/36950033

https://github.com/TeamAmaze/AmazeFileManager/issues/812

