### PR TITLE
Proguard configuration of BouncyCastle/SpongyCastle (for sshj)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -38,8 +38,7 @@ android {
 
     buildTypes {
         debug {
-            minifyEnabled true
-            shrinkResources true
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard.cfg'
 
         }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -38,7 +38,8 @@ android {
 
     buildTypes {
         debug {
-            minifyEnabled false
+            minifyEnabled true
+            shrinkResources true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard.cfg'
 
         }

--- a/app/proguard.cfg
+++ b/app/proguard.cfg
@@ -166,5 +166,28 @@
     public static final int define_*;
 }
 
+#From SpongyCastle, sshj dependency
+-keep class org.spongycastle.**
+-keep class org.bouncycastle.**
+
+#We are not using these anyway
+-dontwarn org.spongycastle.jce.provider.X509LDAPCertStoreSpi
+-dontwarn org.spongycastle.x509.util.LDAPStoreHelper
+-dontwarn org.spongycastle.cert.dane.fetcher.JndiDANEFetcherFactory*
+-dontwarn org.bouncycastle.jce.provider.X509LDAPCertStoreSpi
+-dontwarn org.bouncycastle.x509.util.LDAPStoreHelper
+-dontwarn org.bouncycastle.cert.dane.fetcher.JndiDANEFetcherFactory*
+
+#From sshj. We are not using GSSAPI to connect to SSH
+-dontwarn net.schmizz.sshj.userauth.method.AuthGssApiWithMic
+
+#Warning was at SSHClient.authGssApiWithMic, referencing javax.security.auth.login.LoginContext.
+#But we are not using it too
+-dontwarn net.schmizz.sshj.SSHClient
+
+#ignore test classes
+-dontwarn android.test.**
+-dontwarn org.junit.**
+
 # for DexGuard only
--keepresourcexmlelements manifest/application/meta-data@value=GlideModule
+#-keepresourcexmlelements manifest/application/meta-data@value=GlideModule

--- a/app/proguard.cfg
+++ b/app/proguard.cfg
@@ -190,4 +190,4 @@
 -dontwarn org.junit.**
 
 # for DexGuard only
-#-keepresourcexmlelements manifest/application/meta-data@value=GlideModule
+-keepresourcexmlelements manifest/application/meta-data@value=GlideModule


### PR DESCRIPTION
From request at #977. To reiterate, **it's for sshj to work, may break file encryption/decryption**.

sshj itself ~~seems doesn't~~ needs proguard configurations, ~~but~~ and its dependency, SpongyCastle and BouncyCastle does too.

Verifications:
 - Setup SMB/SFTP connections with username/password
 - Setup SFTP connections with SSH keys with/without passphrases
 - Open SFTP connection, copy file from SSH server
 - SMB/SFTP connections still work after restarting app

P.S. At some point I was thinking of omitting BouncyCastle since SpongyCastle can do exactly the same thing, but sshj's behaviour (as of 0.23.0) that [it'd jump to default JCE provider](https://github.com/hierynomus/sshj/blob/v0.23.0/src/main/java/net/schmizz/sshj/common/SecurityUtils.java#L247-L260) forced me to rollback. It's fixed in their master (hierynomus/sshj#392), but we shall need to wait for a new version published in the repos.