### PR TITLE
Fix typeable paths summary

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -563,7 +563,7 @@
     <string name="go">Go</string>
     <string name="advanced">Advanced</string>
     <string name="typeablepaths_title">Custom paths</string>
-    <string name="typeablepaths_summary">Long press path bar type a custom path</string>
+    <string name="typeablepaths_summary">Long press path bar to type a custom path</string>
     <string name="send_email_to">Send an e-mail to</string>
 
     <string name="text_editor">Text editor settings</string>


### PR DESCRIPTION
Noticed this strange typeable paths summary in preferences which didn't make any sense.