### PR TITLE
Add FileUtils.folderSizeSftp() for recursive folder size calculation

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/filesystem/ssh/SshClientUtils.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/ssh/SshClientUtils.java
@@ -73,7 +73,7 @@ public abstract class SshClientUtils
                 retval = template.execute(client);
             else
                 throw new RuntimeException("Unable to execute template");
-        } catch(IOException e) {
+        } catch(Exception e) {
             Log.e(TAG, "Error executing template method", e);
         } finally {
             if(client != null && template.closeClientOnFinish) {

--- a/app/src/main/java/com/amaze/filemanager/utils/files/FileUtils.java
+++ b/app/src/main/java/com/amaze/filemanager/utils/files/FileUtils.java
@@ -69,6 +69,10 @@ import com.cloudrail.si.types.CloudMetaData;
 import com.googlecode.concurrenttrees.radix.ConcurrentRadixTree;
 import com.googlecode.concurrenttrees.radix.node.concrete.voidvalue.VoidValue;
 
+import net.schmizz.sshj.sftp.RemoteResourceInfo;
+import net.schmizz.sshj.sftp.SFTPClient;
+import net.schmizz.sshj.sftp.SFTPException;
+
 import java.io.File;
 import java.text.ParsePosition;
 import java.text.SimpleDateFormat;
@@ -125,6 +129,34 @@ public class FileUtils {
         }
         return length;
     }
+
+    /**
+     * Use recursive <code>ls</code> to get folder size.
+     *
+     * It is slow, it is stupid, and may be inaccurate (because of permission problems).
+     * Only for fallback use when <code>du</code> is not available.
+     *
+     * @see HybridFile#folderSize(Context)
+     * @param remotePath
+     * @return Folder size in bytes
+     */
+    public static Long folderSizeSftp(SFTPClient client, String remotePath) {
+        Long retval = 0L;
+        try {
+            for (RemoteResourceInfo info : client.ls(remotePath)) {
+                if (info.isDirectory())
+                    retval += folderSizeSftp(client, info.getPath());
+                else
+                    retval += info.getAttributes().getSize();
+            }
+        } catch (SFTPException e) {
+            //Usually happens when permission denied listing files in directory
+            Log.e("folderSizeSftp", "Problem accessing " + remotePath, e);
+        } finally {
+            return retval;
+        }
+    }
+
 
     public static long folderSizeCloud(OpenMode openMode, CloudMetaData sourceFileMeta) {
 


### PR DESCRIPTION
A redo of #919, related to #905. Use this to calculate folder size for SFTP targets if `du` command fails.

`SshClientUtils.execute(SSHClientTemplate)` also changed to capture all Exceptions, including RuntimeExceptions, which caused app to hang when copying files/directories over SFTP due to `NumberFormatException` thrown from `HybridFile.folderSize(Context)` when `du` execution failed or is not available at all.