### PR TITLE
Force texteditor scrollview to fill entire viewport to allow EditText to be full screen

### DIFF
--- a/app/src/main/res/layout/search.xml
+++ b/app/src/main/res/layout/search.xml
@@ -44,8 +44,9 @@
     <ScrollView
         android:layout_width="match_parent"
         android:id="@+id/editscroll"
-        android:layout_height="match_parent">
-    <EditText
+        android:layout_height="match_parent"
+        android:fillViewport="true">
+        <EditText
             android:id="@+id/fname"
             android:layout_width="match_parent"
             android:layout_height="match_parent"


### PR DESCRIPTION
This fix is for issue https://github.com/TeamAmaze/AmazeFileManager/issues/927. It was marked as "low" but the impact potential is minimal since it's an additive change to a one-use layout.

Adding the attribute "android:fillViewport="true" to the ScrollView in the texteditor lets the scrollview take up the entire viewport of its parent, which lets its child, the EditText, take up the full height of the screen as well.
This allows the user to tap anywhere in the view to interact with the EditText

I tested:
- The cursor still specifies where the user can enter
- The text is not erroneously modified with newlines when saving (a newline is sometimes added but that is consistent with the behavior before this change)
- All select-copy-paste interactions behave as expected
- Scroll view still functions as expected (only scrolling when there is "off-screen" content)

Fixes #927.