### PR TITLE
Used InvertedRadixTree for GRID/LIST layout setting

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/activities/MainActivity.java
+++ b/app/src/main/java/com/amaze/filemanager/activities/MainActivity.java
@@ -1118,26 +1118,21 @@ public class MainActivity extends ThemedActivity implements OnRequestPermissions
                 break;
             case R.id.view:
                 final MainFragment mainFragment = ma;
+                int pathLayout = dataUtils.getListOrGridForPath(ma.getCurrentPath(), DataUtils.LIST);
                 if (ma.IS_LIST) {
-                    if (dataUtils.getListfiles().contains(ma.getCurrentPath())) {
-                        dataUtils.getListfiles().remove(ma.getCurrentPath());
-
+                    if (pathLayout == DataUtils.LIST) {
                         AppConfig.runInBackground(() -> {
                             utilsHandler.removeListViewPath(mainFragment.getCurrentPath());
                         });
-                        //grid.removePath(ma.CURRENT_PATH, DataUtils.LIST);
                     }
 
                     AppConfig.runInBackground(() -> {
                         utilsHandler.addGridView(mainFragment.getCurrentPath());
                     });
-                    //grid.addPath(null, ma.CURRENT_PATH, DataUtils.GRID, 0);
-                    dataUtils.getGridFiles().add(ma.getCurrentPath());
-                } else {
-                    if (dataUtils.getGridFiles().contains(ma.getCurrentPath())) {
-                        dataUtils.getGridFiles().remove(ma.getCurrentPath());
-                        //grid.removePath(ma.CURRENT_PATH, DataUtils.GRID);
 
+                    dataUtils.setPathAsGridOrList(ma.getCurrentPath(), DataUtils.GRID);
+                } else {
+                    if (pathLayout == DataUtils.GRID) {
                         AppConfig.runInBackground(() -> {
                             utilsHandler.removeGridViewPath(mainFragment.getCurrentPath());
                         });
@@ -1146,8 +1141,8 @@ public class MainActivity extends ThemedActivity implements OnRequestPermissions
                     AppConfig.runInBackground(() -> {
                         utilsHandler.addListView(mainFragment.getCurrentPath());
                     });
-                    //grid.addPath(null, ma.CURRENT_PATH, DataUtils.LIST, 0);
-                    dataUtils.getListfiles().add(ma.getCurrentPath());
+
+                    dataUtils.setPathAsGridOrList(ma.getCurrentPath(), DataUtils.LIST);
                 }
                 ma.switchView();
                 break;

--- a/app/src/main/java/com/amaze/filemanager/fragments/MainFragment.java
+++ b/app/src/main/java/com/amaze/filemanager/fragments/MainFragment.java
@@ -202,7 +202,7 @@ public class MainFragment extends android.support.v4.app.Fragment implements Bot
         home = getArguments().getString("home");
         CURRENT_PATH = getArguments().getString("lastpath");
 
-        IS_LIST = !checkPathIsGrid(CURRENT_PATH);
+        IS_LIST = dataUtils.getListOrGridForPath(CURRENT_PATH, DataUtils.LIST) == DataUtils.LIST;
 
         accentColor = getMainActivity().getColorPreference().getColor(ColorUsage.ACCENT);
         primaryColor = getMainActivity().getColorPreference().getColor(ColorUsage.PRIMARY);
@@ -385,7 +385,8 @@ public class MainFragment extends android.support.v4.app.Fragment implements Bot
     }
 
     public void switchView() {
-        reloadListElements(false, results, checkPathIsGrid(CURRENT_PATH));
+        boolean isPathLayoutGrid = dataUtils.getListOrGridForPath(CURRENT_PATH, DataUtils.LIST) == DataUtils.GRID;
+        reloadListElements(false, results, isPathLayoutGrid);
     }
 
     @Override
@@ -1029,7 +1030,8 @@ public class MainFragment extends android.support.v4.app.Fragment implements Bot
 
         loadFilesListTask = new LoadFilesListTask(ma.getActivity(), path, ma, openMode, (data) -> {
             if (data != null && data.second != null) {
-                setListElements(data.second, back, path, data.first, false, checkPathIsGrid(path));
+                boolean isPathLayoutGrid = dataUtils.getListOrGridForPath(path, DataUtils.LIST) == DataUtils.GRID;
+                setListElements(data.second, back, path, data.first, false, isPathLayoutGrid);
                 mSwipeRefreshLayout.setRefreshing(false);
             }
         });
@@ -1053,41 +1055,6 @@ public class MainFragment extends android.support.v4.app.Fragment implements Bot
             nofilesview.setBackgroundColor(Utils.getColor(getContext(), R.color.holo_dark_background));
             ((TextView) nofilesview.findViewById(R.id.nofiletext)).setTextColor(Color.WHITE);
         }
-    }
-
-    /**
-     * Probably checks if path is supposed to be shown as a list or as a grid of files.
-     * @param path path to check
-     * @return should be shown as grid
-     */
-    public boolean checkPathIsGrid(String path) {
-        boolean grid = false, both_contain = false;
-        int i1 = -1, i2 = -1;
-        for (String s : dataUtils.getGridFiles()) {
-            i1++;
-            if ((path).contains(s)) {
-                grid = true;
-                break;
-            }
-        }
-        for (String s : dataUtils.getListfiles()) {
-            i2++;
-            if (path.contains(s)) {
-                if (grid) both_contain = true;
-                grid = false;
-                break;
-            }
-        }
-        
-        if (!both_contain) return grid;
-        String path1 = dataUtils.getGridFiles().get(i1), path2 = dataUtils.getListfiles().get(i2);
-
-        if (path1.contains(path2))
-            return true;
-        else if (path2.contains(path1))
-            return false;
-        else
-            return grid;
     }
 
     /**

--- a/app/src/main/java/com/amaze/filemanager/utils/DataUtils.java
+++ b/app/src/main/java/com/amaze/filemanager/utils/DataUtils.java
@@ -34,8 +34,10 @@ public class DataUtils {
 
     private ConcurrentRadixTree<VoidValue> hiddenfiles = new ConcurrentRadixTree<>(new DefaultCharArrayNodeFactory());
 
-    private ArrayList<String> gridfiles = new ArrayList<>();
-    private ArrayList<String> listfiles = new ArrayList<>();
+    public static final int LIST = 0, GRID = 1;
+
+    private InvertedRadixTree<Integer> filesGridOrList = new ConcurrentInvertedRadixTree<>(new DefaultCharArrayNodeFactory());
+
     private LinkedList<String> history = new LinkedList<>();
     private ArrayList<String> storages = new ArrayList<>();
 
@@ -121,8 +123,7 @@ public class DataUtils {
 
     public void clear() {
         hiddenfiles = new ConcurrentRadixTree<>(new DefaultCharArrayNodeFactory());
-        gridfiles = new ArrayList<>();
-        listfiles = new ArrayList<>();
+        filesGridOrList = new ConcurrentInvertedRadixTree<>(new DefaultCharArrayNodeFactory());
         history.clear();
         storages = new ArrayList<>();
         servers = new ArrayList<>();
@@ -338,22 +339,29 @@ public class DataUtils {
         if (hiddenfiles != null) this.hiddenfiles = hiddenfiles;
     }
 
-    public ArrayList<String> getGridFiles() {
-        return gridfiles;
-    }
-
     public synchronized void setGridfiles(ArrayList<String> gridfiles) {
-        if (gridfiles != null)
-            this.gridfiles = gridfiles;
-    }
-
-    public ArrayList<String> getListfiles() {
-        return listfiles;
+        if (gridfiles != null) {
+            for (String gridfile : gridfiles) {
+                setPathAsGridOrList(gridfile, GRID);
+            }
+        }
     }
 
     public synchronized void setListfiles(ArrayList<String> listfiles) {
-        if (listfiles != null)
-            this.listfiles = listfiles;
+        if (listfiles != null) {
+            for (String gridfile : listfiles) {
+                setPathAsGridOrList(gridfile, LIST);
+            }
+        }
+    }
+
+    public void setPathAsGridOrList(String path, int value) {
+        filesGridOrList.put(path, value);
+    }
+
+    public int getListOrGridForPath(String path, int defaultValue) {
+        Integer value = filesGridOrList.getValueForLongestKeyPrefixing(path);
+        return value != null? value:defaultValue;
     }
 
     public void clearHistory() {


### PR DESCRIPTION
Used InvertedRadixTree for GRID/LIST layout setting. This means that a folder's layout will be determined by the lowest manually set ascending relative (or list by default).
Example:

```
/storage/
       |-- a/
       |   |-- a/
       |   |-- b/
       |       |-- c/
       |-- j/
```

1. User sets folder /storage/a/ to grid
2. User sets /storage/a/b/ to list

Now /storage/ is shown as list (default), /storage/a/ is shown as grid,  /storage/a/b/ is shown as list
And /storage/j is shown as list (default), /storage/a/a is shown as grid,  /storage/a/b/c is shown as list