### PR TITLE
Code cleanup for Services and ProgressViewerFragment

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -169,6 +169,10 @@
             android:label="@string/crypt_encrypting"
             />
 
+        <service android:name=".asynchronous.services.DecryptService"
+            android:label="@string/crypt_decrypting"
+            />
+
         <service
             android:name="com.amaze.filemanager.asynchronous.ftpservice.FTPService"
             android:enabled="true"

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/services/CopyService.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/services/CopyService.java
@@ -482,22 +482,14 @@ public class CopyService extends ProgressiveService {
                 mBuilder.setOngoing(false);
                 mBuilder.setAutoCancel(true);
                 mNotifyManager.notify(NotificationConstants.COPY_ID, mBuilder.build());
-                publishCompletedResult();
+                mNotifyManager.cancel(NotificationConstants.COPY_ID);
             }
 
             //for processviewer
             DatapointParcelable intent = new DatapointParcelable(fileName, sourceFiles, sourceProgress,
                     totalSize, writtenSize, speed, move, isComplete);
             addDatapoint(intent);
-        } else publishCompletedResult();
-    }
-
-    public void publishCompletedResult() {
-        try {
-            mNotifyManager.cancel(NotificationConstants.COPY_ID);
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
+        } else mNotifyManager.cancel(NotificationConstants.COPY_ID);
     }
 
     //check if copy is successful

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/services/CopyService.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/services/CopyService.java
@@ -48,6 +48,7 @@ import com.amaze.filemanager.filesystem.HybridFile;
 import com.amaze.filemanager.filesystem.Operations;
 import com.amaze.filemanager.filesystem.RootHelper;
 import com.amaze.filemanager.fragments.ProcessViewerFragment;
+import com.amaze.filemanager.utils.ObtainableServiceBinder;
 import com.amaze.filemanager.utils.OnFileFound;
 import com.amaze.filemanager.utils.files.CryptUtil;
 import com.amaze.filemanager.ui.notifications.NotificationConstants;
