### PR TITLE
Fix app crash on enabling FTP service

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/ui/notifications/FTPNotification.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/notifications/FTPNotification.java
@@ -63,7 +63,7 @@ public class FTPNotification extends BroadcastReceiver {
         notificationIntent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP);
         PendingIntent contentIntent = PendingIntent.getActivity(context, 0, notificationIntent, 0);
 
-        Notification.Builder notificationBuilder = new Notification.Builder(context, NotificationConstants.CHANNEL_NORMAL_ID)
+        Notification.Builder notificationBuilder = new Notification.Builder(context)
                 .setContentTitle(contentTitle)
                 .setContentText(contentText)
                 .setContentIntent(contentIntent)
@@ -71,6 +71,9 @@ public class FTPNotification extends BroadcastReceiver {
                 .setTicker(tickerText)
                 .setWhen(when)
                 .setOngoing(true);
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O)
+            notificationBuilder.setChannelId(NotificationConstants.CHANNEL_NORMAL_ID);
 
         Notification notification;
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {


### PR DESCRIPTION
App crashed when I attempt to start FTP service using current master (120dbc32), either in AP mode or connected to wifi.

Logcat said

````
java.lang.NoSuchMethodError: No direct method <init>(Landroid/content/Context;Ljava/lang/String;)V in class Landroid/app/Notification$Builder; or its super classes (declaration of 'android.app.Notification$Builder' appears in /system/framework/framework.jar)
   at com.amaze.filemanager.ui.notifications.FTPNotification.createNotification(FTPNotification.java:66)
   at com.amaze.filemanager.ui.notifications.FTPNotification.onReceive(FTPNotification.java:30)
   at android.app.ActivityThread.handleReceiver(ActivityThread.java:3056)
   at android.app.ActivityThread.-wrap18(ActivityThread.java)
   at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1573)
   at android.os.Handler.dispatchMessage(Handler.java:102)
   at android.os.Looper.loop(Looper.java:153)
   at android.app.ActivityThread.main(ActivityThread.java:6171)
   at java.lang.reflect.Method.invoke(Native Method)
   at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:891)
   at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:781)
````
It turned out that setting Notification channel ID is only available on API >= 26 (Oreo or later), as hinted [on this SO question](https://stackoverflow.com/questions/44443690/notificationcompat-with-api-26); so I changed the call a little bit, only set the notification channel ID if app is running on Oreo (or later).

Tested with Oneplus One with CandyRom (7.1.2).
  