### PR TITLE
Use generic dialog layout and WarnableTextInputLayout for mkfile, mkdir and rename (#1020)

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/filesystem/FileUtil.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/FileUtil.java
@@ -45,6 +45,7 @@ import java.net.MalformedURLException;
 import java.nio.channels.FileChannel;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Pattern;
 
 import jcifs.smb.SmbException;
 import jcifs.smb.SmbFile;
@@ -57,6 +58,8 @@ import jcifs.smb.SmbFile;
 public abstract class FileUtil {
 
     private static final String LOG = "AmazeFileUtils";
+
+    private static final Pattern FILENAME_REGEX = Pattern.compile("[\\\\\\/:\\*\\?\"<>\\|\\x01-\\x1F\\x7F]", Pattern.CASE_INSENSITIVE);
 
     /**
      * Determine the camera folder. There seems to be no Android API to work for real devices, so this is a best guess.
@@ -1216,4 +1219,17 @@ public abstract class FileUtil {
 
     }
 
+
+    /**
+     * Validate given text is a valid filename.
+     *
+     * @param text
+     * @return true if given text is a valid filename
+     */
+    public static boolean isValidFilename(String text) {
+        //It's not easy to use regex to detect single/double dot while leaving valid values (filename.zip) behind...
+        //So we simply use equality to check them
+        return (!FILENAME_REGEX.matcher(text).find())
+                && !".".equals(text) && !"..".equals(text);
+    }
 }

--- a/app/src/main/java/com/amaze/filemanager/fragments/MainFragment.java
+++ b/app/src/main/java/com/amaze/filemanager/fragments/MainFragment.java
@@ -91,6 +91,7 @@ import com.amaze.filemanager.ui.icons.MimeTypes;
 import com.amaze.filemanager.ui.views.DividerItemDecoration;
 import com.amaze.filemanager.ui.views.FastScroller;
 import com.amaze.filemanager.ui.views.RoundedImageView;
+import com.amaze.filemanager.ui.views.WarnableTextInputValidator;
 import com.amaze.filemanager.utils.BottomBarButtonPath;
 import com.amaze.filemanager.utils.DataUtils;
 import com.amaze.filemanager.utils.MainActivityHelper;
@@ -1245,36 +1246,45 @@ public class MainFragment extends android.support.v4.app.Fragment implements Bot
      * @param f the file to rename
      */
     public void rename(final HybridFileParcelable f) {
-        MaterialDialog.Builder builder = GeneralDialogCreation.createNameDialog(getMainActivity(),
+        MaterialDialog renameDialog = GeneralDialogCreation.showNameDialog(getMainActivity(),
             "",
             f.getName(),
             getResources().getString(R.string.rename),
             getResources().getString(R.string.save),
             null,
-            getResources().getString(R.string.cancel));
+            getResources().getString(R.string.cancel),
+            (dialog, which) -> {
+                EditText textfield = dialog.getCustomView().findViewById(R.id.singleedittext_input);
+                String name1 = textfield.getText().toString();
 
+                if (f.isSmb()){
+                    if (f.isDirectory() && !name1.endsWith("/"))
+                        name1 = name1 + "/";
+                }
+                getMainActivity().mainActivityHelper.rename(openMode, f.getPath(),
+                        CURRENT_PATH + "/" + name1, getActivity(), ThemedActivity.rootMode);
+            }, (text)-> {
+                    boolean isValidFilename = Utils.isValidFilename(text);
 
-        builder.onPositive((dialog, which) -> {
-            EditText textfield = dialog.getInputEditText();
-            String name1 = textfield.getText().toString();
+                    if (!isValidFilename) {
+                        return new WarnableTextInputValidator.ReturnState(
+                                WarnableTextInputValidator.ReturnState.STATE_ERROR, R.string.invalid_name);
+                    } else if (text.length() < 1) {
+                        return new WarnableTextInputValidator.ReturnState(
+                                WarnableTextInputValidator.ReturnState.STATE_ERROR, R.string.field_empty);
+                    }
 
-            if (f.isSmb()){
-                if (f.isDirectory() && !name1.endsWith("/"))
-                    name1 = name1 + "/";
-            }
-            getMainActivity().mainActivityHelper.rename(openMode, f.getPath(),
-                    CURRENT_PATH + "/" + name1, getActivity(), ThemedActivity.rootMode);
-        });
+                    return new WarnableTextInputValidator.ReturnState();
+            });
 
-        MaterialDialog materialDialog = builder.build();
-        materialDialog.show();
 
         // place cursor at the starting of edit text by posting a runnable to edit text
         // this is done because in case android has not populated the edit text layouts yet, it'll
         // reset calls to selection if not posted in message queue
-        materialDialog.getInputEditText().post(() -> {
+        EditText textfield = renameDialog.getCustomView().findViewById(R.id.singleedittext_input);
+        textfield.post(() -> {
             if (!f.isDirectory()) {
-                materialDialog.getInputEditText().setSelection(f.getNameString(getContext()).length());
+                textfield.setSelection(f.getNameString(getContext()).length());
             }
         });
     }

--- a/app/src/main/java/com/amaze/filemanager/fragments/MainFragment.java
+++ b/app/src/main/java/com/amaze/filemanager/fragments/MainFragment.java
@@ -80,6 +80,7 @@ import com.amaze.filemanager.database.CryptHandler;
 import com.amaze.filemanager.database.models.EncryptedEntry;
 import com.amaze.filemanager.database.models.Tab;
 import com.amaze.filemanager.filesystem.CustomFileObserver;
+import com.amaze.filemanager.filesystem.FileUtil;
 import com.amaze.filemanager.filesystem.HybridFile;
 import com.amaze.filemanager.filesystem.HybridFileParcelable;
 import com.amaze.filemanager.filesystem.MediaStoreHack;
@@ -1264,7 +1265,7 @@ public class MainFragment extends android.support.v4.app.Fragment implements Bot
                 getMainActivity().mainActivityHelper.rename(openMode, f.getPath(),
                         CURRENT_PATH + "/" + name1, getActivity(), ThemedActivity.rootMode);
             }, (text)-> {
-                    boolean isValidFilename = Utils.isValidFilename(text);
+                    boolean isValidFilename = FileUtil.isValidFilename(text);
 
                     if (!isValidFilename) {
                         return new WarnableTextInputValidator.ReturnState(

--- a/app/src/main/java/com/amaze/filemanager/fragments/MainFragment.java
+++ b/app/src/main/java/com/amaze/filemanager/fragments/MainFragment.java
@@ -61,6 +61,7 @@ import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.ViewTreeObserver;
+import android.widget.EditText;
 import android.widget.ImageView;
 import android.widget.TextView;
 import android.widget.Toast;
@@ -1244,16 +1245,19 @@ public class MainFragment extends android.support.v4.app.Fragment implements Bot
      * @param f the file to rename
      */
     public void rename(final HybridFileParcelable f) {
-        MaterialDialog.Builder builder = new MaterialDialog.Builder(getActivity());
-        String name = f.getName();
-        builder.input("", name, false, (materialDialog, charSequence) -> {});
-        builder.theme(utilsProvider.getAppTheme().getMaterialDialogTheme());
-        builder.title(getResources().getString(R.string.rename));
+        MaterialDialog.Builder builder = GeneralDialogCreation.createNameDialog(getMainActivity(),
+            "",
+            f.getName(),
+            getResources().getString(R.string.rename),
+            getResources().getString(R.string.save),
+            null,
+            getResources().getString(R.string.cancel));
 
-        builder.onNegative((dialog, which) -> dialog.cancel());
 
         builder.onPositive((dialog, which) -> {
-            String name1 = dialog.getInputEditText().getText().toString();
+            EditText textfield = dialog.getInputEditText();
+            String name1 = textfield.getText().toString();
+
             if (f.isSmb()){
                 if (f.isDirectory() && !name1.endsWith("/"))
                     name1 = name1 + "/";
@@ -1262,12 +1266,8 @@ public class MainFragment extends android.support.v4.app.Fragment implements Bot
                     CURRENT_PATH + "/" + name1, getActivity(), ThemedActivity.rootMode);
         });
 
-        builder.positiveText(R.string.save);
-        builder.negativeText(R.string.cancel);
-        builder.positiveColor(accentColor).negativeColor(accentColor).widgetColor(accentColor);
-        final MaterialDialog materialDialog = builder.build();
+        MaterialDialog materialDialog = builder.build();
         materialDialog.show();
-        Log.d(getClass().getSimpleName(), f.getNameString(getContext()));
 
         // place cursor at the starting of edit text by posting a runnable to edit text
         // this is done because in case android has not populated the edit text layouts yet, it'll

--- a/app/src/main/java/com/amaze/filemanager/ui/dialogs/GeneralDialogCreation.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/dialogs/GeneralDialogCreation.java
@@ -41,6 +41,7 @@ import com.amaze.filemanager.asynchronous.asynctasks.CountItemsOrAndSizeTask;
 import com.amaze.filemanager.asynchronous.asynctasks.GenerateHashesTask;
 import com.amaze.filemanager.asynchronous.asynctasks.LoadFolderSpaceDataTask;
 import com.amaze.filemanager.exceptions.ShellNotRunningException;
+import com.amaze.filemanager.filesystem.FileUtil;
 import com.amaze.filemanager.filesystem.HybridFile;
 import com.amaze.filemanager.filesystem.HybridFileParcelable;
 import com.amaze.filemanager.filesystem.RootHelper;
@@ -865,7 +866,7 @@ public class GeneralDialogCreation {
         new WarnableTextInputValidator(a.getContext(), etFilename, tilFilename,
                         materialDialog.getActionButton(DialogAction.POSITIVE),
                         (text) -> {
-                    boolean isValidFilename = Utils.isValidFilename(text);
+                    boolean isValidFilename = FileUtil.isValidFilename(text);
 
                     if (isValidFilename && text.length() > 0 && !text.toLowerCase().endsWith(".zip")) {
                         return new WarnableTextInputValidator.ReturnState(

--- a/app/src/main/java/com/amaze/filemanager/ui/dialogs/GeneralDialogCreation.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/dialogs/GeneralDialogCreation.java
@@ -11,7 +11,6 @@ import android.os.AsyncTask;
 import android.os.Build;
 import android.preference.PreferenceManager;
 import android.support.annotation.RequiresApi;
-import android.support.design.widget.TextInputEditText;
 import android.support.design.widget.TextInputLayout;
 import android.support.v7.widget.AppCompatButton;
 import android.support.v7.widget.AppCompatEditText;
@@ -21,7 +20,6 @@ import android.text.SpannableString;
 import android.text.TextUtils;
 import android.text.format.Formatter;
 import android.view.View;
-import android.view.WindowManager;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.Button;
 import android.widget.CheckBox;
@@ -33,7 +31,6 @@ import android.widget.Toast;
 import com.afollestad.materialdialogs.DialogAction;
 import com.afollestad.materialdialogs.MaterialDialog;
 import com.afollestad.materialdialogs.Theme;
-import com.afollestad.materialdialogs.util.DialogUtils;
 import com.amaze.filemanager.R;
 import com.amaze.filemanager.activities.MainActivity;
 import com.amaze.filemanager.activities.superclasses.BasicActivity;
@@ -112,27 +109,29 @@ public class GeneralDialogCreation {
         return a.build();
     }
 
-    public static MaterialDialog showNameDialog(final MainActivity m, String[] texts) {
+    public static MaterialDialog.Builder createNameDialog(final MainActivity m, String hint, String prefill,
+                                                          String title, String positiveButtonText,
+                                                          String neutralButtonText, String negativeButtonText) {
         int accentColor = m.getColorPreference().getColor(ColorUsage.ACCENT);
         MaterialDialog.Builder a = new MaterialDialog.Builder(m);
-        a.input(texts[0], texts[1], false,
+        a.input(hint, prefill, false,
                 (materialDialog, charSequence) -> {});
         a.widgetColor(accentColor);
 
         a.theme(m.getAppTheme().getMaterialDialogTheme());
-        a.title(texts[2]);
+        a.title(title);
 
-        a.positiveText(texts[3]);
+        a.positiveText(positiveButtonText);
 
-        if(texts[4] != null) {
-            a.neutralText(texts[4]);
+        if(neutralButtonText != null) {
+            a.neutralText(neutralButtonText);
         }
 
-        if (texts[5] != null) {
-            a.negativeText(texts[5]);
+        if (negativeButtonText != null) {
+            a.negativeText(negativeButtonText);
             a.negativeColor(accentColor);
         }
-        return a.build();
+        return a;
     }
 
     @SuppressWarnings("ConstantConditions")

--- a/app/src/main/java/com/amaze/filemanager/utils/MainActivityHelper.java
+++ b/app/src/main/java/com/amaze/filemanager/utils/MainActivityHelper.java
@@ -135,13 +135,13 @@ public class MainActivityHelper {
     }
 
     private void mk(@StringRes int newText, final OnClickMaterialListener l) {
-        final MaterialDialog materialDialog = GeneralDialogCreation.showNameDialog(mainActivity,
-                new String[]{mainActivity.getResources().getString(R.string.entername),
-                        "",
-                        mainActivity.getResources().getString(newText),
-                        mainActivity.getResources().getString(R.string.create),
-                        mainActivity.getResources().getString(R.string.cancel),
-                        null});
+        final MaterialDialog materialDialog = GeneralDialogCreation.createNameDialog(mainActivity,
+                mainActivity.getResources().getString(R.string.entername),
+                "",
+                mainActivity.getResources().getString(newText),
+                mainActivity.getResources().getString(R.string.create),
+                mainActivity.getResources().getString(R.string.cancel),
+                null);
 
         materialDialog.getActionButton(DialogAction.POSITIVE).setOnClickListener(v -> l.onClick(materialDialog));
         materialDialog.show();

--- a/app/src/main/java/com/amaze/filemanager/utils/MainActivityHelper.java
+++ b/app/src/main/java/com/amaze/filemanager/utils/MainActivityHelper.java
@@ -19,7 +19,6 @@ import android.widget.ImageView;
 import android.widget.TextView;
 import android.widget.Toast;
 
-import com.afollestad.materialdialogs.DialogAction;
 import com.afollestad.materialdialogs.MaterialDialog;
 import com.amaze.filemanager.R;
 import com.amaze.filemanager.activities.MainActivity;
@@ -114,12 +113,12 @@ public class MainActivityHelper {
      * @param ma       {@link MainFragment} current fragment
      */
     void mkdir(final OpenMode openMode, final String path, final MainFragment ma) {
-        mk(R.string.newfolder, (dialog, which) -> {
+        mk(R.string.newfolder, "", (dialog, which) -> {
             EditText textfield = dialog.getCustomView().findViewById(R.id.singleedittext_input);
             mkDir(new HybridFile(openMode, path + "/" + textfield.getText().toString()), ma);
             dialog.dismiss();
         }, (text) -> {
-            boolean isValidFilename = Utils.isValidFilename(text);
+            boolean isValidFilename = FileUtil.isValidFilename(text);
 
             if (!isValidFilename) {
                 return new WarnableTextInputValidator.ReturnState(
@@ -141,12 +140,12 @@ public class MainActivityHelper {
      * @param ma       {@link MainFragment} current fragment
      */
     void mkfile(final OpenMode openMode, final String path, final MainFragment ma) {
-        mk(R.string.newfile, (dialog, which) -> {
+        mk(R.string.newfile, ".txt", (dialog, which) -> {
             EditText textfield = dialog.getCustomView().findViewById(R.id.singleedittext_input);
             mkFile(new HybridFile(openMode, path + "/" + textfield.getText().toString()), ma);
             dialog.dismiss();
         }, (text) -> {
-            boolean isValidFilename = Utils.isValidFilename(text);
+            boolean isValidFilename = FileUtil.isValidFilename(text);
 
             if (isValidFilename && text.length() > 0 && !text.toLowerCase().endsWith(".txt")) {
                 return new WarnableTextInputValidator.ReturnState(
@@ -165,11 +164,11 @@ public class MainActivityHelper {
         });
     }
 
-    private void mk(@StringRes int newText, final MaterialDialog.SingleButtonCallback onPositiveAction,
+    private void mk(@StringRes int newText, String prefill, final MaterialDialog.SingleButtonCallback onPositiveAction,
                     final WarnableTextInputValidator.OnTextValidate validator) {
         GeneralDialogCreation.showNameDialog(mainActivity,
             mainActivity.getResources().getString(R.string.entername),
-            "",
+            prefill,
             mainActivity.getResources().getString(newText),
             mainActivity.getResources().getString(R.string.create),
             mainActivity.getResources().getString(R.string.cancel),

--- a/app/src/main/java/com/amaze/filemanager/utils/MainActivityHelper.java
+++ b/app/src/main/java/com/amaze/filemanager/utils/MainActivityHelper.java
@@ -14,6 +14,7 @@ import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
 import android.view.LayoutInflater;
 import android.view.View;
+import android.widget.EditText;
 import android.widget.ImageView;
 import android.widget.TextView;
 import android.widget.Toast;
@@ -39,6 +40,7 @@ import com.amaze.filemanager.fragments.MainFragment;
 import com.amaze.filemanager.fragments.SearchWorkerFragment;
 import com.amaze.filemanager.fragments.TabFragment;
 import com.amaze.filemanager.ui.dialogs.GeneralDialogCreation;
+import com.amaze.filemanager.ui.views.WarnableTextInputValidator;
 import com.amaze.filemanager.utils.color.ColorUsage;
 import com.amaze.filemanager.utils.files.CryptUtil;
 
@@ -112,10 +114,22 @@ public class MainActivityHelper {
      * @param ma       {@link MainFragment} current fragment
      */
     void mkdir(final OpenMode openMode, final String path, final MainFragment ma) {
-        mk(R.string.newfolder, materialDialog -> {
-            String a = materialDialog.getInputEditText().getText().toString();
-            mkDir(new HybridFile(openMode, path + "/" + a), ma);
-            materialDialog.dismiss();
+        mk(R.string.newfolder, (dialog, which) -> {
+            EditText textfield = dialog.getCustomView().findViewById(R.id.singleedittext_input);
+            mkDir(new HybridFile(openMode, path + "/" + textfield.getText().toString()), ma);
+            dialog.dismiss();
+        }, (text) -> {
+            boolean isValidFilename = Utils.isValidFilename(text);
+
+            if (!isValidFilename) {
+                return new WarnableTextInputValidator.ReturnState(
+                        WarnableTextInputValidator.ReturnState.STATE_ERROR, R.string.invalid_name);
+            } else if (text.length() < 1) {
+                return new WarnableTextInputValidator.ReturnState(
+                        WarnableTextInputValidator.ReturnState.STATE_ERROR, R.string.field_empty);
+            }
+
+            return new WarnableTextInputValidator.ReturnState();
         });
     }
 
@@ -127,28 +141,40 @@ public class MainActivityHelper {
      * @param ma       {@link MainFragment} current fragment
      */
     void mkfile(final OpenMode openMode, final String path, final MainFragment ma) {
-        mk(R.string.newfile, materialDialog -> {
-            String a = materialDialog.getInputEditText().getText().toString();
-            mkFile(new HybridFile(openMode, path + "/" + a), ma);
-            materialDialog.dismiss();
+        mk(R.string.newfile, (dialog, which) -> {
+            EditText textfield = dialog.getCustomView().findViewById(R.id.singleedittext_input);
+            mkFile(new HybridFile(openMode, path + "/" + textfield.getText().toString()), ma);
+            dialog.dismiss();
+        }, (text) -> {
+            boolean isValidFilename = Utils.isValidFilename(text);
+
+            if (isValidFilename && text.length() > 0 && !text.toLowerCase().endsWith(".txt")) {
+                return new WarnableTextInputValidator.ReturnState(
+                        WarnableTextInputValidator.ReturnState.STATE_WARNING, R.string.create_file_suggest_txt_extension);
+            } else {
+                if (!isValidFilename) {
+                    return new WarnableTextInputValidator.ReturnState(
+                            WarnableTextInputValidator.ReturnState.STATE_ERROR, R.string.invalid_name);
+                } else if (text.length() < 1) {
+                    return new WarnableTextInputValidator.ReturnState(
+                            WarnableTextInputValidator.ReturnState.STATE_ERROR, R.string.field_empty);
+                }
+            }
+
+            return new WarnableTextInputValidator.ReturnState();
         });
     }
 
-    private void mk(@StringRes int newText, final OnClickMaterialListener l) {
-        final MaterialDialog materialDialog = GeneralDialogCreation.createNameDialog(mainActivity,
-                mainActivity.getResources().getString(R.string.entername),
-                "",
-                mainActivity.getResources().getString(newText),
-                mainActivity.getResources().getString(R.string.create),
-                mainActivity.getResources().getString(R.string.cancel),
-                null);
-
-        materialDialog.getActionButton(DialogAction.POSITIVE).setOnClickListener(v -> l.onClick(materialDialog));
-        materialDialog.show();
-    }
-
-    private interface OnClickMaterialListener {
-        void onClick(MaterialDialog materialDialog);
+    private void mk(@StringRes int newText, final MaterialDialog.SingleButtonCallback onPositiveAction,
+                    final WarnableTextInputValidator.OnTextValidate validator) {
+        GeneralDialogCreation.showNameDialog(mainActivity,
+            mainActivity.getResources().getString(R.string.entername),
+            "",
+            mainActivity.getResources().getString(newText),
+            mainActivity.getResources().getString(R.string.create),
+            mainActivity.getResources().getString(R.string.cancel),
+            null, onPositiveAction, validator)
+            .show();
     }
 
     public void add(int pos) {

--- a/app/src/main/java/com/amaze/filemanager/utils/Utils.java
+++ b/app/src/main/java/com/amaze/filemanager/utils/Utils.java
@@ -21,6 +21,7 @@ import com.amaze.filemanager.filesystem.HybridFileParcelable;
 
 import java.io.File;
 import java.text.SimpleDateFormat;
+import java.util.regex.Pattern;
 
 /**
  * Contains useful functions and methods (NOTHING HERE DEALS WITH FILES)
@@ -38,6 +39,7 @@ public class Utils {
     private static final String INPUT_INTENT_BLACKLIST_PIPE = "\\|";
     private static final String INPUT_INTENT_BLACKLIST_AMP = "&&";
     private static final String INPUT_INTENT_BLACKLIST_DOTS = "\\.\\.\\.";
+    private static final Pattern FILENAME_REGEX = Pattern.compile("[\\\\\\/:\\*\\?\"<>\\|\\x01-\\x1F\\x7F]", Pattern.CASE_INSENSITIVE);
 
 
     //methods for fastscroller
@@ -231,4 +233,16 @@ public class Utils {
         return -1;
     }
 
+    /**
+     * Validate given text is a valid filename.
+     *
+     * @param text
+     * @return true if given text is a valid filename
+     */
+    public static boolean isValidFilename(String text) {
+        //It's not easy to use regex to detect single/double dot while leaving valid values (filename.zip) behind...
+        //So we simply use equality to check them
+        return (!FILENAME_REGEX.matcher(text).find())
+                && !".".equals(text) && !"..".equals(text);
+    }
 }

--- a/app/src/main/java/com/amaze/filemanager/utils/Utils.java
+++ b/app/src/main/java/com/amaze/filemanager/utils/Utils.java
@@ -21,7 +21,6 @@ import com.amaze.filemanager.filesystem.HybridFileParcelable;
 
 import java.io.File;
 import java.text.SimpleDateFormat;
-import java.util.regex.Pattern;
 
 /**
  * Contains useful functions and methods (NOTHING HERE DEALS WITH FILES)
@@ -39,8 +38,6 @@ public class Utils {
     private static final String INPUT_INTENT_BLACKLIST_PIPE = "\\|";
     private static final String INPUT_INTENT_BLACKLIST_AMP = "&&";
     private static final String INPUT_INTENT_BLACKLIST_DOTS = "\\.\\.\\.";
-    private static final Pattern FILENAME_REGEX = Pattern.compile("[\\\\\\/:\\*\\?\"<>\\|\\x01-\\x1F\\x7F]", Pattern.CASE_INSENSITIVE);
-
 
     //methods for fastscroller
     public static float clamp(float min, float max, float value) {
@@ -231,18 +228,5 @@ public class Utils {
             }
         }
         return -1;
-    }
-
-    /**
-     * Validate given text is a valid filename.
-     *
-     * @param text
-     * @return true if given text is a valid filename
-     */
-    public static boolean isValidFilename(String text) {
-        //It's not easy to use regex to detect single/double dot while leaving valid values (filename.zip) behind...
-        //So we simply use equality to check them
-        return (!FILENAME_REGEX.matcher(text).find())
-                && !".".equals(text) && !"..".equals(text);
     }
 }

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -571,4 +571,6 @@
   <string name="about_amaze">Material設計風格的 Android檔案管理員</string>
   <string name="license">版權宣告</string>
   <string name="libraries">第三方程式庫</string>
+  <string name="create_file_suggest_txt_extension">建議以 \".txt\"作為檔案擴展名稱。</string>
+  <string name="compress_file_suggest_zip_extension">建議以 \".zip\"作為檔案擴展名稱。</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -616,5 +616,6 @@
     <string name="license">License</string>
     <string name="libraries">Libraries</string>
     <string name="password_repeat">Repeat password</string>
+    <string name="create_file_suggest_txt_extension">It\'s recommended to use \".txt\" as the file extension.</string>
 </resources>
 


### PR DESCRIPTION
While working on the dialogs for create files and folders, I also noticed the rename dialog was using its own dialog, so I migrated it too.

Tried to keep `GenericDialogCreation.showNameDialog()` as generic as possible, hence passing the callbacks in the method.

See if you liked this refactoring.