### PR TITLE
Issues/785 copy crash

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/fragments/MainFragment.java
+++ b/app/src/main/java/com/amaze/filemanager/fragments/MainFragment.java
@@ -1027,8 +1027,8 @@ public class MainFragment extends android.support.v4.app.Fragment implements Bot
             loadFilesListTask.cancel(true);
         }
 
-        loadFilesListTask = new LoadFilesListTask(ma.getActivity(), path, ma, openMode,(data) -> {
-            if (data.second != null) {
+        loadFilesListTask = new LoadFilesListTask(ma.getActivity(), path, ma, openMode, (data) -> {
+            if (data != null && data.second != null) {
                 setListElements(data.second, back, path, data.first, false, checkPathIsGrid(path));
                 mSwipeRefreshLayout.setRefreshing(false);
             }

--- a/app/src/play/java/com/amaze/filemanager/activities/MainActivity.java
+++ b/app/src/play/java/com/amaze/filemanager/activities/MainActivity.java
@@ -1575,8 +1575,9 @@ public class MainActivity extends ThemedActivity implements OnRequestPermissions
                         oppathe = "";
                     }
                     for (int i = 0; i < oparrayListList.size(); i++) {
+                        ArrayList<HybridFileParcelable> sourceList = oparrayListList.get(i);
                         Intent intent1 = new Intent(con, CopyService.class);
-                        intent1.putExtra(CopyService.TAG_COPY_SOURCES, oparrayList.get(i));
+                        intent1.putExtra(CopyService.TAG_COPY_SOURCES, sourceList);
                         intent1.putExtra(CopyService.TAG_COPY_TARGET, oppatheList.get(i));
                         ServiceWatcherUtil.runService(this, intent1);
                     }


### PR DESCRIPTION
fixes https://github.com/TeamAmaze/AmazeFileManager/issues/785

NOTE: there was 2 crashes I saw when copying so I included both fixes.. 

- the primary fix was in MainActivity referencing oparrayList which was just set to 'null' a few lines above