### PR TITLE
Use statvfs@openssh.com extension to query disk size/available space for SFTP targets

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/filesystem/HybridFile.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/HybridFile.java
@@ -685,7 +685,8 @@ public class HybridFile {
                     @Override
                     public Long execute(@NonNull SFTPClient client) throws IOException {
                         try {
-                            Statvfs.Response response = new Statvfs.Response(client.getSFTPEngine().request(Statvfs.request(client, SshClientUtils.extractRemotePathFrom(path))).retrieve());
+                            Statvfs.Response response = new Statvfs.Response(path,
+                                    client.getSFTPEngine().request(Statvfs.request(client, SshClientUtils.extractRemotePathFrom(path))).retrieve());
                             return response.diskFreeSpace();
                         } catch (SFTPException e) {
                             Log.e(TAG, "Error querying server", e);
@@ -739,7 +740,8 @@ public class HybridFile {
                     @Override
                     public Long execute(@NonNull SFTPClient client) throws IOException {
                         try {
-                            Statvfs.Response response = new Statvfs.Response(client.getSFTPEngine().request(Statvfs.request(client, SshClientUtils.extractRemotePathFrom(path))).retrieve());
+                            Statvfs.Response response = new Statvfs.Response(path,
+                                    client.getSFTPEngine().request(Statvfs.request(client, SshClientUtils.extractRemotePathFrom(path))).retrieve());
                             return response.diskSize();
                         } catch (SFTPException e) {
                             Log.e(TAG, "Error querying server", e);

--- a/app/src/main/java/com/amaze/filemanager/filesystem/ssh/Statvfs.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/ssh/Statvfs.java
@@ -95,10 +95,10 @@ public class Statvfs
          */
 
         // f_bsize
-        public final Long fileSystemBlockSize;
+        public final Integer fileSystemBlockSize;
 
         // f_frsize
-        public final Long fundermentalFileSystemBlockSize;
+        public final Integer fundamentalFileSystemBlockSize;
 
         // f_blocks
         public final Long fileSystemBlocks;
@@ -122,10 +122,10 @@ public class Statvfs
         public final BigInteger fileSystemId;
 
         // f_flag
-        public final Long fileSystemFlag;
+        public final Integer fileSystemFlag;
 
         // f_namemax
-        public final Long filenameMaxLength;
+        public final Integer filenameMaxLength;
 
         public Response(net.schmizz.sshj.sftp.Response response) throws SFTPException, Buffer.BufferException
         {
@@ -137,8 +137,8 @@ public class Statvfs
 
             mResponse = response;
 
-            fileSystemBlockSize = mResponse.readUInt32();
-            fundermentalFileSystemBlockSize = mResponse.readUInt64();
+            fileSystemBlockSize = Long.valueOf(mResponse.readUInt32()).intValue();
+            fundamentalFileSystemBlockSize = Long.valueOf(mResponse.readUInt64()).intValue();
             fileSystemBlocks = mResponse.readUInt64();
             freeFileSystemBlocks = mResponse.readUInt64();
             availableFileSystemBlocks = mResponse.readUInt64();
@@ -146,8 +146,8 @@ public class Statvfs
             freeFileInodes = mResponse.readUInt64();
             availableFileInodes = mResponse.readUInt64();
             fileSystemId = mResponse.readUInt64AsBigInteger();
-            fileSystemFlag = mResponse.readUInt64();
-            filenameMaxLength = mResponse.readUInt64();
+            fileSystemFlag = Long.valueOf(mResponse.readUInt64()).intValue();
+            filenameMaxLength = Long.valueOf(mResponse.readUInt64()).intValue();
         }
 
         /**

--- a/app/src/main/java/com/amaze/filemanager/filesystem/ssh/Statvfs.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/ssh/Statvfs.java
@@ -1,0 +1,179 @@
+/*
+ * Statvfs.java
+ *
+ * Copyright © 2018 Raymond Lai <airwave209gt at gmail.com>.
+ *
+ * This file is part of AmazeFileManager.
+ *
+ * AmazeFileManager is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * AmazeFileManager is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with AmazeFileManager. If not, see <http ://www.gnu.org/licenses/>.
+ */
+
+package com.amaze.filemanager.filesystem.ssh;
+
+import net.schmizz.sshj.common.Buffer;
+import net.schmizz.sshj.sftp.PacketType;
+import net.schmizz.sshj.sftp.Request;
+import net.schmizz.sshj.sftp.SFTPClient;
+import net.schmizz.sshj.sftp.SFTPException;
+
+import java.math.BigInteger;
+
+/**
+ * Wrapper for SSH <code>statvfs@openssh.com</code> request/response.
+ *
+ * This is not specified in official SSH protocol; it is implemented by OpenSSH (which is the most
+ * used SSH server implementation around.
+ */
+public class Statvfs
+{
+    private static final String STATVFS_OPENSSH_COM = "statvfs@openssh.com";
+
+    /**
+     * Convenience method for creating <code>statvfs@openssh.com</code> {@link Request}s.
+     *
+     * @param sftpClient {@link SFTPClient} instance
+     * @param path remote path
+     * @return {@link Request}
+     */
+    public static final Request request(final SFTPClient sftpClient, final String path){
+        return sftpClient.getSFTPEngine().newRequest(PacketType.EXTENDED)
+                .putString(STATVFS_OPENSSH_COM)
+                .putString(path,
+                        sftpClient.getSFTPEngine().getSubsystem().getRemoteCharset());
+    }
+
+    /**
+     * Wrapper object for {@link net.schmizz.sshj.sftp.Response}.
+     *
+     * PROTOCOL specification defines the packet structure as
+     *
+     * <code>
+     * uint64          f_bsize         // file system block size
+     * uint64          f_frsize        // fundamental fs block size
+     * uint64          f_blocks        // number of blocks (unit f_frsize)
+     * uint64          f_bfree         // free blocks in file system
+     * uint64          f_bavail        // free blocks for non-root
+     * uint64          f_files         // total file inodes
+     * uint64          f_ffree         // free file inodes
+     * uint64          f_favail        // free file inodes for to non-root
+     * uint64          f_fsid          // file system id
+     * uint64          f_flag          // bit mask of f_flag values
+     * uint64          f_namemax       // maximum filename length
+     * </code>
+     *
+     * whereas <code>f_flag</code> is defined as
+     *
+     * <code>
+     * #define SSH_FXE_STATVFS_ST_RDONLY       0x1     // read-only
+     * #define SSH_FXE_STATVFS_ST_NOSUID       0x2     // no setuid
+     * </code>
+     *
+     * @see <a href="https://cvsweb.openbsd.org/cgi-bin/cvsweb/src/usr.bin/ssh/PROTOCOL?annotate=HEAD">PROTOCOL specification</a>
+     */
+    public static class Response
+    {
+        public final net.schmizz.sshj.sftp.Response mResponse;
+
+        /*
+            Regarding choice of number types:
+
+            - fileSystemFlag is only 0x0, 0x1 and 0x2
+            - filenameMaxLength should be well within Long.VALUE_MAX
+
+            Others, can use BigInteger to prepare for the ever increasing disk size for years to come.
+         */
+
+        // f_bsize
+        public final Long fileSystemBlockSize;
+
+        // f_frsize
+        public final Long fundermentalFileSystemBlockSize;
+
+        // f_blocks
+        public final Long fileSystemBlocks;
+
+        // f_bfree
+        public final Long freeFileSystemBlocks;
+
+        // f_bavail
+        public final Long availableFileSystemBlocks;
+
+        // f_files
+        public final Long totalFileInodes;
+
+        // f_ffree
+        public final Long freeFileInodes;
+
+        // f_favail
+        public final Long availableFileInodes;
+
+        // f_fsid
+        public final Long fileSystemId;
+
+        // f_flag
+        public final Long fileSystemFlag;
+
+        // f_namemax
+        public final Long filenameMaxLength;
+
+        public Response(net.schmizz.sshj.sftp.Response response) throws SFTPException, Buffer.BufferException
+        {
+            response.ensurePacketTypeIs(PacketType.EXTENDED_REPLY);
+
+            if(!response.readStatusCode().equals(net.schmizz.sshj.sftp.Response.StatusCode.OK)) {
+                throw new SFTPException("Bad response code: " + response.readStatusCode());
+            }
+
+            mResponse = response;
+
+            fileSystemBlockSize = mResponse.readUInt32();
+            fundermentalFileSystemBlockSize = mResponse.readUInt64();
+            fileSystemBlocks = mResponse.readUInt64();
+            freeFileSystemBlocks = mResponse.readUInt64();
+            availableFileSystemBlocks = mResponse.readUInt64();
+            totalFileInodes = mResponse.readUInt64();
+            freeFileInodes = mResponse.readUInt64();
+            availableFileInodes = mResponse.readUInt64();
+            fileSystemId = mResponse.readUInt64();
+            fileSystemFlag = mResponse.readUInt64();
+            filenameMaxLength = mResponse.readUInt64();
+        }
+
+        /**
+         * Return disk size (filesystem block size * total filesystem blocks).
+         *
+         * Depending on the target SSH server implementation, the result may be the disk size of the
+         * physical disk where the queried path resides at.
+         *
+         * @return disk size in bytes
+         */
+        public Long diskSize()
+        {
+            return fileSystemBlocks * fileSystemBlockSize;
+        }
+
+        /**
+         * Return disk free space (filesystem block size * available filesystem blocks).
+         *
+         * Depending on the target SSH server implementation, the result may be the disk free space
+         * of the physical disk where the queried path resides at.
+         *
+         * @return disk free space in bytes
+         */
+        public Long diskFreeSpace()
+        {
+            return availableFileSystemBlocks * fileSystemBlockSize;
+        }
+    }
+}

--- a/app/src/main/java/com/amaze/filemanager/filesystem/ssh/Statvfs.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/ssh/Statvfs.java
@@ -119,7 +119,7 @@ public class Statvfs
         public final Long availableFileInodes;
 
         // f_fsid
-        public final Long fileSystemId;
+        public final BigInteger fileSystemId;
 
         // f_flag
         public final Long fileSystemFlag;
@@ -145,7 +145,7 @@ public class Statvfs
             totalFileInodes = mResponse.readUInt64();
             freeFileInodes = mResponse.readUInt64();
             availableFileInodes = mResponse.readUInt64();
-            fileSystemId = mResponse.readUInt64();
+            fileSystemId = mResponse.readUInt64AsBigInteger();
             fileSystemFlag = mResponse.readUInt64();
             filenameMaxLength = mResponse.readUInt64();
         }

--- a/app/src/main/java/com/amaze/filemanager/filesystem/ssh/Statvfs.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/ssh/Statvfs.java
@@ -83,6 +83,8 @@ public class Statvfs
      */
     public static class Response
     {
+        public final String mRemotePath;
+
         public final net.schmizz.sshj.sftp.Response mResponse;
 
         /*
@@ -127,7 +129,7 @@ public class Statvfs
         // f_namemax
         public final Integer filenameMaxLength;
 
-        public Response(net.schmizz.sshj.sftp.Response response) throws SFTPException, Buffer.BufferException
+        public Response(String remotePath, net.schmizz.sshj.sftp.Response response) throws SFTPException, Buffer.BufferException
         {
             response.ensurePacketTypeIs(PacketType.EXTENDED_REPLY);
 
@@ -135,6 +137,7 @@ public class Statvfs
                 throw new SFTPException("Bad response code: " + response.readStatusCode());
             }
 
+            mRemotePath = remotePath;
             mResponse = response;
 
             fileSystemBlockSize = Long.valueOf(mResponse.readUInt32()).intValue();
@@ -174,6 +177,24 @@ public class Statvfs
         public Long diskFreeSpace()
         {
             return availableFileSystemBlocks * fileSystemBlockSize;
+        }
+
+        @Override
+        public String toString() {
+            return new StringBuilder()
+                    .append("Response statvfs@openssh.com query for [").append(mRemotePath).append("], ")
+                    .append("fileSystemBlockSize=").append(fileSystemBlockSize).append(',')
+                    .append("fundamentalFileSystemBlockSize=").append(fundamentalFileSystemBlockSize).append(',')
+                    .append("fileSystemBlocks=").append(fileSystemBlocks).append(',')
+                    .append("freeFileSystemBlocks=").append(freeFileSystemBlocks).append(',')
+                    .append("availableFileSystemBlocks=").append(availableFileSystemBlocks).append(',')
+                    .append("totalFileInodes=").append(totalFileInodes).append(',')
+                    .append("freeFileInodes=").append(freeFileInodes).append(',')
+                    .append("availableFileInodes=").append(availableFileInodes).append(',')
+                    .append("fileSystemId=").append(fileSystemId).append(',')
+                    .append("fileSystemFlag=").append(fileSystemFlag).append(',')
+                    .append("filenameMaxLength=").append(filenameMaxLength)
+                    .toString();
         }
     }
 }

--- a/app/src/main/java/com/amaze/filemanager/filesystem/ssh/Statvfs.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/ssh/Statvfs.java
@@ -97,37 +97,37 @@ public class Statvfs
          */
 
         // f_bsize
-        public final Integer fileSystemBlockSize;
+        public final int fileSystemBlockSize;
 
         // f_frsize
-        public final Integer fundamentalFileSystemBlockSize;
+        public final int fundamentalFileSystemBlockSize;
 
         // f_blocks
-        public final Long fileSystemBlocks;
+        public final long fileSystemBlocks;
 
         // f_bfree
-        public final Long freeFileSystemBlocks;
+        public final long freeFileSystemBlocks;
 
         // f_bavail
-        public final Long availableFileSystemBlocks;
+        public final long availableFileSystemBlocks;
 
         // f_files
-        public final Long totalFileInodes;
+        public final long totalFileInodes;
 
         // f_ffree
-        public final Long freeFileInodes;
+        public final long freeFileInodes;
 
         // f_favail
-        public final Long availableFileInodes;
+        public final long availableFileInodes;
 
         // f_fsid
         public final BigInteger fileSystemId;
 
         // f_flag
-        public final Integer fileSystemFlag;
+        public final int fileSystemFlag;
 
         // f_namemax
-        public final Integer filenameMaxLength;
+        public final int filenameMaxLength;
 
         public Response(String remotePath, net.schmizz.sshj.sftp.Response response) throws SFTPException, Buffer.BufferException
         {
@@ -140,8 +140,8 @@ public class Statvfs
             mRemotePath = remotePath;
             mResponse = response;
 
-            fileSystemBlockSize = Long.valueOf(mResponse.readUInt32()).intValue();
-            fundamentalFileSystemBlockSize = Long.valueOf(mResponse.readUInt64()).intValue();
+            fileSystemBlockSize = (int) mResponse.readUInt32();
+            fundamentalFileSystemBlockSize = (int) mResponse.readUInt64();
             fileSystemBlocks = mResponse.readUInt64();
             freeFileSystemBlocks = mResponse.readUInt64();
             availableFileSystemBlocks = mResponse.readUInt64();
@@ -149,8 +149,8 @@ public class Statvfs
             freeFileInodes = mResponse.readUInt64();
             availableFileInodes = mResponse.readUInt64();
             fileSystemId = mResponse.readUInt64AsBigInteger();
-            fileSystemFlag = Long.valueOf(mResponse.readUInt64()).intValue();
-            filenameMaxLength = Long.valueOf(mResponse.readUInt64()).intValue();
+            fileSystemFlag = (int) mResponse.readUInt64();
+            filenameMaxLength = (int) mResponse.readUInt64();
         }
 
         /**
@@ -161,7 +161,7 @@ public class Statvfs
          *
          * @return disk size in bytes
          */
-        public Long diskSize()
+        public long diskSize()
         {
             return fileSystemBlocks * fileSystemBlockSize;
         }
@@ -174,7 +174,7 @@ public class Statvfs
          *
          * @return disk free space in bytes
          */
-        public Long diskFreeSpace()
+        public long diskFreeSpace()
         {
             return availableFileSystemBlocks * fileSystemBlockSize;
         }


### PR DESCRIPTION
Concern of running commands on the remote server, whether it's command already available on the remote server or injecting scripts, in #924, which is dangerous.

In previous implementation of SFTP support, remote command was used to query disk size and free space on the remote SSH server.

Luckily, there is a `statvfs@openssh.com` extension available at OpenSSH and Bitvise SSH servers, the two most common SSH server implementations, allowing SFTP clients to query disk space and free space without running arbitary commands.

As suggested [here](https://serverfault.com/questions/301953/how-to-check-diskspace-on-sftp-server) and [here](https://stackoverflow.com/questions/19769776/sftp-check-free-space-available#19775455). Specification is [here](https://cvsweb.openbsd.org/cgi-bin/cvsweb/src/usr.bin/ssh/PROTOCOL?annotate=HEAD), at section 3.4.

This commit implements such support, and yes, it's tested with OpenSSH and Bitvise SSH servers. On SSH server implementations that doesn't support `statvfs@openssh.com` extension (which would give incorrect replies), `HybridFile.getTotal(Context)` and `HybridFile.getUsableSpace()` will return 0 (not tested though).

`BigInteger` was used in the first implementation, however changed back to `Long` in align with `HybridFile`...and actually I don't know if there is any implication on using `BigInteger`. Based on calculation, the caveat on using `Long` is app may crash if disk size on the SSH server is above 8191 petabytes (`Long.MAX_VALUE`). `BigInteger` on the other hand can support up to 16383 petabytes.