### PR TITLE
"AMOLED" to "OLED" (more generic and shorter)

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -106,7 +106,7 @@
     <string name="light">Material Light</string>
     <string name="dark">Material Dark</string>
     <string name="daytime">Daytime</string>
-    <string name="black">Black (for AMOLED)</string>
+    <string name="black">Black (for OLED)</string>
     <!--Skin-->
     <!--DirectorySortMode-->
     <string name="foldersOnTop">Folders On Top</string>


### PR DESCRIPTION
Any OLED screen will benefit from having half the screen completely black (i.e. turned off), but "OLED" is shorter that AMOLED.