### PR TITLE
Android 8 support for launcher shortcuts

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/fragments/MainFragment.java
+++ b/app/src/main/java/com/amaze/filemanager/fragments/MainFragment.java
@@ -43,6 +43,9 @@ import android.preference.PreferenceManager;
 import android.support.design.widget.AppBarLayout;
 import android.support.v4.app.FragmentActivity;
 import android.support.v4.app.FragmentManager;
+import android.support.v4.content.pm.ShortcutInfoCompat;
+import android.support.v4.content.pm.ShortcutManagerCompat;
+import android.support.v4.graphics.drawable.IconCompat;
 import android.support.v4.widget.DrawerLayout;
 import android.support.v4.widget.SwipeRefreshLayout;
 import android.support.v7.view.ActionMode;
@@ -1594,18 +1597,30 @@ public class MainFragment extends android.support.v4.app.Fragment implements Bot
     private void addShortcut(LayoutElementParcelable path) {
         //Adding shortcut for MainActivity
         //on Home screen
-        Intent shortcutIntent = new Intent(getActivity().getApplicationContext(),
-                MainActivity.class);
+        final Context ctx = getContext();
+
+        if (!ShortcutManagerCompat.isRequestPinShortcutSupported(ctx)) {
+            Toast.makeText(getActivity(),
+                getString(R.string.addshortcut_not_supported_by_launcher),
+                Toast.LENGTH_SHORT).show();
+            return;
+        }
+
+        Intent shortcutIntent = new Intent(ctx, MainActivity.class);
         shortcutIntent.putExtra("path", path.desc);
         shortcutIntent.setAction(Intent.ACTION_MAIN);
         shortcutIntent.setFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
-        Intent addIntent = new Intent();
-        addIntent.putExtra(Intent.EXTRA_SHORTCUT_INTENT, shortcutIntent);
-        addIntent.putExtra(Intent.EXTRA_SHORTCUT_NAME, new File(path.desc).getName());
-        addIntent.putExtra(Intent.EXTRA_SHORTCUT_ICON_RESOURCE,
-                Intent.ShortcutIconResource.fromContext(getActivity(), R.mipmap.ic_launcher));
-        addIntent.setAction("com.android.launcher.action.INSTALL_SHORTCUT");
-        getActivity().sendBroadcast(addIntent);
+
+        // Using file path as shortcut id.
+        ShortcutInfoCompat info = new ShortcutInfoCompat.Builder(ctx, path.desc)
+                .setActivity(getMainActivity().getComponentName())
+                .setIcon(IconCompat.createWithResource(ctx, R.mipmap.ic_launcher))
+                .setIntent(shortcutIntent)
+                .setLongLabel(path.desc)
+                .setShortLabel(new File(path.desc).getName())
+                .build();
+
+        ShortcutManagerCompat.requestPinShortcut(ctx, info, null);
     }
 
     // This method is used to implement the modification for the pre Searching

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -517,4 +517,5 @@
   <!-- end of plurals -->
   <string name="no_name">Файл должен иметь имя</string>
   <string name="add_item">Добавить элемент</string>
+  <string name="addshortcut_not_supported_by_launcher">Создание ярлыков не поддерживается Вашим лаунчером.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -599,5 +599,6 @@
         Please contact your system administrator or setup a new connection to continue connecting to the server.
     </string>
     <string name="ssh_key_prompt_passphrase">Please enter key passphrase.</string>
+    <string name="addshortcut_not_supported_by_launcher">Shortcuts creation is not supported by your launcher.</string>
 </resources>
 


### PR DESCRIPTION
This pull request is another option to fix an issue #771. It differs from the previously suggested fix (#818) mainly in two points:
1. It is implemented using appcompat and avoids explicit implementation of different behavior for different Android API levels;
2. It uses [pinned shortcuts](https://developer.android.com/reference/android/content/pm/ShortcutManager.html#requestPinShortcut%28android.content.pm.ShortcutInfo,%20android.content.IntentSender%29) instead of [dynamic shortcuts](https://developer.android.com/reference/android/content/pm/ShortcutManager.html#addDynamicShortcuts%28java.util.List%3Candroid.content.pm.ShortcutInfo%3E%29) used in #818. Pinned shortcuts are [recommended](https://developer.android.com/about/versions/oreo/android-8.0-changes.html#as) to use instead of those previously created by `INSTALL_SHORTCUT` broadcast and seem to provide the same user experience. Appcompat flavor of this feature uses the same broadcast to provide this feature on lower Android versions.

There is also a question concerning the state of license headers. It seems that most of files (at least those I worked with) contain a lot of modifications done, at least, in 2017 — 2018, while all the authors in license headers state their copyright only for 2014. As far as I understand, the copyright notice should contain information on all the years when modifications were done. Am I right with it or should I have just put my name in that list of 2014-year authors? For now, I left the license headers unchanged.
 
Fixes #771.