### PR TITLE
Revert "Remove Async inner class from inside method to avoid memory leaks"

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/fragments/MainFragment.java
+++ b/app/src/main/java/com/amaze/filemanager/fragments/MainFragment.java
@@ -98,7 +98,6 @@ import com.amaze.filemanager.utils.OTGUtil;
 import com.amaze.filemanager.utils.OpenMode;
 import com.amaze.filemanager.utils.SmbStreamer.Streamer;
 import com.amaze.filemanager.utils.Utils;
-import com.amaze.filemanager.utils.application.AppConfig;
 import com.amaze.filemanager.utils.cloud.CloudUtil;
 import com.amaze.filemanager.utils.color.ColorUsage;
 import com.amaze.filemanager.utils.files.CryptUtil;
@@ -1656,39 +1655,20 @@ public class MainFragment extends android.support.v4.app.Fragment implements Bot
             // no results were found
             LIST_ELEMENTS.clear();
         }
-        
-        AppConfig.runInBackground(new AppConfig.CustomAsyncCallbacks() {
+        new AsyncTask<Void, Void, Void>() {
             @Override
-            public <E> E doInBackground() {
-
+            protected Void doInBackground(Void... params) {
                 Collections.sort(LIST_ELEMENTS, new FileListSorter(dsort, sortby, asc));
                 return null;
             }
 
             @Override
-            public Void onPostExecute(Object result) {
-
+            public void onPostExecute(Void c) {
                 reloadListElements(true, true, !IS_LIST);// TODO: 7/7/2017 this is really inneffient, use RecycleAdapter's createHeaders()
                 getMainActivity().getAppbar().getBottomBar().setPathText("");
                 getMainActivity().getAppbar().getBottomBar().setFullPathText(getString(R.string.searchresults, query));
-                return null;
             }
-
-            @Override
-            public Void onPreExecute() {
-                return null;
-            }
-
-            @Override
-            public Void publishResult(Object... result) {
-                return null;
-            }
-
-            @Override
-            public <T> T[] params() {
-                return null;
-            }
-        });
+        }.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
     }
 
     public static void launchSMB(final SmbFile smbFile, final long si, final Activity activity) {


### PR DESCRIPTION
Anonimous classes have an implicit reference to 'this' and thus are not static; this makes them especially prone to memory leaks. Both the code before and after have possibility of memory leak.
In my opinion the best solution would be a public AsyncTask or a static inner AsyncTask with a weakreference to context.
This reverts commit 38586bc320f6b4a35ef5bd4fa7a1e3f4e918c6db.