### PR TITLE
Modified disableButton logic for the shortcuts dialog to watch both edit texts for validity

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/fragments/preference_fragments/FoldersPref.java
+++ b/app/src/main/java/com/amaze/filemanager/fragments/preference_fragments/FoldersPref.java
@@ -121,8 +121,7 @@ public class FoldersPref extends PreferenceFragment implements Preference.OnPref
 
         dialog.getActionButton(DialogAction.POSITIVE).setEnabled(false);
 
-        disableButtonIfTitleEmpty(editText1, dialog);
-        disableButtonIfNotPath(editText2, dialog);
+        disableButtonIfNotValid(editText1, editText2, dialog);
 
         dialog.getActionButton(DialogAction.POSITIVE)
                 .setOnClickListener(new View.OnClickListener() {
@@ -181,8 +180,7 @@ public class FoldersPref extends PreferenceFragment implements Preference.OnPref
         dialog.getActionButton(DialogAction.POSITIVE)
                 .setEnabled(FileUtils.isPathAccesible(editText2.getText().toString(), sharedPrefs));
 
-        disableButtonIfTitleEmpty(editText1, dialog);
-        disableButtonIfNotPath(editText2, dialog);
+        disableButtonIfNotValid(editText1, editText2, dialog);
 
         dialog.getActionButton(DialogAction.POSITIVE)
                 .setOnClickListener(new View.OnClickListener() {
@@ -259,22 +257,27 @@ public class FoldersPref extends PreferenceFragment implements Preference.OnPref
         dialog.show();
     }
 
-    private void disableButtonIfNotPath(EditText path, final MaterialDialog dialog) {
+    private void disableButtonIfNotValid(EditText title, EditText path, final MaterialDialog dialog) {
         path.addTextChangedListener(new SimpleTextWatcher() {
             @Override
             public void afterTextChanged(Editable s) {
-                dialog.getActionButton(DialogAction.POSITIVE)
-                        .setEnabled(FileUtils.isPathAccesible(s.toString(), sharedPrefs));
+                dialog.getActionButton(DialogAction.POSITIVE).setEnabled(
+                        isShortcutValid(title.getEditableText(), s));
             }
         });
-    }
-
-    private void disableButtonIfTitleEmpty(final EditText title, final MaterialDialog dialog) {
+    
         title.addTextChangedListener(new SimpleTextWatcher() {
             @Override
             public void afterTextChanged(Editable s) {
-                dialog.getActionButton(DialogAction.POSITIVE).setEnabled(title.length() > 0);
+                dialog.getActionButton(DialogAction.POSITIVE).setEnabled(
+                    isShortcutValid(s, path.getEditableText()));
             }
         });
+    }
+    
+    private boolean isShortcutValid(Editable title, Editable path) {
+        boolean isPath = FileUtils.isPathAccesible(path.toString(), sharedPrefs);
+        boolean hasTitle = title.length() > 0;
+        return isPath && hasTitle;
     }
 }


### PR DESCRIPTION
Not tied to a current issue.

Bug: If a newly created or modified shortcut has either a title OR a valid file path, it can be created/modified, allowing invalid shortcuts to be created

Previously, shortcut validity was being checked on the title edit text and the path edit text separately. This change consolidates the check into one method with two listeners that both check for validity of changed text and the other edit text's value

I kept the enable logic in the listener to allow it to be more easily extended later and only broke the "isValid" check out to its own method.

I tested:
- Modifying either edit text functions as expected
- A shortcut without both valid values cannot be created/modified
- A shortcut with bot valid values can be created/modified
