### PR TITLE
Moved drawer open/close logic to post event

### DIFF
--- a/app/src/play/java/com/amaze/filemanager/activities/MainActivity.java
+++ b/app/src/play/java/com/amaze/filemanager/activities/MainActivity.java
@@ -1754,8 +1754,7 @@ public class MainActivity extends ThemedActivity implements OnRequestPermissions
             isDrawerLocked = false;
             initDrawerOpen = false;
         }
-        mDrawerLayout.post(() ->
-        {
+        mDrawerLayout.post(() -> {
             if (initDrawerOpen) {
                 mDrawerLayout.openDrawer(mDrawerLinear);
             } else {

--- a/app/src/play/java/com/amaze/filemanager/activities/MainActivity.java
+++ b/app/src/play/java/com/amaze/filemanager/activities/MainActivity.java
@@ -1743,17 +1743,25 @@ public class MainActivity extends ThemedActivity implements OnRequestPermissions
         mDrawerList = findViewById(R.id.menu_drawer);
         drawerHeaderView.setBackgroundResource(R.drawable.amaze_header);
         //drawerHeaderParent.setBackgroundColor(Color.parseColor((currentTab==1 ? skinTwo : skin)));
+        boolean initDrawerOpen;
         if (findViewById(R.id.tab_frame) != null) {
             mDrawerLayout.setDrawerLockMode(DrawerLayout.LOCK_MODE_LOCKED_OPEN, mDrawerLinear);
-            mDrawerLayout.openDrawer(mDrawerLinear);
             mDrawerLayout.setScrimColor(Color.TRANSPARENT);
             isDrawerLocked = true;
-        } else if (findViewById(R.id.tab_frame) == null) {
-
+            initDrawerOpen = true;
+        } else {
             mDrawerLayout.setDrawerLockMode(DrawerLayout.LOCK_MODE_UNLOCKED, mDrawerLinear);
-            mDrawerLayout.closeDrawer(mDrawerLinear);
             isDrawerLocked = false;
+            initDrawerOpen = false;
         }
+        mDrawerLayout.post(() ->
+        {
+            if (initDrawerOpen) {
+                mDrawerLayout.openDrawer(mDrawerLinear);
+            } else {
+                mDrawerLayout.closeDrawer(mDrawerLinear);
+            }
+        });
         mDrawerList.addHeaderView(drawerHeaderLayout);
         getSupportActionBar().setDisplayShowTitleEnabled(false);
         fabBgView = findViewById(R.id.fab_bg);


### PR DESCRIPTION
Fixes #692

Another low priority bug fix to get comfortable with the code base a little more.

The close/openDrawer calls in the MainActivity's intialiseView method were being performed before the drawer finished laying out. This meant when closeDrawer got called (exiting a "tablet" layout), openDrawer got called after in the DrawerLayout.onRestoreInstanceState method.
Moving the calls to open/close out to run when the view posts resolved this. The drawer will now always be closed when rotating out of "tablet" orientation.

Also removed redundant conditionals on the if-else. If it's not not null, it's null. If that is somehow wrong here, let me know.

I tested:
- Rotating into tablet orientation (on my Pixel 2 XL, landscape is tablet) opens the drawer like before and forces it to stay open
- Rotating into non-tablet orientation, closes the drawer
- The drawer can still be opened and is usable like before
- There is no animation jitter between the view post and the action
