### PR TITLE
Added accent colors to available colors

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/fragments/preference_fragments/ColorPref.java
+++ b/app/src/main/java/com/amaze/filemanager/fragments/preference_fragments/ColorPref.java
@@ -116,7 +116,7 @@ public class ColorPref extends PreferenceFragment implements Preference.OnPrefer
             case PreferencesConstants.PREFERENCE_ICON_SKIN:
                 final ColorUsage usage = ColorUsage.fromString(preference.getKey());
                 if (usage != null) {
-                    ColorAdapter adapter = new ColorAdapter(getActivity(), ColorPreference.availableColors, usage);
+                    ColorAdapter adapter = new ColorAdapter(getActivity(), ColorPreference.getUniqueAvailableColors(getContext()), usage);
 
                     GridView v = (GridView) getActivity().getLayoutInflater().inflate(R.layout.dialog_grid, null);
                     v.setAdapter(adapter);

--- a/app/src/main/java/com/amaze/filemanager/fragments/preference_fragments/ColorPref.java
+++ b/app/src/main/java/com/amaze/filemanager/fragments/preference_fragments/ColorPref.java
@@ -116,7 +116,7 @@ public class ColorPref extends PreferenceFragment implements Preference.OnPrefer
             case PreferencesConstants.PREFERENCE_ICON_SKIN:
                 final ColorUsage usage = ColorUsage.fromString(preference.getKey());
                 if (usage != null) {
-                    ColorAdapter adapter = new ColorAdapter(getActivity(), ColorPreference.getUniqueAvailableColors(getContext()), usage);
+                    ColorAdapter adapter = new ColorAdapter(getActivity(), ColorPreference.getUniqueAvailableColors(getActivity()), usage);
 
                     GridView v = (GridView) getActivity().getLayoutInflater().inflate(R.layout.dialog_grid, null);
                     v.setAdapter(adapter);

--- a/app/src/main/java/com/amaze/filemanager/utils/color/ColorPreference.java
+++ b/app/src/main/java/com/amaze/filemanager/utils/color/ColorPreference.java
@@ -41,7 +41,11 @@ public class ColorPreference {
             R.color.primary_brown,
             R.color.primary_grey_900,
             R.color.primary_blue_grey,
-            R.color.primary_teal_900
+            R.color.primary_teal_900,
+            R.color.accent_pink,
+            R.color.accent_amber,
+            R.color.accent_light_blue,
+            R.color.accent_light_green
     );
 
     private static final String TAG = "ColorPreference";

--- a/app/src/main/java/com/amaze/filemanager/utils/color/ColorPreference.java
+++ b/app/src/main/java/com/amaze/filemanager/utils/color/ColorPreference.java
@@ -6,11 +6,13 @@ import android.content.res.Resources;
 import android.graphics.drawable.ColorDrawable;
 import android.support.annotation.ColorInt;
 import android.support.annotation.ColorRes;
+import android.support.v4.content.ContextCompat;
 import android.util.Log;
 
 import com.amaze.filemanager.R;
 import com.amaze.filemanager.utils.Utils;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -217,6 +219,19 @@ public class ColorPreference {
     @Deprecated
     public String getColorAsString(ColorUsage usage) {
         return String.format("#%06X", (0xFFFFFF & getColor(usage)));
+    }
+    
+    public static List<Integer> getUniqueAvailableColors(Context context) {
+        List<Integer> uniqueAvailableColors = new ArrayList<>();
+        List<Integer> tempColorsHex = new ArrayList<>();
+        for(Integer color : availableColors) {
+            Integer colorHex = ContextCompat.getColor(context, color);
+            if(!(tempColorsHex.contains(colorHex))) {
+                uniqueAvailableColors.add(color);
+            }
+            tempColorsHex.add(colorHex);
+        }
+        return uniqueAvailableColors;
     }
 
 }


### PR DESCRIPTION
Not related to an existing issue:

Bugfix: After setting color preferences explicitly through settings (notably to "Default), killing the app and attempting to reopen causes the app to crash on startup due to colors set in theme missing from available colors array

I'm not sure how this was missed, so let me know if I am missing something. Each theme contains an "accent color" (R.color.accent*) but that accent color is not present in the ColorPreference.availableColors array. This causes an ArrayOutOfBounds exception to be thrown after the app is killed and get recreated completely, since the initial color setter requires the color to be in that array.

Fix: Added all accent colors to available colors array

I tested:
- All color preferences to verify they started appropriately
     - The color themes are unmodified
- A crashing exception is not thrown on start up