### PR TITLE
Enabled multi dex support in API < 20

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -149,6 +149,8 @@ dependencies {
     annotationProcessor 'com.github.bumptech.glide:compiler:4.4.0'
 
     implementation 'com.github.jahirfiquitiva:FABsMenu:1.1.1'//Floating Action Buttons Menu (aka expandable FAB)
+
+    compile 'com.android.support:multidex:1.0.2'//Multiple dex files
 }
 
 configurations.all {

--- a/app/src/main/java/com/amaze/filemanager/utils/application/LeakCanaryApplication.java
+++ b/app/src/main/java/com/amaze/filemanager/utils/application/LeakCanaryApplication.java
@@ -1,13 +1,13 @@
 package com.amaze.filemanager.utils.application;
 
-import android.app.Application;
+import android.support.multidex.MultiDexApplication;
 
 /**
  * @author Emmanuel
  *         on 28/8/2017, at 18:12.
  */
 
-public class LeakCanaryApplication extends Application {
+public class LeakCanaryApplication extends MultiDexApplication {
 
     @Override
     public void onCreate() {


### PR DESCRIPTION
This should fix a crash that ocurred in API < 20. Beware that another crash regarding the FAB lib has emerged and [has already been reported](https://github.com/jahirfiquitiva/FABsMenu/issues/27) (by me).