### PR TITLE
Prevent the PreferencesActivity from being restarted when irrelevant preferences are changed

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/activities/PreferencesActivity.java
+++ b/app/src/main/java/com/amaze/filemanager/activities/PreferencesActivity.java
@@ -62,7 +62,7 @@ public class PreferencesActivity extends ThemedActivity {
     public static final int QUICKACCESS_PREFERENCE = 3;
     public static final int ADVANCEDSEARCH_PREFERENCE = 4;
 
-    private boolean changed = false;
+    private boolean restartActivity = false;
     //The preference fragment currently selected
     private int selectedItem = 0;
 
@@ -103,7 +103,7 @@ public class PreferencesActivity extends ThemedActivity {
             if(((ColorPref) currentFragment).onBackPressed()) return;
         }
 
-        if (selectedItem != START_PREFERENCE && changed) {
+        if (selectedItem != START_PREFERENCE && restartActivity) {
             restartActivity(this);
         } else if (selectedItem != START_PREFERENCE) {
             selectItem(START_PREFERENCE);
@@ -122,7 +122,7 @@ public class PreferencesActivity extends ThemedActivity {
             case android.R.id.home:
                 if(currentFragment.onOptionsItemSelected(item)) return true;
 
-                if (selectedItem != START_PREFERENCE && changed) {
+                if (selectedItem != START_PREFERENCE && restartActivity) {
                     restartActivity(this);
                 } else if (selectedItem != START_PREFERENCE) {
                     selectItem(START_PREFERENCE);
@@ -144,12 +144,12 @@ public class PreferencesActivity extends ThemedActivity {
         return false;
     }
 
-    public void setChanged() {
-        changed = true;
+    public void setRestartActivity() {
+        restartActivity = true;
     }
 
-    public boolean getChanged() {
-        return changed;
+    public boolean getRestartActivity() {
+        return restartActivity;
     }
 
     public void invalidateRecentsColorAndIcon() {

--- a/app/src/main/java/com/amaze/filemanager/fragments/preference_fragments/ColorPref.java
+++ b/app/src/main/java/com/amaze/filemanager/fragments/preference_fragments/ColorPref.java
@@ -135,7 +135,7 @@ public class ColorPref extends PreferenceFragment implements Preference.OnPrefer
                                 @Override
                                 public void onNeutral(MaterialDialog dialog) {
                                     super.onNeutral(dialog);
-                                    if (activity != null) activity.setChanged();
+                                    if (activity != null) activity.setRestartActivity();
                                     activity.getColorPreference()
                                             .setRes(usage, usage.getDefaultColor())
                                             .saveToPreferences(sharedPref);
@@ -172,7 +172,7 @@ public class ColorPref extends PreferenceFragment implements Preference.OnPrefer
     }
 
     private void loadSection0() {
-        if(((PreferencesActivity) getActivity()).getChanged()) {
+        if(((PreferencesActivity) getActivity()).getRestartActivity()) {
             ((PreferencesActivity) getActivity()).restartActivity(getActivity());
         }
 
@@ -189,7 +189,7 @@ public class ColorPref extends PreferenceFragment implements Preference.OnPrefer
         invalidateColorPreference(selectedColors);
         selectedColors.setColorPreference(activity.getColorPreference(), activity.getAppTheme());
         selectedColors.setListener(() -> {
-            if (activity != null) activity.setChanged();
+            if (activity != null) activity.setRestartActivity();
             checkCustomization();
             invalidateEverything();
 

--- a/app/src/main/java/com/amaze/filemanager/fragments/preference_fragments/FoldersPref.java
+++ b/app/src/main/java/com/amaze/filemanager/fragments/preference_fragments/FoldersPref.java
@@ -74,8 +74,6 @@ public class FoldersPref extends PreferenceFragment implements Preference.OnPref
 
     @Override
     public boolean onPreferenceClick(final Preference preference) {
-        if (sharedPrefs != null) activity.setChanged();
-
         if (preference instanceof PathSwitchPreference) {
             PathSwitchPreference p = (PathSwitchPreference) preference;
             switch (p.getLastItemClicked()) {

--- a/app/src/main/java/com/amaze/filemanager/fragments/preference_fragments/QuickAccessPref.java
+++ b/app/src/main/java/com/amaze/filemanager/fragments/preference_fragments/QuickAccessPref.java
@@ -56,7 +56,6 @@ public class QuickAccessPref extends PreferenceFragment implements Preference.On
 
     @Override
     public boolean onPreferenceClick(Preference preference) {
-        if (preferences != null) ((PreferencesActivity) getActivity()).setChanged();
         currentValue[prefPos.get(preference.getKey())] = ((SwitchPreference) preference).isChecked();
         TinyDB.putBooleanArray(preferences, KEY, currentValue);
         return true;


### PR DESCRIPTION
I do not believe there is an issue linked to this fix. Let me know how you feel about my handling of this.

Bug fixed: When changing a preference value in FolderPrefs or QuickAccessPrefs, a double back press is required to exit the fragment.

- Currently, every time a preference fragment makes a change, it sets the "changed" Boolean in PreferencesActivity. onBackPressed, if this Boolean is true, the activity ends up getting restarted. On restart, it will attempt to open the same fragment again. This behavior is to handle the multiple screens of ColorPref.
- While the logic of telling the activity that the fragment changed a preference makes sense, it does not seem to have any reason to care that preference changed, it just wants to know if it needs to restart.

This change refactors the "changed" logic to convert it into "restartActivity" logic. This new concept tells the activity when it needs to restart rather than when a preference changes. In the future, if a single screen needs to handle restarting the activity, this same problem will come up unless onBackPressed is overridden appropriately for the fragment.

I tested:
- Closing QuickAccessPref fragment (closes to activity)
    - Preferences still set appropriately immediately
- Closing FolderPref fragment (closes to activity)
    - Preferences still set appropriately immediately
- Closing ColorPref from the first screen (closes to activity)
- Closing ColorPref from second screen (closes to first ColorPref screen)
    - Activity is restarted appropriately with any color changes