@@ -79,7 +80,7 @@ public class CopyService extends Service {
     private Context c;
 
     private ProgressListener progressListener;
-    private final IBinder mBinder = new LocalBinder();
+    private final IBinder mBinder = new ObtainableServiceBinder<>(this);
     private ProgressHandler progressHandler;
     private ServiceWatcherUtil watcherUtil;
 
@@ -568,13 +569,6 @@ public class CopyService extends Service {
     public IBinder onBind(Intent arg0) {
         // TODO Auto-generated method stub
         return mBinder;
-    }
-
-    public class LocalBinder extends Binder {
-        public CopyService getService() {
-            // Return this instance of LocalService so clients can call public methods
-            return CopyService.this;
-        }
     }
 
     public interface ProgressListener {

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/services/DecryptService.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/services/DecryptService.java
@@ -91,6 +91,9 @@ public class DecryptService extends ProgressiveService {
 
         @Override
         protected Void doInBackground(Void... params) {
+            String baseFileFolder = baseFile.isDirectory()?
+                    baseFile.getPath():
+                    baseFile.getPath().substring(0, baseFile.getPath().lastIndexOf('/'));
 
             if (baseFile.isDirectory())  totalSize = baseFile.folderSize(context);
             else totalSize = baseFile.length(context);
@@ -101,7 +104,7 @@ public class DecryptService extends ProgressiveService {
 
             addFirstDatapoint(baseFile.getName(), 1, totalSize, false);// we're using encrypt as move flag false
 
-            if (FileUtil.checkFolder(baseFile.getPath(), context) == 1) {
+            if (FileUtil.checkFolder(baseFileFolder, context) == 1) {
                 serviceWatcherUtil.watch();
 
                 // we're here to decrypt, we'll decrypt at a custom path.

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/services/DecryptService.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/services/DecryptService.java
@@ -160,7 +160,7 @@ public class DecryptService extends ProgressiveService {
 
             //for processviewer
             DatapointParcelable intent = new DatapointParcelable(fileName, sourceFiles,
-                    sourceProgress, totalSize, writtenSize, speed, false, false);
+                    sourceProgress, totalSize, writtenSize, speed, false);
             addDatapoint(intent);
         } else notificationManager.cancel(NotificationConstants.DECRYPT_ID);
     }

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/services/DecryptService.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/services/DecryptService.java
@@ -158,7 +158,7 @@ public class DecryptService extends ProgressiveService {
 
             //for processviewer
             DatapointParcelable intent = new DatapointParcelable(fileName, sourceFiles,
-                    sourceProgress, totalSize, writtenSize, speed, false,false);
+                    sourceProgress, totalSize, writtenSize, speed, false, false);
             addDatapoint(intent);
         } else publishCompletedResult();
     }

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/services/DecryptService.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/services/DecryptService.java
@@ -16,22 +16,22 @@ import com.amaze.filemanager.activities.MainActivity;
 import com.amaze.filemanager.filesystem.FileUtil;
 import com.amaze.filemanager.filesystem.HybridFile;
 import com.amaze.filemanager.filesystem.HybridFileParcelable;
-import com.amaze.filemanager.ui.notifications.NotificationConstants;
-import com.amaze.filemanager.utils.files.CryptUtil;
 import com.amaze.filemanager.utils.DatapointParcelable;
 import com.amaze.filemanager.utils.ObtainableServiceBinder;
 import com.amaze.filemanager.utils.OpenMode;
 import com.amaze.filemanager.utils.ProgressHandler;
 import com.amaze.filemanager.utils.ServiceWatcherUtil;
+import com.amaze.filemanager.utils.files.CryptUtil;
+import com.amaze.filemanager.utils.files.EncryptDecryptUtils;
 
 import java.util.ArrayList;
 
 /**
- * Created by vishal on 8/4/17 edited by Emmanuel Messulam <emmanuelbendavid@gmail.com>
+ * @author Emmanuel Messulam <emmanuelbendavid@gmail.com>
+ *         on 28/11/2017, at 20:59.
  */
 
-public class EncryptService extends ProgressiveService {
-
+public class DecryptService extends ProgressiveService {
     public static final String TAG_SOURCE = "crypt_source";     // source file to encrypt or decrypt
     public static final String TAG_DECRYPT_PATH = "decrypt_path";
     public static final String TAG_OPEN_MODE = "open_mode";
@@ -48,6 +48,7 @@ public class EncryptService extends ProgressiveService {
     private ServiceWatcherUtil serviceWatcherUtil;
     private long totalSize = 0l;
     private OpenMode openMode;
+    private String decryptPath;
     private HybridFileParcelable baseFile;
     private ArrayList<HybridFile> failedOps = new ArrayList<>();
 
@@ -61,7 +62,6 @@ public class EncryptService extends ProgressiveService {
 
     @Override
     public int onStartCommand(Intent intent, int flags, int startId) {
-
         baseFile = intent.getParcelableExtra(TAG_SOURCE);
 
         openMode = OpenMode.values()[intent.getIntExtra(TAG_OPEN_MODE, OpenMode.UNKNOWN.ordinal())];
@@ -71,19 +71,17 @@ public class EncryptService extends ProgressiveService {
         notificationIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
         notificationIntent.putExtra(MainActivity.KEY_INTENT_PROCESS_VIEWER, true);
         PendingIntent pendingIntent = PendingIntent.getActivity(this, 0, notificationIntent, 0);
-        notificationBuilder = new NotificationCompat.Builder(this, NotificationConstants.CHANNEL_NORMAL_ID);
+        notificationBuilder = new NotificationCompat.Builder(this);
         notificationBuilder.setContentIntent(pendingIntent);
 
-        // we have to encrypt the source
+        decryptPath = intent.getStringExtra(TAG_DECRYPT_PATH);
+        notificationBuilder.setContentTitle(getResources().getString(R.string.crypt_decrypting));
+        notificationBuilder.setSmallIcon(R.drawable.ic_folder_lock_open_white_36dp);
 
-        notificationBuilder.setContentTitle(getResources().getString(R.string.crypt_encrypting));
-        notificationBuilder.setSmallIcon(R.drawable.ic_folder_lock_white_36dp);
-
-        NotificationConstants.setMetadata(getApplicationContext(), notificationBuilder);
 
         startForeground(ID_NOTIFICATION, notificationBuilder.build());
 
-        new BackgroundTask().execute();
+        new DecryptService.BackgroundTask().execute();
 
 
         return START_STICKY;
@@ -98,17 +96,19 @@ public class EncryptService extends ProgressiveService {
             else totalSize = baseFile.length(context);
 
             progressHandler = new ProgressHandler(1, totalSize);
-            progressHandler.setProgressListener(EncryptService.this::publishResults);
+            progressHandler.setProgressListener(DecryptService.this::publishResults);
             serviceWatcherUtil = new ServiceWatcherUtil(progressHandler, totalSize);
 
-            addFirstDatapoint(baseFile.getName(), 1, totalSize, true);// we're using encrypt as move flag false
+            addFirstDatapoint(baseFile.getName(), 1, totalSize, false);// we're using encrypt as move flag false
 
             if (FileUtil.checkFolder(baseFile.getPath(), context) == 1) {
                 serviceWatcherUtil.watch();
 
-                // we're here to encrypt
+                // we're here to decrypt, we'll decrypt at a custom path.
+                // the path is to the same directory as in encrypted one in normal case
+                // and the cache directory in case we're here because of the viewer
                 try {
-                    new CryptUtil(context, baseFile, progressHandler, failedOps);
+                    new CryptUtil(context, baseFile, decryptPath, progressHandler, failedOps);
                 } catch (Exception e) {
                     e.printStackTrace();
                     failedOps.add(baseFile);
@@ -125,11 +125,8 @@ public class EncryptService extends ProgressiveService {
             serviceWatcherUtil.stopWatch();
             generateNotification(failedOps);
 
-            Intent intent = new Intent(MainActivity.KEY_INTENT_LOAD_LIST);
-            intent.putExtra(MainActivity.KEY_INTENT_LOAD_LIST_FILE, "");
+            Intent intent = new Intent(EncryptDecryptUtils.DECRYPT_BROADCAST);
             sendBroadcast(intent);
-
-            stopSelf();
         }
     }
 
@@ -143,6 +140,7 @@ public class EncryptService extends ProgressiveService {
             notificationBuilder.setProgress(100, Math.round(progressPercent), false);
             notificationBuilder.setOngoing(true);
             int title = R.string.crypt_encrypting;
+            title = R.string.crypt_decrypting;
             notificationBuilder.setContentTitle(context.getResources().getString(title));
             notificationBuilder.setContentText(fileName + " " + Formatter.formatFileSize(context,
                     writtenSize) + "/" +
@@ -159,8 +157,8 @@ public class EncryptService extends ProgressiveService {
             }
 
             //for processviewer
-            DatapointParcelable intent = new DatapointParcelable(fileName, sourceFiles, sourceProgress,
-                    totalSize, writtenSize, speed, true, false);
+            DatapointParcelable intent = new DatapointParcelable(fileName, sourceFiles,
+                    sourceProgress, totalSize, writtenSize, speed, false,false);
             addDatapoint(intent);
         } else publishCompletedResult();
     }
@@ -188,31 +186,28 @@ public class EncryptService extends ProgressiveService {
      * Displays a notification, sends intent and cancels progress if there were some failures
      * in copy progress
      * @param failedOps
-     *
      */
     void generateNotification(ArrayList<HybridFile> failedOps) {
         notificationManager.cancelAll();
 
         if(failedOps.size()==0)return;
 
-        NotificationCompat.Builder mBuilder = new NotificationCompat.Builder(context, NotificationConstants.CHANNEL_NORMAL_ID)
-            .setContentTitle(context.getString(R.string.operationunsuccesful))
-            .setContentText(context.getString(R.string.copy_error, context.getString(R.string.copy_error).replace("%s",
-                    context.getString(R.string.crypt_encrypted).toLowerCase())))
-            .setAutoCancel(true);
-
-        NotificationConstants.setMetadata(context, mBuilder);
+        NotificationCompat.Builder mBuilder=new NotificationCompat.Builder(context);
+        mBuilder.setContentTitle(context.getString(R.string.operationunsuccesful));
+        mBuilder.setContentText(context.getString(R.string.copy_error).replace("%s",
+                        context.getString(R.string.crypt_decrypted).toLowerCase()));
+        mBuilder.setAutoCancel(true);
 
         progressHandler.setCancelled(true);
 
         Intent intent= new Intent(this, MainActivity.class);
         intent.putExtra(MainActivity.TAG_INTENT_FILTER_FAILED_OPS, failedOps);
-        intent.putExtra("move", true);
+        intent.putExtra("move", false);
 
         PendingIntent pIntent = PendingIntent.getActivity(this, 101, intent,PendingIntent.FLAG_UPDATE_CURRENT);
 
         mBuilder.setContentIntent(pIntent);
-        mBuilder.setSmallIcon(R.drawable.ic_folder_lock_white_36dp);
+        mBuilder.setSmallIcon(R.drawable.ic_folder_lock_open_white_36dp);
 
         notificationManager.notify(741,mBuilder.build());
 

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/services/DecryptService.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/services/DecryptService.java
@@ -16,6 +16,7 @@ import com.amaze.filemanager.activities.MainActivity;
 import com.amaze.filemanager.filesystem.FileUtil;
 import com.amaze.filemanager.filesystem.HybridFile;
 import com.amaze.filemanager.filesystem.HybridFileParcelable;
+import com.amaze.filemanager.ui.notifications.NotificationConstants;
 import com.amaze.filemanager.utils.DatapointParcelable;
 import com.amaze.filemanager.utils.ObtainableServiceBinder;
 import com.amaze.filemanager.utils.OpenMode;
@@ -35,8 +36,6 @@ public class DecryptService extends ProgressiveService {
     public static final String TAG_SOURCE = "crypt_source";     // source file to encrypt or decrypt
     public static final String TAG_DECRYPT_PATH = "decrypt_path";
     public static final String TAG_OPEN_MODE = "open_mode";
-
-    private static final int ID_NOTIFICATION = 27978;
 
     public static final String TAG_BROADCAST_CRYPT_CANCEL = "crypt_cancel";
 
@@ -79,7 +78,7 @@ public class DecryptService extends ProgressiveService {
         notificationBuilder.setSmallIcon(R.drawable.ic_folder_lock_open_white_36dp);
 
 
-        startForeground(ID_NOTIFICATION, notificationBuilder.build());
+        startForeground(NotificationConstants.DECRYPT_ID, notificationBuilder.build());
 
         new DecryptService.BackgroundTask().execute();
 
@@ -149,13 +148,13 @@ public class DecryptService extends ProgressiveService {
                     writtenSize) + "/" +
                     Formatter.formatFileSize(context, totalSize));
 
-            notificationManager.notify(ID_NOTIFICATION, notificationBuilder.build());
+            notificationManager.notify(NotificationConstants.DECRYPT_ID, notificationBuilder.build());
             if (writtenSize == totalSize || totalSize == 0) {
 
                 notificationBuilder.setContentText("");
                 notificationBuilder.setOngoing(false);
                 notificationBuilder.setAutoCancel(true);
-                notificationManager.notify(ID_NOTIFICATION, notificationBuilder.build());
+                notificationManager.notify(NotificationConstants.DECRYPT_ID, notificationBuilder.build());
                 publishCompletedResult();
             }
 
@@ -168,7 +167,7 @@ public class DecryptService extends ProgressiveService {
 
     public void publishCompletedResult(){
         try {
-            notificationManager.cancel(ID_NOTIFICATION);
+            notificationManager.cancel(NotificationConstants.DECRYPT_ID);
         } catch (Exception e) {
             e.printStackTrace();
         }
@@ -212,7 +211,7 @@ public class DecryptService extends ProgressiveService {
         mBuilder.setContentIntent(pIntent);
         mBuilder.setSmallIcon(R.drawable.ic_folder_lock_open_white_36dp);
 
-        notificationManager.notify(741,mBuilder.build());
+        notificationManager.notify(NotificationConstants.FAILED_ID,mBuilder.build());
 
         intent=new Intent(MainActivity.TAG_INTENT_FILTER_GENERAL);
         intent.putExtra(MainActivity.TAG_INTENT_FILTER_FAILED_OPS, failedOps);

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/services/DecryptService.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/services/DecryptService.java
@@ -155,22 +155,14 @@ public class DecryptService extends ProgressiveService {
                 notificationBuilder.setOngoing(false);
                 notificationBuilder.setAutoCancel(true);
                 notificationManager.notify(NotificationConstants.DECRYPT_ID, notificationBuilder.build());
-                publishCompletedResult();
+                notificationManager.cancel(NotificationConstants.DECRYPT_ID);
             }
 
             //for processviewer
             DatapointParcelable intent = new DatapointParcelable(fileName, sourceFiles,
                     sourceProgress, totalSize, writtenSize, speed, false, false);
             addDatapoint(intent);
-        } else publishCompletedResult();
-    }
-
-    public void publishCompletedResult(){
-        try {
-            notificationManager.cancel(NotificationConstants.DECRYPT_ID);
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
+        } else notificationManager.cancel(NotificationConstants.DECRYPT_ID);
     }
 
     @Override

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/services/EncryptService.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/services/EncryptService.java
@@ -36,8 +36,6 @@ public class EncryptService extends ProgressiveService {
     public static final String TAG_DECRYPT_PATH = "decrypt_path";
     public static final String TAG_OPEN_MODE = "open_mode";
 
-    private static final int ID_NOTIFICATION = 27978;
-
     public static final String TAG_BROADCAST_CRYPT_CANCEL = "crypt_cancel";
 
     private NotificationManager notificationManager;
@@ -81,7 +79,7 @@ public class EncryptService extends ProgressiveService {
 
         NotificationConstants.setMetadata(getApplicationContext(), notificationBuilder);
 
-        startForeground(ID_NOTIFICATION, notificationBuilder.build());
+        startForeground(NotificationConstants.ENCRYPT_ID, notificationBuilder.build());
 
         new BackgroundTask().execute();
 
@@ -148,13 +146,13 @@ public class EncryptService extends ProgressiveService {
                     writtenSize) + "/" +
                     Formatter.formatFileSize(context, totalSize));
 
-            notificationManager.notify(ID_NOTIFICATION, notificationBuilder.build());
+            notificationManager.notify(NotificationConstants.ENCRYPT_ID, notificationBuilder.build());
             if (writtenSize == totalSize || totalSize == 0) {
 
                 notificationBuilder.setContentText("");
                 notificationBuilder.setOngoing(false);
                 notificationBuilder.setAutoCancel(true);
-                notificationManager.notify(ID_NOTIFICATION, notificationBuilder.build());
+                notificationManager.notify(NotificationConstants.ENCRYPT_ID, notificationBuilder.build());
                 publishCompletedResult();
             }
 
@@ -167,7 +165,7 @@ public class EncryptService extends ProgressiveService {
 
     public void publishCompletedResult(){
         try {
-            notificationManager.cancel(ID_NOTIFICATION);
+            notificationManager.cancel(NotificationConstants.ENCRYPT_ID);
         } catch (Exception e) {
             e.printStackTrace();
         }
@@ -214,7 +212,7 @@ public class EncryptService extends ProgressiveService {
         mBuilder.setContentIntent(pIntent);
         mBuilder.setSmallIcon(R.drawable.ic_folder_lock_white_36dp);
 
-        notificationManager.notify(741,mBuilder.build());
+        notificationManager.notify(NotificationConstants.FAILED_ID, mBuilder.build());
 
         intent=new Intent(MainActivity.TAG_INTENT_FILTER_GENERAL);
         intent.putExtra(MainActivity.TAG_INTENT_FILTER_FAILED_OPS, failedOps);

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/services/EncryptService.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/services/EncryptService.java
@@ -28,7 +28,7 @@ import com.amaze.filemanager.utils.files.EncryptDecryptUtils;
 import java.util.ArrayList;
 
 /**
- * Created by vishal on 8/4/17.
+ * Created by vishal on 8/4/17 edited by Emmanuel Messulam <emmanuelbendavid@gmail.com>
  */
 
 public class EncryptService extends ProgressiveService {

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/services/EncryptService.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/services/EncryptService.java
@@ -153,22 +153,14 @@ public class EncryptService extends ProgressiveService {
                 notificationBuilder.setOngoing(false);
                 notificationBuilder.setAutoCancel(true);
                 notificationManager.notify(NotificationConstants.ENCRYPT_ID, notificationBuilder.build());
-                publishCompletedResult();
+                notificationManager.cancel(NotificationConstants.ENCRYPT_ID);
             }
 
             //for processviewer
             DatapointParcelable intent = new DatapointParcelable(fileName, sourceFiles, sourceProgress,
                     totalSize, writtenSize, speed, true, false);
             addDatapoint(intent);
-        } else publishCompletedResult();
-    }
-
-    public void publishCompletedResult(){
-        try {
-            notificationManager.cancel(NotificationConstants.ENCRYPT_ID);
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
+        } else notificationManager.cancel(NotificationConstants.ENCRYPT_ID);
     }
 
     @Override

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/services/EncryptService.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/services/EncryptService.java
@@ -158,7 +158,7 @@ public class EncryptService extends ProgressiveService {
 
             //for processviewer
             DatapointParcelable intent = new DatapointParcelable(fileName, sourceFiles, sourceProgress,
-                    totalSize, writtenSize, speed, true, false);
+                    totalSize, writtenSize, speed, false);
             addDatapoint(intent);
         } else notificationManager.cancel(NotificationConstants.ENCRYPT_ID);
     }

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/services/EncryptService.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/services/EncryptService.java
@@ -8,20 +8,20 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.os.AsyncTask;
-import android.os.Binder;
 import android.os.IBinder;
 import android.support.v4.app.NotificationCompat;
 import android.text.format.Formatter;
 
 import com.amaze.filemanager.R;
 import com.amaze.filemanager.activities.MainActivity;
-import com.amaze.filemanager.filesystem.HybridFileParcelable;
 import com.amaze.filemanager.filesystem.FileUtil;
 import com.amaze.filemanager.filesystem.HybridFile;
+import com.amaze.filemanager.filesystem.HybridFileParcelable;
 import com.amaze.filemanager.fragments.ProcessViewerFragment;
 import com.amaze.filemanager.ui.notifications.NotificationConstants;
 import com.amaze.filemanager.utils.files.CryptUtil;
 import com.amaze.filemanager.utils.CopyDataParcelable;
+import com.amaze.filemanager.utils.ObtainableServiceBinder;
 import com.amaze.filemanager.utils.OpenMode;
 import com.amaze.filemanager.utils.ProgressHandler;
 import com.amaze.filemanager.utils.ServiceWatcherUtil;
@@ -51,7 +51,7 @@ public class EncryptService extends Service {
     private NotificationManager notificationManager;
     private NotificationCompat.Builder notificationBuilder;
     private Context context;
-    private IBinder mBinder = new LocalBinder();
+    private IBinder mBinder = new ObtainableServiceBinder<>(this);
     private ProgressHandler progressHandler;
     private ServiceWatcherUtil serviceWatcherUtil;
     private long totalSize = 0l;
@@ -224,13 +224,6 @@ public class EncryptService extends Service {
     @Override
     public IBinder onBind(Intent intent) {
         return mBinder;
-    }
-
-    public class LocalBinder extends Binder {
-
-        public EncryptService getService() {
-            return EncryptService.this;
-        }
     }
 
     @Override

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/services/ExtractService.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/services/ExtractService.java
@@ -61,6 +61,7 @@ import java.util.Enumeration;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
+
 public class ExtractService extends ProgressiveService {
 
     Context context;
@@ -117,15 +118,16 @@ public class ExtractService extends ProgressiveService {
         return START_STICKY;
     }
 
+    @Override
+    public void onDestroy() {
+        unregisterReceiver(receiver1);
+    }
+
     /**
      * Method calculates zip file size to initiate progress
      * Supporting local file extraction progress for now
-     *
-     * @param filePath
-     * @return
      */
     private long getTotalSize(String filePath) {
-
         return new File(filePath).length();
     }
 
@@ -322,7 +324,6 @@ public class ExtractService extends ProgressiveService {
          * @param archive         the file pointing to archive
          * @param destinationPath the where to extract
          * @param entryNamesList  names of files to be extracted from the archive
-         * @return
          */
         private void extract(@NonNull final ExtractService extractService, File archive, String destinationPath,
                                 String[] entryNamesList) throws IOException {
@@ -539,18 +540,11 @@ public class ExtractService extends ProgressiveService {
         }
     }
 
-
-    @Override
-    public void onDestroy() {
-        unregisterReceiver(receiver1);
-    }
-
     /**
      * Class used for the client Binder.  Because we know this service always
      * runs in the same process as its clients, we don't need to deal with IPC.
      */
     private BroadcastReceiver receiver1 = new BroadcastReceiver() {
-
         @Override
         public void onReceive(Context context, Intent intent) {
             progressHandler.setCancelled(true);
@@ -558,8 +552,7 @@ public class ExtractService extends ProgressiveService {
     };
 
     @Override
-    public IBinder onBind(Intent arg0) {
-        // TODO Auto-generated method stub
+    public IBinder onBind(Intent intent) {
         return mBinder;
     }
 

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/services/ExtractService.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/services/ExtractService.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2014 Arpit Khurana <arpitkh96@gmail.com>, Vishal Nehra <vishalmeham2@gmail.com>
+ *                       Emmanuel Messulam <emmanuelbendavid@gmail.com>
  *
  * This file is part of Amaze File Manager.
  *

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/services/ExtractService.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/services/ExtractService.java
@@ -152,7 +152,7 @@ public class ExtractService extends ProgressiveService {
             }
 
             DatapointParcelable intent = new DatapointParcelable(fileName, sourceFiles, sourceProgress,
-                    total, done, speed, false, isCompleted);
+                    total, done, speed, isCompleted);
             addDatapoint(intent);
         } else mNotifyManager.cancel(NotificationConstants.EXTRACT_ID);
     }

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/services/ExtractService.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/services/ExtractService.java
@@ -27,7 +27,6 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.os.AsyncTask;
-import android.os.Binder;
 import android.os.IBinder;
 import android.support.annotation.NonNull;
 import android.support.v4.app.NotificationCompat;
@@ -40,6 +39,7 @@ import com.amaze.filemanager.filesystem.FileUtil;
 import com.amaze.filemanager.fragments.ProcessViewerFragment;
 import com.amaze.filemanager.ui.notifications.NotificationConstants;
 import com.amaze.filemanager.utils.CopyDataParcelable;
+import com.amaze.filemanager.utils.ObtainableServiceBinder;
 import com.amaze.filemanager.utils.ProgressHandler;
 import com.amaze.filemanager.utils.ServiceWatcherUtil;
 import com.amaze.filemanager.utils.application.AppConfig;
@@ -65,6 +65,8 @@ import java.util.zip.ZipFile;
 public class ExtractService extends Service {
 
     Context context;
+
+    private final IBinder mBinder = new ObtainableServiceBinder<>(this);
 
     // list of data packages,// to initiate chart in process viewer fragment
     private ArrayList<CopyDataParcelable> dataPackages = new ArrayList<>();
@@ -126,15 +128,6 @@ public class ExtractService extends Service {
     private long getTotalSize(String filePath) {
 
         return new File(filePath).length();
-    }
-
-    private final IBinder mBinder = new LocalBinder();
-
-    public class LocalBinder extends Binder {
-        public ExtractService getService() {
-            // Return this instance of LocalService so clients can call public methods
-            return ExtractService.this;
-        }
     }
 
     public void setProgressListener(ProgressListener progressListener) {

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/services/ExtractService.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/services/ExtractService.java
@@ -148,21 +148,13 @@ public class ExtractService extends ProgressiveService {
                 mBuilder.setProgress(100, 100, false);
                 mBuilder.setOngoing(false);
                 mNotifyManager.notify(NotificationConstants.EXTRACT_ID, mBuilder.build());
-                publishCompletedResult("");
+                mNotifyManager.cancel(NotificationConstants.EXTRACT_ID);
             }
 
             DatapointParcelable intent = new DatapointParcelable(fileName, sourceFiles, sourceProgress,
                     total, done, speed, false, isCompleted);
             addDatapoint(intent);
-        } else publishCompletedResult(fileName);
-    }
-
-    public void publishCompletedResult(String a) {
-        try {
-            mNotifyManager.cancel(NotificationConstants.EXTRACT_ID);
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
+        } else mNotifyManager.cancel(NotificationConstants.EXTRACT_ID);
     }
 
     public static class DoWork extends AsyncTask<Void, Void, Void> {

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/services/ProgressiveService.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/services/ProgressiveService.java
@@ -10,7 +10,7 @@ import com.amaze.filemanager.utils.ServiceWatcherUtil;
 import java.util.ArrayList;
 
 /**
- * @author Emmanuel
+ * @author Emmanuel Messulam <emmanuelbendavid@gmail.com>
  *         on 28/11/2017, at 19:32.
  */
 

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/services/ProgressiveService.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/services/ProgressiveService.java
@@ -1,0 +1,77 @@
+package com.amaze.filemanager.asynchronous.services;
+
+import android.app.Service;
+
+import com.amaze.filemanager.activities.MainActivity;
+import com.amaze.filemanager.fragments.ProcessViewerFragment;
+import com.amaze.filemanager.utils.DatapointParcelable;
+import com.amaze.filemanager.utils.ServiceWatcherUtil;
+
+import java.util.ArrayList;
+
+/**
+ * @author Emmanuel
+ *         on 28/11/2017, at 19:32.
+ */
+
+public abstract class ProgressiveService extends Service {
+    // list of data packages which contains progress
+    private ArrayList<DatapointParcelable> dataPackages = new ArrayList<>();
+    private EncryptService.ProgressListener progressListener;
+
+    public final void setProgressListener(ProgressListener progressListener) {
+        this.progressListener = progressListener;
+    }
+
+    public final ProgressListener getProgressListener() {
+        return progressListener;
+    }
+
+    protected void addFirstDatapoint(String name, int amountOfFiles, long totalBytes, boolean move) {
+        if(!dataPackages.isEmpty()) throw new IllegalStateException("This is not the first datapoint!");
+
+        DatapointParcelable intent1 = new DatapointParcelable(name, amountOfFiles, totalBytes, move);
+        putDataPackage(intent1);
+    }
+
+    protected void addDatapoint(DatapointParcelable datapoint) {
+        if(dataPackages.isEmpty()) throw new IllegalStateException("This is the first datapoint!");
+
+        putDataPackage(datapoint);
+        if (getProgressListener() != null) {
+            getProgressListener().onUpdate(datapoint);
+            if (datapoint.completed) getProgressListener().refresh();
+        }
+    }
+
+    /**
+     * Returns the {@link #dataPackages} list which contains
+     * data to be transferred to {@link ProcessViewerFragment}
+     * Method call is synchronized so as to avoid modifying the list
+     * by {@link ServiceWatcherUtil#handlerThread} while {@link MainActivity#runOnUiThread(Runnable)}
+     * is executing the callbacks in {@link ProcessViewerFragment}
+     */
+    public final synchronized DatapointParcelable getDataPackage(int index) {
+        return this.dataPackages.get(index);
+    }
+
+    public final synchronized int getDataPackageSize() {
+        return this.dataPackages.size();
+    }
+
+    /**
+     * Puts a {@link DatapointParcelable} into a list
+     * Method call is synchronized so as to avoid modifying the list
+     * by {@link ServiceWatcherUtil#handlerThread} while {@link MainActivity#runOnUiThread(Runnable)}
+     * is executing the callbacks in {@link ProcessViewerFragment}
+     */
+    private synchronized void putDataPackage(DatapointParcelable dataPackage) {
+        this.dataPackages.add(dataPackage);
+    }
+
+    public interface ProgressListener {
+        void onUpdate(DatapointParcelable dataPackage);
+        void refresh();
+    }
+
+}

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/services/ZipService.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/services/ZipService.java
@@ -27,7 +27,6 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.os.AsyncTask;
-import android.os.Binder;
 import android.os.Bundle;
 import android.os.IBinder;
 import android.preference.PreferenceManager;
@@ -41,6 +40,7 @@ import com.amaze.filemanager.filesystem.HybridFileParcelable;
 import com.amaze.filemanager.fragments.ProcessViewerFragment;
 import com.amaze.filemanager.ui.notifications.NotificationConstants;
 import com.amaze.filemanager.utils.CopyDataParcelable;
+import com.amaze.filemanager.utils.ObtainableServiceBinder;
 import com.amaze.filemanager.utils.PreferenceUtils;
 import com.amaze.filemanager.utils.ProgressHandler;
 import com.amaze.filemanager.utils.ServiceWatcherUtil;
@@ -65,7 +65,7 @@ public class ZipService extends Service {
     Context c;
     ProgressListener progressListener;
     long totalBytes = 0L;
-    private final IBinder mBinder = new LocalBinder();
+    private final IBinder mBinder = new ObtainableServiceBinder<>(this);
     private ProgressHandler progressHandler;
     private ArrayList<CopyDataParcelable> dataPackages = new ArrayList<>();
 
@@ -119,13 +119,6 @@ public class ZipService extends Service {
         new DoWork().execute(b);
         // If we get killed, after returning from here, restart
         return START_STICKY;
-    }
-
-    public class LocalBinder extends Binder {
-        public ZipService getService() {
-            // Return this instance of LocalService so clients can call public methods
-            return ZipService.this;
-        }
     }
 
     public void setProgressListener(ProgressListener progressListener) {

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/services/ZipService.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/services/ZipService.java
@@ -241,7 +241,7 @@ public class ZipService extends ProgressiveService {
                 mBuilder.setProgress(100, 100, false);
                 mBuilder.setOngoing(false);
                 mNotifyManager.notify(NotificationConstants.ZIP_ID, mBuilder.build());
-                publishCompletedResult();
+                mNotifyManager.cancel(NotificationConstants.ZIP_ID);
                 isCompleted = true;
             }
 
@@ -250,15 +250,7 @@ public class ZipService extends ProgressiveService {
 
             addDatapoint(intent);
         } else {
-            publishCompletedResult();
-        }
-    }
-
-    public void publishCompletedResult() {
-        try {
             mNotifyManager.cancel(NotificationConstants.ZIP_ID);
-        } catch (Exception e) {
-            e.printStackTrace();
         }
     }
 

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/services/ZipService.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/services/ZipService.java
@@ -246,7 +246,7 @@ public class ZipService extends ProgressiveService {
             }
 
             DatapointParcelable intent = new DatapointParcelable(fileName, sourceFiles, sourceProgress,
-                    total, done, speed, false, isCompleted);
+                    total, done, speed, isCompleted);
 
             addDatapoint(intent);
         } else {

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/services/ZipService.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/services/ZipService.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2014 Arpit Khurana <arpitkh96@gmail.com>, Vishal Nehra <vishalmeham2@gmail.com>
+ *                      Emmanuel Messulam <emmanuelbendavid@gmail.com>
  *
  * This file is part of Amaze File Manager.
  *

--- a/app/src/main/java/com/amaze/filemanager/fragments/ProcessViewerFragment.java
+++ b/app/src/main/java/com/amaze/filemanager/fragments/ProcessViewerFragment.java
@@ -19,14 +19,12 @@
 
 package com.amaze.filemanager.fragments;
 
-import android.app.Service;
 import android.content.ComponentName;
 import android.content.Intent;
 import android.content.ServiceConnection;
 import android.graphics.Color;
 import android.graphics.Typeface;
 import android.graphics.drawable.ColorDrawable;
-import android.os.Binder;
 import android.os.Bundle;
 import android.os.IBinder;
 import android.support.v4.app.Fragment;
@@ -47,8 +45,9 @@ import com.amaze.filemanager.activities.MainActivity;
 import com.amaze.filemanager.asynchronous.services.CopyService;
 import com.amaze.filemanager.asynchronous.services.EncryptService;
 import com.amaze.filemanager.asynchronous.services.ExtractService;
+import com.amaze.filemanager.asynchronous.services.ProgressiveService;
 import com.amaze.filemanager.asynchronous.services.ZipService;
-import com.amaze.filemanager.utils.CopyDataParcelable;
+import com.amaze.filemanager.utils.DatapointParcelable;
 import com.amaze.filemanager.utils.ObtainableServiceBinder;
 import com.amaze.filemanager.utils.Utils;
 import com.amaze.filemanager.utils.color.ColorUsage;
@@ -126,7 +125,7 @@ public class ProcessViewerFragment extends Fragment {
         public void onServiceConnected(ComponentName className,
                                        IBinder service) {
             // We've bound to LocalService, cast the IBinder and get LocalService instance
-            CopyService copyService = ((ObtainableServiceBinder<CopyService>) service).getService();
+            ProgressiveService copyService = ((ObtainableServiceBinder<? extends ProgressiveService>) service).getService();
 
             for (int i=0; i<copyService.getDataPackageSize(); i++) {
 
@@ -136,9 +135,9 @@ public class ProcessViewerFragment extends Fragment {
             // animate the chart a little after initial values have been applied
             mLineChart.animateXY(500, 500);
 
-            copyService.setProgressListener(new CopyService.ProgressListener() {
+            copyService.setProgressListener(new ProgressiveService.ProgressListener() {
                 @Override
-                public void onUpdate(final CopyDataParcelable dataPackage) {
+                public void onUpdate(final DatapointParcelable dataPackage) {
                     if (getActivity() == null || getActivity().getSupportFragmentManager().
                             findFragmentByTag(MainActivity.KEY_INTENT_PROCESS_VIEWER) == null) {
                         // callback called when we're not inside the app
@@ -165,7 +164,7 @@ public class ProcessViewerFragment extends Fragment {
         public void onServiceConnected(ComponentName className,
                                        IBinder service) {
             // We've bound to LocalService, cast the IBinder and get LocalService instance
-            ExtractService extractService = ((ObtainableServiceBinder<ExtractService>) service).getService();
+            ProgressiveService extractService = ((ObtainableServiceBinder<? extends ProgressiveService>) service).getService();
 
             for (int i=0; i<extractService.getDataPackageSize(); i++) {
 
@@ -175,9 +174,9 @@ public class ProcessViewerFragment extends Fragment {
             // animate the chart a little after initial values have been applied
             mLineChart.animateXY(500, 500);
 
-            extractService.setProgressListener(new ExtractService.ProgressListener() {
+            extractService.setProgressListener(new ProgressiveService.ProgressListener() {
                 @Override
-                public void onUpdate(final CopyDataParcelable dataPackage) {
+                public void onUpdate(final DatapointParcelable dataPackage) {
                     if (getActivity()==null) {
                         // callback called when we're not inside the app
                         return;
@@ -201,7 +200,7 @@ public class ProcessViewerFragment extends Fragment {
         @Override
         public void onServiceConnected(ComponentName className, IBinder service) {
             // We've bound to LocalService, cast the IBinder and get LocalService instance
-            ZipService zipService = ((ObtainableServiceBinder<ZipService>) service).getService();
+            ProgressiveService zipService = ((ObtainableServiceBinder<? extends ProgressiveService>) service).getService();
 
             for (int i = 0; i< zipService.getDataPackageSize(); i++) {
 
@@ -211,9 +210,9 @@ public class ProcessViewerFragment extends Fragment {
             // animate the chart a little after initial values have been applied
             mLineChart.animateXY(500, 500);
 
-            zipService.setProgressListener(new ZipService.ProgressListener() {
+            zipService.setProgressListener(new ProgressiveService.ProgressListener() {
                 @Override
-                public void onUpdate(final CopyDataParcelable dataPackage) {
+                public void onUpdate(final DatapointParcelable dataPackage) {
                     if (getActivity() == null) {
                         // callback called when we're not inside the app
                         return;
@@ -238,10 +237,10 @@ public class ProcessViewerFragment extends Fragment {
         @Override
         public void onServiceConnected(ComponentName name, IBinder service) {
             // We've bound to LocalService, cast the IBinder and get LocalService instance
-            EncryptService encryptService = ((ObtainableServiceBinder<EncryptService>) service).getService();
+            ProgressiveService encryptService = ((ObtainableServiceBinder<? extends ProgressiveService>) service).getService();
 
             for (int i=0; i<encryptService.getDataPackageSize(); i++) {
-                CopyDataParcelable dataPackage = encryptService.getDataPackage(i);
+                DatapointParcelable dataPackage = encryptService.getDataPackage(i);
                 processResults(dataPackage, dataPackage.move? ServiceType.DECRYPT
                         : ServiceType.ENCRYPT);
             }
@@ -249,9 +248,9 @@ public class ProcessViewerFragment extends Fragment {
             // animate the chart a little after initial values have been applied
             mLineChart.animateXY(500, 500);
 
-            encryptService.setProgressListener(new EncryptService.ProgressListener() {
+            encryptService.setProgressListener(new ProgressiveService.ProgressListener() {
                 @Override
-                public void onUpdate(final CopyDataParcelable dataPackage) {
+                public void onUpdate(final DatapointParcelable dataPackage) {
                     if (getActivity() == null) {
                         // callback called when we're not inside the app
                         return;
@@ -311,7 +310,7 @@ public class ProcessViewerFragment extends Fragment {
     }
 
     /**
-     * Enum helps defining the result type for {@link #processResults(CopyDataParcelable, ServiceType)}
+     * Enum helps defining the result type for {@link #processResults(DatapointParcelable, ServiceType)}
      * to process
      */
     enum ServiceType {
@@ -319,7 +318,7 @@ public class ProcessViewerFragment extends Fragment {
         COPY, EXTRACT, COMPRESS, ENCRYPT, DECRYPT
     }
 
-    public void processResults(final CopyDataParcelable dataPackage, ServiceType serviceType) {
+    public void processResults(final DatapointParcelable dataPackage, ServiceType serviceType) {
         if (dataPackage != null) {
             String name = dataPackage.name;
             long total = dataPackage.totalSize;

--- a/app/src/main/java/com/amaze/filemanager/fragments/ProcessViewerFragment.java
+++ b/app/src/main/java/com/amaze/filemanager/fragments/ProcessViewerFragment.java
@@ -324,19 +324,16 @@ public class ProcessViewerFragment extends Fragment {
      * @param yValue the y-axis value, bytes processed per sec
      */
     private void addEntry(float xValue, float yValue) {
-
         ILineDataSet dataSet = mLineData.getDataSetByIndex(0);
-        if (dataSet==null) {
-            // adding set for first time
+
+        if (dataSet == null) {// adding set for first time
             dataSet = createDataSet();
             mLineData.addDataSet(dataSet);
         }
 
-        int randomDataSetIndex = (int) (Math.random() * mLineData.getDataSetCount());
-        mLineData.addEntry(new Entry(xValue, yValue), randomDataSetIndex);
-        mLineData.notifyDataChanged();
+        dataSet.addEntry(new Entry(xValue, yValue));
 
-        // let the chart know it's data has changed
+        mLineData.notifyDataChanged();
         mLineChart.notifyDataSetChanged();
         mLineChart.invalidate();
     }

--- a/app/src/main/java/com/amaze/filemanager/fragments/ProcessViewerFragment.java
+++ b/app/src/main/java/com/amaze/filemanager/fragments/ProcessViewerFragment.java
@@ -214,6 +214,8 @@ public class ProcessViewerFragment extends Fragment {
                     + "</font></i>");
 
             mProgressTimer.setText(timerSpan);
+
+            if(dataPackage.completed) mCancelButton.setVisibility(View.GONE);
         }
     }
 

--- a/app/src/main/java/com/amaze/filemanager/fragments/ProcessViewerFragment.java
+++ b/app/src/main/java/com/amaze/filemanager/fragments/ProcessViewerFragment.java
@@ -66,13 +66,12 @@ import java.util.concurrent.TimeUnit;
 
 public class ProcessViewerFragment extends Fragment {
 
-    boolean isInitialized = false;
-    SharedPreferences sharedPrefs;
-    MainActivity mainActivity;
-    int accentColor, primaryColor;
-    ImageButton mCancelButton;
-    ImageView mProgressImage;
-
+    private boolean isInitialized = false;
+    private SharedPreferences sharedPrefs;
+    private MainActivity mainActivity;
+    private int accentColor, primaryColor;
+    private ImageButton mCancelButton;
+    private ImageView mProgressImage;
     private View rootView;
     private CardView mCardView;
     private LineChart mLineChart;

--- a/app/src/main/java/com/amaze/filemanager/fragments/ProcessViewerFragment.java
+++ b/app/src/main/java/com/amaze/filemanager/fragments/ProcessViewerFragment.java
@@ -19,16 +19,16 @@
 
 package com.amaze.filemanager.fragments;
 
+import android.app.Service;
 import android.content.ComponentName;
 import android.content.Intent;
 import android.content.ServiceConnection;
-import android.content.SharedPreferences;
 import android.graphics.Color;
 import android.graphics.Typeface;
 import android.graphics.drawable.ColorDrawable;
+import android.os.Binder;
 import android.os.Bundle;
 import android.os.IBinder;
-import android.preference.PreferenceManager;
 import android.support.v4.app.Fragment;
 import android.support.v7.widget.CardView;
 import android.text.Html;
@@ -49,6 +49,7 @@ import com.amaze.filemanager.asynchronous.services.EncryptService;
 import com.amaze.filemanager.asynchronous.services.ExtractService;
 import com.amaze.filemanager.asynchronous.services.ZipService;
 import com.amaze.filemanager.utils.CopyDataParcelable;
+import com.amaze.filemanager.utils.ObtainableServiceBinder;
 import com.amaze.filemanager.utils.Utils;
 import com.amaze.filemanager.utils.color.ColorUsage;
 import com.amaze.filemanager.utils.files.FileUtils;
@@ -125,9 +126,7 @@ public class ProcessViewerFragment extends Fragment {
         public void onServiceConnected(ComponentName className,
                                        IBinder service) {
             // We've bound to LocalService, cast the IBinder and get LocalService instance
-
-            CopyService.LocalBinder localBinder = (CopyService.LocalBinder) service;
-            CopyService copyService = localBinder.getService();
+            CopyService copyService = ((ObtainableServiceBinder<CopyService>) service).getService();
 
             for (int i=0; i<copyService.getDataPackageSize(); i++) {
 
@@ -166,8 +165,7 @@ public class ProcessViewerFragment extends Fragment {
         public void onServiceConnected(ComponentName className,
                                        IBinder service) {
             // We've bound to LocalService, cast the IBinder and get LocalService instance
-            ExtractService.LocalBinder localBinder = (ExtractService.LocalBinder) service;
-            ExtractService extractService = localBinder.getService();
+            ExtractService extractService = ((ObtainableServiceBinder<ExtractService>) service).getService();
 
             for (int i=0; i<extractService.getDataPackageSize(); i++) {
 
@@ -203,8 +201,7 @@ public class ProcessViewerFragment extends Fragment {
         @Override
         public void onServiceConnected(ComponentName className, IBinder service) {
             // We've bound to LocalService, cast the IBinder and get LocalService instance
-            ZipService.LocalBinder localBinder = (ZipService.LocalBinder) service;
-            ZipService zipService = localBinder.getService();
+            ZipService zipService = ((ObtainableServiceBinder<ZipService>) service).getService();
 
             for (int i = 0; i< zipService.getDataPackageSize(); i++) {
 
@@ -240,8 +237,8 @@ public class ProcessViewerFragment extends Fragment {
     private ServiceConnection mCryptConnection = new ServiceConnection() {
         @Override
         public void onServiceConnected(ComponentName name, IBinder service) {
-            EncryptService.LocalBinder binder = (EncryptService.LocalBinder) service;
-            EncryptService encryptService = binder.getService();
+            // We've bound to LocalService, cast the IBinder and get LocalService instance
+            EncryptService encryptService = ((ObtainableServiceBinder<EncryptService>) service).getService();
 
             for (int i=0; i<encryptService.getDataPackageSize(); i++) {
                 CopyDataParcelable dataPackage = encryptService.getDataPackage(i);

--- a/app/src/main/java/com/amaze/filemanager/fragments/ProcessViewerFragment.java
+++ b/app/src/main/java/com/amaze/filemanager/fragments/ProcessViewerFragment.java
@@ -67,7 +67,6 @@ import java.util.concurrent.TimeUnit;
 public class ProcessViewerFragment extends Fragment {
 
     private boolean isInitialized = false;
-    private SharedPreferences sharedPrefs;
     private MainActivity mainActivity;
     private int accentColor, primaryColor;
     private ImageButton mCancelButton;
@@ -95,7 +94,7 @@ public class ProcessViewerFragment extends Fragment {
         mainActivity.updateViews(new ColorDrawable(primaryColor));
         mainActivity.getAppbar().setTitle(R.string.process_viewer);
         mainActivity.floatingActionButton.getMenuButton().hide();
-        sharedPrefs = PreferenceManager.getDefaultSharedPreferences(getActivity());
+        
         mainActivity.supportInvalidateOptionsMenu();
 
         mCardView = (CardView) rootView.findViewById(R.id.card_view);

--- a/app/src/main/java/com/amaze/filemanager/fragments/ProcessViewerFragment.java
+++ b/app/src/main/java/com/amaze/filemanager/fragments/ProcessViewerFragment.java
@@ -160,11 +160,6 @@ public class ProcessViewerFragment extends Fragment {
         getActivity().unbindService(mDecryptConnection);
     }
 
-    @Override
-    public void onDestroy() {
-        super.onDestroy();
-    }
-
     /**
      * Enum helps defining the result type for {@link #processResults(DatapointParcelable, ServiceType)}
      * to process

--- a/app/src/main/java/com/amaze/filemanager/fragments/ProcessViewerFragment.java
+++ b/app/src/main/java/com/amaze/filemanager/fragments/ProcessViewerFragment.java
@@ -68,6 +68,13 @@ import java.util.concurrent.TimeUnit;
 
 public class ProcessViewerFragment extends Fragment {
 
+    /**
+     * Helps defining the result type for {@link #processResults(DatapointParcelable, int)}
+     * to process
+     */
+    private static final int SERVICE_COPY = 0, SERVICE_EXTRACT = 1, SERVICE_COMPRESS = 2,
+            SERVICE_ENCRYPT = 3, SERVICE_DECRYPT = 4;
+
     private boolean isInitialized = false;
     private MainActivity mainActivity;
     private int accentColor, primaryColor;
@@ -121,11 +128,11 @@ public class ProcessViewerFragment extends Fragment {
             mCardView.setCardElevation(0f);
         }
 
-        mCopyConnection = new CustomServiceConnection(this, mLineChart, ServiceType.COPY);
-        mExtractConnection = new CustomServiceConnection(this, mLineChart, ServiceType.EXTRACT);
-        mCompressConnection = new CustomServiceConnection(this, mLineChart, ServiceType.COMPRESS);
-        mEncryptConnection = new CustomServiceConnection(this, mLineChart, ServiceType.ENCRYPT);
-        mDecryptConnection = new CustomServiceConnection(this, mLineChart, ServiceType.DECRYPT);
+        mCopyConnection = new CustomServiceConnection(this, mLineChart, SERVICE_COPY);
+        mExtractConnection = new CustomServiceConnection(this, mLineChart, SERVICE_EXTRACT);
+        mCompressConnection = new CustomServiceConnection(this, mLineChart, SERVICE_COMPRESS);
+        mEncryptConnection = new CustomServiceConnection(this, mLineChart, SERVICE_ENCRYPT);
+        mDecryptConnection = new CustomServiceConnection(this, mLineChart, SERVICE_DECRYPT);
 
         return rootView;
     }
@@ -160,15 +167,7 @@ public class ProcessViewerFragment extends Fragment {
         getActivity().unbindService(mDecryptConnection);
     }
 
-    /**
-     * Enum helps defining the result type for {@link #processResults(DatapointParcelable, ServiceType)}
-     * to process
-     */
-    enum ServiceType {
-        COPY, EXTRACT, COMPRESS, ENCRYPT, DECRYPT
-    }
-
-    public void processResults(final DatapointParcelable dataPackage, ServiceType serviceType) {
+    public void processResults(final DatapointParcelable dataPackage, int serviceType) {
         if (dataPackage != null) {
             String name = dataPackage.name;
             long total = dataPackage.totalSize;
@@ -231,12 +230,11 @@ public class ProcessViewerFragment extends Fragment {
     }
 
     /**
-     * Setup drawables and click listeners based on the {@link ServiceType}
-     * @param serviceType
+     * Setup drawables and click listeners based on the SERVICE_* constants
      */
-    private void setupDrawables(ServiceType serviceType, boolean isMove) {
+    private void setupDrawables(int serviceType, boolean isMove) {
         switch (serviceType) {
-            case COPY:
+            case SERVICE_COPY:
                 if (mainActivity.getAppTheme().equals(AppTheme.DARK) || mainActivity.getAppTheme().equals(AppTheme.BLACK)) {
 
                     mProgressImage.setImageDrawable(getResources()
@@ -249,7 +247,7 @@ public class ProcessViewerFragment extends Fragment {
                         : getResources().getString(R.string.copying));
                 cancelBroadcast(new Intent(CopyService.TAG_BROADCAST_COPY_CANCEL));
                 break;
-            case EXTRACT:
+            case SERVICE_EXTRACT:
                 if (mainActivity.getAppTheme().equals(AppTheme.DARK) || mainActivity.getAppTheme().equals(AppTheme.BLACK)) {
 
                     mProgressImage.setImageDrawable(getResources()
@@ -261,7 +259,7 @@ public class ProcessViewerFragment extends Fragment {
                 mProgressTypeText.setText(getResources().getString(R.string.extracting));
                 cancelBroadcast(new Intent(ExtractService.TAG_BROADCAST_EXTRACT_CANCEL));
                 break;
-            case COMPRESS:
+            case SERVICE_COMPRESS:
                 if (mainActivity.getAppTheme().equals(AppTheme.DARK) || mainActivity.getAppTheme().equals(AppTheme.BLACK)) {
 
                     mProgressImage.setImageDrawable(getResources()
@@ -273,7 +271,7 @@ public class ProcessViewerFragment extends Fragment {
                 mProgressTypeText.setText(getResources().getString(R.string.compressing));
                 cancelBroadcast(new Intent(ZipService.KEY_COMPRESS_BROADCAST_CANCEL));
                 break;
-            case ENCRYPT:
+            case SERVICE_ENCRYPT:
                 if (mainActivity.getAppTheme().equals(AppTheme.DARK) || mainActivity.getAppTheme().equals(AppTheme.BLACK)) {
 
                     mProgressImage.setImageDrawable(getResources()
@@ -285,7 +283,7 @@ public class ProcessViewerFragment extends Fragment {
                 mProgressTypeText.setText(getResources().getString(R.string.crypt_encrypting));
                 cancelBroadcast(new Intent(EncryptService.TAG_BROADCAST_CRYPT_CANCEL));
                 break;
-            case DECRYPT:
+            case SERVICE_DECRYPT:
                 if (mainActivity.getAppTheme().equals(AppTheme.DARK) || mainActivity.getAppTheme().equals(AppTheme.BLACK)) {
 
                     mProgressImage.setImageDrawable(getResources()
@@ -395,9 +393,9 @@ public class ProcessViewerFragment extends Fragment {
 
         private ProcessViewerFragment fragment;
         private LineChart lineChart;
-        private ServiceType serviceType;
+        private int serviceType;
 
-        public CustomServiceConnection(ProcessViewerFragment frag, LineChart lineChart, ServiceType serviceType) {
+        public CustomServiceConnection(ProcessViewerFragment frag, LineChart lineChart, int serviceType) {
             fragment = frag;
             this.lineChart = lineChart;
             this.serviceType = serviceType;

--- a/app/src/main/java/com/amaze/filemanager/ui/ItemPopupMenu.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/ItemPopupMenu.java
@@ -129,8 +129,6 @@ public class ItemPopupMenu extends PopupMenu implements PopupMenu.OnMenuItemClic
             case R.id.encrypt:
                 final Intent encryptIntent = new Intent(context, EncryptService.class);
                 encryptIntent.putExtra(EncryptService.TAG_OPEN_MODE, rowItem.getMode().ordinal());
-                encryptIntent.putExtra(EncryptService.TAG_CRYPT_MODE,
-                        EncryptService.CryptEnum.ENCRYPT.ordinal());
                 encryptIntent.putExtra(EncryptService.TAG_SOURCE, rowItem.generateBaseFile());
 
                 final SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(context);

--- a/app/src/main/java/com/amaze/filemanager/ui/notifications/FTPNotification.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/notifications/FTPNotification.java
@@ -22,8 +22,6 @@ import java.net.InetAddress;
  */
 public class FTPNotification extends BroadcastReceiver {
 
-    private static final int NOTIFICATION_ID = 2123;
-
     @Override
     public void onReceive(Context context, Intent intent) {
         switch(intent.getAction()){
@@ -96,7 +94,7 @@ public class FTPNotification extends BroadcastReceiver {
         }
 
         // Pass Notification to NotificationManager
-        notificationManager.notify(NOTIFICATION_ID, notification);
+        notificationManager.notify(NotificationConstants.FTP_ID, notification);
     }
 
     private void removeNotification(Context context){

--- a/app/src/main/java/com/amaze/filemanager/ui/notifications/NotificationConstants.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/notifications/NotificationConstants.java
@@ -11,11 +11,20 @@ import android.support.v4.app.NotificationCompat;
 import com.amaze.filemanager.R;
 
 /**
- * @author Emmanuel
+ * @author Emmanuel Messulam <emmanuelbendavid@gmail.com>
  *         on 17/9/2017, at 13:34.
  */
 
 public class NotificationConstants {
+
+    public static final int WAIT_ID = -1;
+    public static final int COPY_ID = 0;
+    public static final int EXTRACT_ID = 1;
+    public static final int ZIP_ID = 2;
+    public static final int DECRYPT_ID = 3;
+    public static final int ENCRYPT_ID = 4;
+    public static final int FTP_ID = 5;
+    public static final int FAILED_ID = 6;
 
     public static final String CHANNEL_NORMAL_ID = "normalChannel";
 

--- a/app/src/main/java/com/amaze/filemanager/utils/DatapointParcelable.java
+++ b/app/src/main/java/com/amaze/filemanager/utils/DatapointParcelable.java
@@ -13,7 +13,7 @@ import com.amaze.filemanager.fragments.ProcessViewerFragment;
  * This class also acts as a middle layer to communicate with
  * {@link ProcessViewerFragment}
  */
-public class CopyDataParcelable implements Parcelable {
+public class DatapointParcelable implements Parcelable {
 
     // which file is being copied from total number of files
     public final int sourceProgress;
@@ -35,7 +35,7 @@ public class CopyDataParcelable implements Parcelable {
     // name of source file being copied
     public final String name;
 
-    public CopyDataParcelable(String name, int amountOfSourceFiles, long totalSize, boolean move) {
+    public DatapointParcelable(String name, int amountOfSourceFiles, long totalSize, boolean move) {
         this.name = name;
         sourceFiles = amountOfSourceFiles;
         this.totalSize = totalSize;
@@ -47,7 +47,7 @@ public class CopyDataParcelable implements Parcelable {
         completed = false;
     }
 
-    public CopyDataParcelable(String name, int amountOfSourceFiles, int sourceProgress,
+    public DatapointParcelable(String name, int amountOfSourceFiles, int sourceProgress,
                               long totalSize, long byteProgress, int speedRaw, boolean move,
                               boolean completed) {
         this.name = name;
@@ -59,8 +59,7 @@ public class CopyDataParcelable implements Parcelable {
         this.move = move;
         this.completed = completed;
     }
-
-    protected CopyDataParcelable(Parcel in) {
+    protected DatapointParcelable(Parcel in) {
         sourceProgress = in.readInt();
         byteProgress = in.readLong();
         sourceFiles = in.readInt();
@@ -71,15 +70,15 @@ public class CopyDataParcelable implements Parcelable {
         speedRaw = in.readInt();
     }
 
-    public static final Creator<CopyDataParcelable> CREATOR = new Creator<CopyDataParcelable>() {
+    public static final Creator<DatapointParcelable> CREATOR = new Creator<DatapointParcelable>() {
         @Override
-        public CopyDataParcelable createFromParcel(Parcel in) {
-            return new CopyDataParcelable(in);
+        public DatapointParcelable createFromParcel(Parcel in) {
+            return new DatapointParcelable(in);
         }
 
         @Override
-        public CopyDataParcelable[] newArray(int size) {
-            return new CopyDataParcelable[size];
+        public DatapointParcelable[] newArray(int size) {
+            return new DatapointParcelable[size];
         }
     };
     

--- a/app/src/main/java/com/amaze/filemanager/utils/DatapointParcelable.java
+++ b/app/src/main/java/com/amaze/filemanager/utils/DatapointParcelable.java
@@ -3,38 +3,56 @@ package com.amaze.filemanager.utils;
 import android.os.Parcel;
 import android.os.Parcelable;
 
-import com.amaze.filemanager.asynchronous.services.CopyService;
+import com.amaze.filemanager.asynchronous.services.ProgressiveService;
 import com.amaze.filemanager.fragments.ProcessViewerFragment;
 
 /**
- * Created by Arpit on 01-08-2015.
+ * Created by Arpit on 01-08-2015
+ *      edited by Emmanuel Messulam <emmanuelbendavid@gmail.com>
  *
- * Class stores the {@link CopyService} progress variables.
- * This class also acts as a middle layer to communicate with
- * {@link ProcessViewerFragment}
+ * Class stores the {@link ProgressiveService} progress variables.
+ * This class also acts as data carrier to communicate with {@link ProcessViewerFragment}
  */
 public class DatapointParcelable implements Parcelable {
 
-    // which file is being copied from total number of files
+    /**
+     * which file is being copied from total number of files
+     */
     public final int sourceProgress;
 
-    // current byte position in total bytes pool
+    /**
+     * current byte position in total bytes pool
+     */
     public final long byteProgress;
-
-    // total number of source files to be copied
+    /**
+     * total number of source files to be copied
+     */
     public final int sourceFiles;
-
-    // total size of all source files combined
+    /**
+     * total size of all source files combined
+     */
     public final long totalSize;
-
-    // bytes being copied per sec
+    /**
+     * bytes being copied per sec
+     */
     public final int speedRaw;
 
     public final boolean completed, move;
 
-    // name of source file being copied
+     /**
+     * name of source file being copied
+     */
     public final String name;
 
+    /**
+     * For the first datapoint, everything is 0 or false except the params. Allows
+     * move boolean to change the text from "Copying" to "Moving" in case of copy.
+     *
+     * @param name name of source file being copied
+     * @param amountOfSourceFiles total number of source files to be copied
+     * @param totalSize total size of all source files combined
+     * @param move allows changing the text from "Copying" to "Moving" in case of copy
+     */
     public DatapointParcelable(String name, int amountOfSourceFiles, long totalSize, boolean move) {
         this.name = name;
         sourceFiles = amountOfSourceFiles;
@@ -47,6 +65,42 @@ public class DatapointParcelable implements Parcelable {
         completed = false;
     }
 
+    /**
+     *
+     * @param name name of source file being copied
+     * @param amountOfSourceFiles total number of source files to be copied
+     * @param sourceProgress which file is being copied from total number of files
+     * @param totalSize total size of all source files combined
+     * @param byteProgress current byte position in total bytes pool
+     * @param speedRaw bytes being copied per sec
+     * @param completed if the operation has finished
+     */
+    public DatapointParcelable(String name, int amountOfSourceFiles, int sourceProgress,
+                               long totalSize, long byteProgress, int speedRaw, boolean completed) {
+        this.name = name;
+        sourceFiles = amountOfSourceFiles;
+        this.sourceProgress = sourceProgress;
+        this.totalSize = totalSize;
+        this.byteProgress = byteProgress;
+        this.speedRaw = speedRaw;
+        this.completed = completed;
+
+        move = false;
+    }
+
+    /**
+     * The same as {@link DatapointParcelable#DatapointParcelable(String, int, int, long, long, int, boolean)}
+     * but allows move boolean to change the text from "Copying" to "Moving" in case of copy.
+     *
+     * @param name name of source file being copied
+     * @param amountOfSourceFiles total number of source files to be copied
+     * @param sourceProgress which file is being copied from total number of files
+     * @param totalSize total size of all source files combined
+     * @param byteProgress current byte position in total bytes pool
+     * @param speedRaw bytes being copied per sec
+     * @param move allows changing the text from "Copying" to "Moving" in case of copy
+     * @param completed if the operation has finished
+     */
     public DatapointParcelable(String name, int amountOfSourceFiles, int sourceProgress,
                               long totalSize, long byteProgress, int speedRaw, boolean move,
                               boolean completed) {
@@ -59,6 +113,7 @@ public class DatapointParcelable implements Parcelable {
         this.move = move;
         this.completed = completed;
     }
+
     protected DatapointParcelable(Parcel in) {
         sourceProgress = in.readInt();
         byteProgress = in.readLong();

--- a/app/src/main/java/com/amaze/filemanager/utils/MainActivityHelper.java
+++ b/app/src/main/java/com/amaze/filemanager/utils/MainActivityHelper.java
@@ -68,7 +68,7 @@ public class MainActivityHelper {
         accentColor = mainActivity.getColorPreference().getColor(ColorUsage.ACCENT);
     }
 
-    public void showFailedOperationDialog(ArrayList<HybridFileParcelable> failedOps, boolean move, Context contextc) {
+    public void showFailedOperationDialog(ArrayList<HybridFileParcelable> failedOps, Context contextc) {
         MaterialDialog.Builder mat=new MaterialDialog.Builder(contextc);
         mat.title(contextc.getString(R.string.operationunsuccesful));
         mat.theme(mainActivity.getAppTheme().getMaterialDialogTheme());

--- a/app/src/main/java/com/amaze/filemanager/utils/ObtainableServiceBinder.java
+++ b/app/src/main/java/com/amaze/filemanager/utils/ObtainableServiceBinder.java
@@ -1,0 +1,23 @@
+package com.amaze.filemanager.utils;
+
+import android.app.Service;
+import android.os.Binder;
+
+/**
+ * @author Emmanuel
+ *         on 28/11/2017, at 19:04.
+ */
+
+public class ObtainableServiceBinder<T extends Service> extends Binder {
+
+    private final T service;
+
+    public ObtainableServiceBinder(T service) {
+        this.service = service;
+    }
+
+    public T getService() {
+        return service;
+    }
+
+}

--- a/app/src/main/java/com/amaze/filemanager/utils/ProgressHandler.java
+++ b/app/src/main/java/com/amaze/filemanager/utils/ProgressHandler.java
@@ -8,7 +8,7 @@ import com.amaze.filemanager.fragments.ProcessViewerFragment;
  * Base class to handle progress of services operation
  * Utilized for generation of notification,
  * talking to {@link ProcessViewerFragment} through
- * {@link CopyDataParcelable}
+ * {@link DatapointParcelable}
  *
  */
 public class ProgressHandler {

--- a/app/src/main/java/com/amaze/filemanager/utils/ServiceWatcherUtil.java
+++ b/app/src/main/java/com/amaze/filemanager/utils/ServiceWatcherUtil.java
@@ -35,8 +35,6 @@ public class ServiceWatcherUtil {
 
     private static int HAULT_COUNTER = -1;
 
-    public static final int ID_NOTIFICATION_WAIT =  9248;
-
     /**
      *
      * @param progressHandler to publish progress after certain delay
@@ -177,13 +175,13 @@ public class ServiceWatcherUtil {
 
                     if (pendingIntents.size()==0) {
                         // we've done all the work, free up resources (if not already killed by system)
-                        notificationManager.cancel(ID_NOTIFICATION_WAIT);
+                        notificationManager.cancel(NotificationConstants.WAIT_ID);
                         handler.removeCallbacks(this);
                         waitingThread.quit();
                         return;
                     } else {
 
-                        notificationManager.notify(ID_NOTIFICATION_WAIT, mBuilder.build());
+                        notificationManager.notify(NotificationConstants.WAIT_ID, mBuilder.build());
                     }
                 }
                 handler.postDelayed(this, 5000);

--- a/app/src/main/java/com/amaze/filemanager/utils/files/EncryptDecryptUtils.java
+++ b/app/src/main/java/com/amaze/filemanager/utils/files/EncryptDecryptUtils.java
@@ -9,6 +9,7 @@ import android.widget.Toast;
 
 import com.amaze.filemanager.R;
 import com.amaze.filemanager.activities.MainActivity;
+import com.amaze.filemanager.asynchronous.services.DecryptService;
 import com.amaze.filemanager.asynchronous.services.EncryptService;
 import com.amaze.filemanager.database.CryptHandler;
 import com.amaze.filemanager.database.models.EncryptedEntry;
@@ -57,13 +58,10 @@ public class EncryptDecryptUtils {
                                    UtilitiesProviderInterface utilsProvider,
                                    boolean broadcastResult) {
 
-        Intent decryptIntent = new Intent(main.getContext(), EncryptService.class);
+        Intent decryptIntent = new Intent(main.getContext(), DecryptService.class);
         decryptIntent.putExtra(EncryptService.TAG_OPEN_MODE, openMode.ordinal());
-        decryptIntent.putExtra(EncryptService.TAG_CRYPT_MODE,
-                EncryptService.CryptEnum.DECRYPT.ordinal());
         decryptIntent.putExtra(EncryptService.TAG_SOURCE, sourceFile);
         decryptIntent.putExtra(EncryptService.TAG_DECRYPT_PATH, decryptPath);
-        decryptIntent.putExtra(EncryptService.TAG_BROADCAST_RESULT, broadcastResult);
         SharedPreferences preferences1 = PreferenceManager.getDefaultSharedPreferences(main.getContext());
 
         EncryptedEntry encryptedEntry;

--- a/app/src/play/java/com/amaze/filemanager/activities/MainActivity.java
+++ b/app/src/play/java/com/amaze/filemanager/activities/MainActivity.java
@@ -363,7 +363,7 @@ public class MainActivity extends ThemedActivity implements OnRequestPermissions
         if (intent.getStringArrayListExtra(TAG_INTENT_FILTER_FAILED_OPS) != null) {
             ArrayList<HybridFileParcelable> failedOps = intent.getParcelableArrayListExtra(TAG_INTENT_FILTER_FAILED_OPS);
             if (failedOps != null) {
-                mainActivityHelper.showFailedOperationDialog(failedOps, intent.getBooleanExtra("move", false), this);
+                mainActivityHelper.showFailedOperationDialog(failedOps, this);
             }
         }
         if (actionIntent != null) {
@@ -1932,7 +1932,7 @@ public class MainActivity extends ThemedActivity implements OnRequestPermissions
         } else if (i.getStringArrayListExtra(TAG_INTENT_FILTER_FAILED_OPS) != null) {
             ArrayList<HybridFileParcelable> failedOps = i.getParcelableArrayListExtra(TAG_INTENT_FILTER_FAILED_OPS);
             if (failedOps != null) {
-                mainActivityHelper.showFailedOperationDialog(failedOps, i.getBooleanExtra("move", false), this);
+                mainActivityHelper.showFailedOperationDialog(failedOps, this);
             }
         } else if (i.getCategories() != null && i.getCategories().contains(CLOUD_AUTHENTICATOR_GDRIVE)) {
 
@@ -2008,7 +2008,7 @@ public class MainActivity extends ThemedActivity implements OnRequestPermissions
             if (i.getStringArrayListExtra(TAG_INTENT_FILTER_FAILED_OPS) != null) {
                 ArrayList<HybridFileParcelable> failedOps = i.getParcelableArrayListExtra(TAG_INTENT_FILTER_FAILED_OPS);
                 if (failedOps != null) {
-                    mainActivityHelper.showFailedOperationDialog(failedOps, i.getBooleanExtra("move", false), mainActivity);
+                    mainActivityHelper.showFailedOperationDialog(failedOps, mainActivity);
                 }
             }
         }


### PR DESCRIPTION
* Uses a generalizing abstract class and a simple binder child to reduce repeated code in services.
* Had to separate Encryption and Decryption. 
* Moved notification IDs to NotificationConstants.
* Fixed decryption failing bug.
* Better javadoc in DatapointParcelable.
* ProcessViewerFragment.ServiceType enum to int final vars (see [this](https://android.jlelse.eu/android-performance-avoid-using-enum-on-android-326be0794dc3)).
* Small optimization of chart data loading.