### PR TITLE
Fix ZipService (second try)

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/asynchronous/services/ExtractService.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/services/ExtractService.java
@@ -237,7 +237,7 @@ public class ExtractService extends ProgressiveService {
             BufferedInputStream inputStream = new BufferedInputStream(
                     zipFile.getInputStream(entry));
             BufferedOutputStream outputStream = new BufferedOutputStream(
-                    FileUtil.getOutputStream(outputFile, context, 0));
+                    FileUtil.getOutputStream(outputFile, context));
             try {
                 int len;
                 byte buf[] = new byte[GenericCopyUtil.DEFAULT_BUFFER_SIZE];
@@ -268,7 +268,7 @@ public class ExtractService extends ProgressiveService {
             BufferedInputStream inputStream = new BufferedInputStream(
                     zipFile.getInputStream(entry));
             BufferedOutputStream outputStream = new BufferedOutputStream(
-                    FileUtil.getOutputStream(outputFile, context, entry.getFullUnpackSize()));
+                    FileUtil.getOutputStream(outputFile, context));
             try {
                 int len;
                 byte buf[] = new byte[GenericCopyUtil.DEFAULT_BUFFER_SIZE];
@@ -296,7 +296,7 @@ public class ExtractService extends ProgressiveService {
             }
 
             BufferedOutputStream outputStream = new BufferedOutputStream(
-                    FileUtil.getOutputStream(outputFile, context, entry.getRealSize()));
+                    FileUtil.getOutputStream(outputFile, context));
             try {
                 int len;
                 byte buf[] = new byte[GenericCopyUtil.DEFAULT_BUFFER_SIZE];

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/services/ZipService.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/services/ZipService.java
@@ -153,7 +153,7 @@ public class ZipService extends ProgressiveService {
             watcherUtil.watch();
 
             try {
-                out = FileUtil.getOutputStream(zipDirectory, c, totalBytes);
+                out = FileUtil.getOutputStream(zipDirectory, c);
                 zos = new ZipOutputStream(new BufferedOutputStream(out));
 
                 int fileProgress = 0;

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/services/ZipService.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/services/ZipService.java
@@ -77,17 +77,13 @@ public class ZipService extends ProgressiveService {
     @Override
     public int onStartCommand(Intent intent, int flags, final int startId) {
         Bundle b = new Bundle();
-        String path = intent.getStringExtra(KEY_COMPRESS_PATH);
+        mZipPath = intent.getStringExtra(KEY_COMPRESS_PATH);
 
         ArrayList<HybridFileParcelable> baseFiles = intent.getParcelableArrayListExtra(KEY_COMPRESS_FILES);
 
-        File zipFile = new File(path);
-        mZipPath = path;
-        
+        File zipFile = new File(mZipPath);
+
         mNotifyManager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
-        if (!mZipPath.equals(path)) {
-            mZipPath.concat(mZipPath.endsWith("/") ? (zipFile.getName()) : ("/" + zipFile.getName()));
-        }
 
         if (!zipFile.exists()) {
             try {

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/services/ZipService.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/services/ZipService.java
@@ -66,12 +66,10 @@ public class ZipService extends ProgressiveService {
     NotificationManager mNotifyManager;
     NotificationCompat.Builder mBuilder;
     String mZipPath;
-    Context c;
     private DoWork asyncTask;
 
     @Override
     public void onCreate() {
-        c = getApplicationContext();
         registerReceiver(receiver1, new IntentFilter(KEY_COMPRESS_BROADCAST_CANCEL));
     }
 
@@ -89,7 +87,6 @@ public class ZipService extends ProgressiveService {
             try {
                 zipFile.createNewFile();
             } catch (IOException e) {
-                // TODO Auto-generated catch block
                 e.printStackTrace();
             }
         }
@@ -159,7 +156,6 @@ public class ZipService extends ProgressiveService {
         }
 
         public void execute(final @NonNull Context context, ArrayList<File> baseFiles, String zipPath) {
-
             OutputStream out;
             File zipDirectory = new File(zipPath);
             watcherUtil = new ServiceWatcherUtil(progressHandler, totalBytes);
@@ -190,7 +186,6 @@ public class ZipService extends ProgressiveService {
         }
 
         private void compressFile(File file, String path) throws IOException, NullPointerException {
-
             if (!file.isDirectory()) {
                 if (progressHandler.getCancelled()) return;
 
@@ -205,13 +200,11 @@ public class ZipService extends ProgressiveService {
                 in.close();
                 return;
             }
-            if (file.list() == null) {
-                return;
-            }
+
+            if (file.list() == null) return;
+
             for (File currentFile : file.listFiles()) {
-
                 compressFile(currentFile, path + File.separator + file.getName());
-
             }
         }
     }
@@ -225,9 +218,9 @@ public class ZipService extends ProgressiveService {
             mBuilder.setProgress(100, Math.round(progressPercent), false);
             mBuilder.setOngoing(true);
             int title = R.string.compressing;
-            mBuilder.setContentTitle(c.getResources().getString(title));
+            mBuilder.setContentTitle(getResources().getString(title));
             mBuilder.setContentText(new File(fileName).getName() + " " +
-                    Formatter.formatFileSize(c, done) + "/" + Formatter.formatFileSize(c, total));
+                    Formatter.formatFileSize(this, done) + "/" + Formatter.formatFileSize(this, total));
             mNotifyManager.notify(NotificationConstants.ZIP_ID, mBuilder.build());
             if (done == total || total == 0) {
                 mBuilder.setContentTitle(getString(R.string.compression_complete));
@@ -254,7 +247,6 @@ public class ZipService extends ProgressiveService {
      */
 
     private BroadcastReceiver receiver1 = new BroadcastReceiver() {
-
         @Override
         public void onReceive(Context context, Intent intent) {
             asyncTask.cancel(true);
@@ -263,7 +255,6 @@ public class ZipService extends ProgressiveService {
 
     @Override
     public IBinder onBind(Intent arg0) {
-        // TODO Auto-generated method stub
         return mBinder;
     }
 

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/services/ZipService.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/services/ZipService.java
@@ -27,7 +27,6 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.os.AsyncTask;
-import android.os.Bundle;
 import android.os.IBinder;
 import android.support.v4.app.NotificationCompat;
 import android.text.format.Formatter;
@@ -76,7 +75,6 @@ public class ZipService extends ProgressiveService {
 
     @Override
     public int onStartCommand(Intent intent, int flags, final int startId) {
-        Bundle b = new Bundle();
         mZipPath = intent.getStringExtra(KEY_COMPRESS_PATH);
 
         ArrayList<HybridFileParcelable> baseFiles = intent.getParcelableArrayListExtra(KEY_COMPRESS_FILES);
@@ -124,14 +122,6 @@ public class ZipService extends ProgressiveService {
             this.zipPath = zipPath;
         }
 
-        public ArrayList<File> toFileArray(ArrayList<HybridFileParcelable> a) {
-            ArrayList<File> b = new ArrayList<>();
-            for (int i = 0; i < a.size(); i++) {
-                b.add(new File(a.get(i).getPath()));
-            }
-            return b;
-        }
-
         protected Void doInBackground(Void... p1) {
             // setting up service watchers and initial data packages
             // finding total size on background thread (this is necessary condition for SMB!)
@@ -143,7 +133,7 @@ public class ZipService extends ProgressiveService {
 
             addFirstDatapoint(baseFiles.get(0).getName(), baseFiles.size(), totalBytes, false);
 
-            execute(toFileArray(baseFiles), zipPath);
+            execute(FileUtils.hybridListToFileArrayList(baseFiles), zipPath);
             return null;
         }
 

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/services/ZipService.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/services/ZipService.java
@@ -127,9 +127,7 @@ public class ZipService extends ProgressiveService {
             // finding total size on background thread (this is necessary condition for SMB!)
             totalBytes = FileUtils.getTotalBytes(baseFiles, c);
             progressHandler = new ProgressHandler(baseFiles.size(), totalBytes);
-            progressHandler.setProgressListener((fileName, sourceFiles, sourceProgress, totalSize, writtenSize, speed) -> {
-                publishResults(fileName, sourceFiles, sourceProgress, totalSize, writtenSize, speed, false);
-            });
+            progressHandler.setProgressListener(ZipService.this::publishResults);
 
             addFirstDatapoint(baseFiles.get(0).getName(), baseFiles.size(), totalBytes, false);
 
@@ -208,7 +206,9 @@ public class ZipService extends ProgressiveService {
     }
 
     private void publishResults(String fileName, int sourceFiles, int sourceProgress,
-                                long total, long done, int speed, boolean isCompleted) {
+                                long total, long done, int speed) {
+        boolean isCompleted = false;
+
         if (!progressHandler.getCancelled()) {
             float progressPercent = ((float) done / total) * 100;
             mBuilder.setProgress(100, Math.round(progressPercent), false);

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/services/ZipService.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/services/ZipService.java
@@ -29,7 +29,6 @@ import android.content.IntentFilter;
 import android.os.AsyncTask;
 import android.os.Bundle;
 import android.os.IBinder;
-import android.preference.PreferenceManager;
 import android.support.v4.app.NotificationCompat;
 import android.text.format.Formatter;
 
@@ -40,7 +39,6 @@ import com.amaze.filemanager.filesystem.HybridFileParcelable;
 import com.amaze.filemanager.ui.notifications.NotificationConstants;
 import com.amaze.filemanager.utils.DatapointParcelable;
 import com.amaze.filemanager.utils.ObtainableServiceBinder;
-import com.amaze.filemanager.utils.PreferenceUtils;
 import com.amaze.filemanager.utils.ProgressHandler;
 import com.amaze.filemanager.utils.ServiceWatcherUtil;
 import com.amaze.filemanager.utils.files.FileUtils;
@@ -84,8 +82,8 @@ public class ZipService extends ProgressiveService {
         ArrayList<HybridFileParcelable> baseFiles = intent.getParcelableArrayListExtra(KEY_COMPRESS_FILES);
 
         File zipFile = new File(path);
-        mZipPath = PreferenceManager.getDefaultSharedPreferences(this)
-                .getString(PreferenceUtils.KEY_PATH_COMPRESS, path);
+        mZipPath = path;
+        
         mNotifyManager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
         if (!mZipPath.equals(path)) {
             mZipPath.concat(mZipPath.endsWith("/") ? (zipFile.getName()) : ("/" + zipFile.getName()));

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/services/ZipService.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/services/ZipService.java
@@ -65,7 +65,7 @@ public class ZipService extends ProgressiveService {
 
     private NotificationManager mNotifyManager;
     private NotificationCompat.Builder mBuilder;
-    private DoWork asyncTask;
+    private CompressAsyncTask asyncTask;
 
     @Override
     public void onCreate() {
@@ -101,13 +101,13 @@ public class ZipService extends ProgressiveService {
         NotificationConstants.setMetadata(this, mBuilder);
         startForeground(NotificationConstants.ZIP_ID, mBuilder.build());
 
-        asyncTask = new DoWork(this, baseFiles, mZipPath);
+        asyncTask = new CompressAsyncTask(this, baseFiles, mZipPath);
         asyncTask.execute();
         // If we get killed, after returning from here, restart
         return START_STICKY;
     }
 
-    public static class DoWork extends AsyncTask<Void, Void, Void> {
+    public static class CompressAsyncTask extends AsyncTask<Void, Void, Void> {
 
         @SuppressLint("StaticFieldLeak")
         private ZipService zipService;
@@ -118,7 +118,7 @@ public class ZipService extends ProgressiveService {
         private long totalBytes = 0L;
         private ArrayList<HybridFileParcelable> baseFiles;
 
-        public DoWork(ZipService zipService, ArrayList<HybridFileParcelable> baseFiles, String zipPath) {
+        public CompressAsyncTask(ZipService zipService, ArrayList<HybridFileParcelable> baseFiles, String zipPath) {
             this.zipService = zipService;
             this.baseFiles = baseFiles;
             this.zipPath = zipPath;

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/services/ZipService.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/services/ZipService.java
@@ -63,9 +63,8 @@ public class ZipService extends ProgressiveService {
 
     private final IBinder mBinder = new ObtainableServiceBinder<>(this);
 
-    NotificationManager mNotifyManager;
-    NotificationCompat.Builder mBuilder;
-    String mZipPath;
+    private NotificationManager mNotifyManager;
+    private NotificationCompat.Builder mBuilder;
     private DoWork asyncTask;
 
     @Override
@@ -75,7 +74,7 @@ public class ZipService extends ProgressiveService {
 
     @Override
     public int onStartCommand(Intent intent, int flags, final int startId) {
-        mZipPath = intent.getStringExtra(KEY_COMPRESS_PATH);
+        String mZipPath = intent.getStringExtra(KEY_COMPRESS_PATH);
 
         ArrayList<HybridFileParcelable> baseFiles = intent.getParcelableArrayListExtra(KEY_COMPRESS_FILES);
 

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/services/ZipService.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/services/ZipService.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2014 Arpit Khurana <arpitkh96@gmail.com>, Vishal Nehra <vishalmeham2@gmail.com>
- *                      Emmanuel Messulam <emmanuelbendavid@gmail.com>
+ * Copyright (C) 2017-2018 Emmanuel Messulam <emmanuelbendavid@gmail.com>
  *
  * This file is part of Amaze File Manager.
  *

--- a/app/src/main/java/com/amaze/filemanager/filesystem/FileUtil.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/FileUtil.java
@@ -145,10 +145,6 @@ public abstract class FileUtil {
     }
 
     public static OutputStream getOutputStream(final File target, Context context) throws FileNotFoundException {
-        return getOutputStream(target, context, 0);
-    }
-
-    public static OutputStream getOutputStream(final File target, Context context, long s) throws FileNotFoundException {
         OutputStream outStream = null;
         // First try the normal way
         if (isWritable(target)) {

--- a/app/src/main/java/com/amaze/filemanager/filesystem/HybridFile.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/HybridFile.java
@@ -1085,7 +1085,7 @@ public class HybridFile {
                 break;
             default:
                 try {
-                    outputStream = FileUtil.getOutputStream(new File(path), context, length());
+                    outputStream = FileUtil.getOutputStream(new File(path), context);
                 } catch (Exception e) {
                     outputStream=null;
                     e.printStackTrace();

--- a/app/src/main/java/com/amaze/filemanager/utils/PreferenceUtils.java
+++ b/app/src/main/java/com/amaze/filemanager/utils/PreferenceUtils.java
@@ -8,7 +8,6 @@ import android.graphics.Color;
 public class PreferenceUtils {
 
     public static final String KEY_CURRENT_TAB = "current_tab";
-    public static final String KEY_PATH_COMPRESS = "zippath";
 
     public static final int DEFAULT_PRIMARY = 4;
     public static final int DEFAULT_ACCENT = 1;

--- a/app/src/main/java/com/amaze/filemanager/utils/files/FileUtils.java
+++ b/app/src/main/java/com/amaze/filemanager/utils/files/FileUtils.java
@@ -919,4 +919,15 @@ public class FileUtils {
         return !dir.contains(OTGUtil.PREFIX_OTG) && !dir.startsWith("/storage");
     }
 
+    /**
+     * Converts ArrayList of HybridFileParcelable to ArrayList of File
+     */
+    public static ArrayList<File> hybridListToFileArrayList(ArrayList<HybridFileParcelable> a) {
+        ArrayList<File> b = new ArrayList<>();
+        for (int i = 0; i < a.size(); i++) {
+            b.add(new File(a.get(i).getPath()));
+        }
+        return b;
+    }
+
 }


### PR DESCRIPTION
Better code in ZipService (second try, with no weird glitch in ServiceWatcherFragment):
* Statiziced AsyncTask
* Privatized vars
* Centralized cancellation of AsyncTask (aka put everything inside `onCancelled()`)
* Fusioned `FileUtil.getOutputStream(2)` and `getOutputStream(3)` into `getOutputStream(2)`
* Corrected copyright to show years
* more details in commits