### PR TITLE
Exclude commons-logging-api, maven-scm-api and maven-scm-provider-svnexe

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -97,6 +97,9 @@ dependencies {
 
     implementation ('com.github.junrar:junrar:0.7') {
         exclude module: 'commons-logging'
+        exclude module: 'commons-logging-api'
+        exclude module: 'maven-scm-api'
+        exclude module: 'maven-scm-provider-svnexe'
     }
 
     implementation 'com.afollestad.material-dialogs:core:0.9.6.0'


### PR DESCRIPTION
This will remove them (and their transitive dependencies) from the dependency tree, thereby preventing builds from complaining having classes which are also available in Android itself.

Fixes #974.