### PR TITLE
Decompression returns separate name and path vals

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/adapters/CompressedExplorerAdapter.java
+++ b/app/src/main/java/com/amaze/filemanager/adapters/CompressedExplorerAdapter.java
@@ -205,24 +205,16 @@ public class CompressedExplorerAdapter extends RecyclerView.Adapter<CompressedIt
         } else {
             GlideApp.with(compressedExplorerFragment).load(rowItem.iconData.image).into(holder.genericIcon);
 
-            final StringBuilder stringBuilder = new StringBuilder(rowItem.name);
             if (compressedExplorerFragment.showLastModified)
                 holder.date.setText(Utils.getDate(rowItem.date, compressedExplorerFragment.year));
             if (rowItem.directory) {
                 holder.genericIcon.setImageDrawable(folder);
                 gradientDrawable.setColor(Color.parseColor(compressedExplorerFragment.iconskin));
-                if (stringBuilder.toString().length() > 0) {
-                    stringBuilder.deleteCharAt(rowItem.name.length() - 1);
-                    try {
-                        holder.txtTitle.setText(stringBuilder.toString().substring(stringBuilder.toString().lastIndexOf("/") + 1));
-                    } catch (Exception e) {
-                        holder.txtTitle.setText(rowItem.name.substring(0, rowItem.name.lastIndexOf("/")));
-                    }
-                }
+                holder.txtTitle.setText(rowItem.name);
             } else {
                 if (compressedExplorerFragment.showSize)
                     holder.txtDesc.setText(Formatter.formatFileSize(context, rowItem.size));
-                holder.txtTitle.setText(rowItem.name.substring(rowItem.name.lastIndexOf("/") + 1));
+                holder.txtTitle.setText(rowItem.name);
                 if (compressedExplorerFragment.coloriseIcons) {
                     ColorUtils.colorizeIcons(context, rowItem.filetype, gradientDrawable,
                             Color.parseColor(compressedExplorerFragment.iconskin));
@@ -261,12 +253,8 @@ public class CompressedExplorerAdapter extends RecyclerView.Adapter<CompressedIt
                 if (compressedExplorerFragment.selection) {
                     toggleChecked(position, holder.checkImageView);
                 } else {
-                    final StringBuilder stringBuilder = new StringBuilder(rowItem.name);
-                    if (rowItem.directory)
-                        stringBuilder.deleteCharAt(rowItem.name.length() - 1);
-
                     if (rowItem.directory) {
-                        compressedExplorerFragment.changePath(stringBuilder.toString());
+                        compressedExplorerFragment.changePath(rowItem.path);
                     } else {
                         String fileName = compressedExplorerFragment.compressedFile.getName().substring(0,
                                 compressedExplorerFragment.compressedFile.getName().lastIndexOf("."));

--- a/app/src/main/java/com/amaze/filemanager/adapters/data/CompressedObjectParcelable.java
+++ b/app/src/main/java/com/amaze/filemanager/adapters/data/CompressedObjectParcelable.java
@@ -17,14 +17,16 @@ public class CompressedObjectParcelable implements Parcelable {
     public final boolean directory;
     public final int type;
     public final String name;
+    public final String path;
     public final long date, size;
     public final int filetype;
     public final IconDataParcelable iconData;
 
-    public CompressedObjectParcelable(String name, long date, long size, boolean directory) {
+    public CompressedObjectParcelable(String name, String path, long date, long size, boolean directory) {
         this.directory = directory;
         this.type = TYPE_NORMAL;
         this.name = name;
+        this.path = path;
         this.date = date;
         this.size = size;
         this.filetype = Icons.getTypeOfFile(name, directory);
@@ -39,6 +41,7 @@ public class CompressedObjectParcelable implements Parcelable {
         this.directory = true;
         this.type = TYPE_GOBACK;
         this.name = null;
+        this.path = null;
         this.date = 0;
         this.size = 0;
         this.filetype = -1;
@@ -55,6 +58,7 @@ public class CompressedObjectParcelable implements Parcelable {
         if(type != TYPE_GOBACK) {
             p1.writeInt(directory? 1:0);
             p1.writeString(name);
+            p1.writeString(path);
             p1.writeLong(size);
             p1.writeLong(date);
             p1.writeInt(filetype);
@@ -78,6 +82,7 @@ public class CompressedObjectParcelable implements Parcelable {
         if(type == TYPE_GOBACK) {
             directory = true;
             name = null;
+            path = null;
             date = 0;
             size = 0;
             filetype = -1;
@@ -85,6 +90,7 @@ public class CompressedObjectParcelable implements Parcelable {
         } else {
             directory = im.readInt() == 1;
             name = im.readString();
+            path = im.readString();
             size = im.readLong();
             date = im.readLong();
             filetype = im.readInt();

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/compress/CompressedHelperTask.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/compress/CompressedHelperTask.java
@@ -1,6 +1,7 @@
 package com.amaze.filemanager.asynchronous.asynctasks.compress;
 
 import android.os.AsyncTask;
+import android.support.annotation.NonNull;
 
 import com.amaze.filemanager.adapters.data.CompressedObjectParcelable;
 import com.amaze.filemanager.utils.OnAsyncTaskFinished;
@@ -45,5 +46,12 @@ public abstract class CompressedHelperTask extends AsyncTask<Void, Void, ArrayLi
     }
 
     abstract void addElements(ArrayList<CompressedObjectParcelable> elements);
+
+    protected String getName(@NonNull String path, @NonNull String divider) {
+        if(path.endsWith(divider)) path = path.substring(0, path.length()-divider.length());
+        int lastInstance = path.lastIndexOf(divider);
+        if(lastInstance == -1) return path;
+        return path.substring(lastInstance+1, path.length());
+    }
 
 }

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/compress/CompressedHelperTask.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/compress/CompressedHelperTask.java
@@ -20,9 +20,18 @@ public abstract class CompressedHelperTask extends AsyncTask<Void, Void, ArrayLi
 
     private boolean createBackItem;
     private OnAsyncTaskFinished<ArrayList<CompressedObjectParcelable>> onFinish;
+    protected String relativePath;
 
-    CompressedHelperTask(boolean goBack,
+    CompressedHelperTask(String relativePath, boolean goBack,
                          OnAsyncTaskFinished<ArrayList<CompressedObjectParcelable>> l) {
+        if(relativePath == null || relativePath.isEmpty() || relativePath.equals("/")) {
+            this.relativePath = "";
+        } else if(!relativePath.endsWith("/")) {
+            this.relativePath = relativePath + "/";
+        } else {
+            this.relativePath = relativePath;
+        }
+
         createBackItem = goBack;
         onFinish = l;
     }

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/compress/GzipHelperTask.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/compress/GzipHelperTask.java
@@ -40,11 +40,12 @@ public class GzipHelperTask extends CompressedHelperTask {
 
                 boolean isInBaseDir = relativePath.equals("") && !name.contains(SEPARATOR);
                 boolean isInRelativeDir = name.contains(SEPARATOR)
-                        && name.substring(0, name.lastIndexOf(SEPARATOR)).equals(relativePath);
+                        && name.substring(0, name.lastIndexOf(SEPARATOR)+1).equals(relativePath);
 
                 if (isInBaseDir || isInRelativeDir) {
-                    elements.add(new CompressedObjectParcelable(entry.getName(),
-                            entry.getLastModifiedDate().getTime(), entry.getSize(), entry.isDirectory()));
+                    elements.add(new CompressedObjectParcelable(getName(entry.getName(), SEPARATOR),
+                            entry.getName(), entry.getLastModifiedDate().getTime(), entry.getSize(),
+                            entry.isDirectory()));
                 }
             }
         } catch (IOException e) {

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/compress/GzipHelperTask.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/compress/GzipHelperTask.java
@@ -17,13 +17,12 @@ import static com.amaze.filemanager.filesystem.compressed.CompressedHelper.SEPAR
 
 public class GzipHelperTask extends CompressedHelperTask {
 
-    private String filePath, relativePath;
+    private String filePath;
 
     public GzipHelperTask(String filePath, String relativePath, boolean goBack,
                          OnAsyncTaskFinished<ArrayList<CompressedObjectParcelable>> l) {
-        super(goBack, l);
+        super(relativePath, goBack, l);
         this.filePath = filePath;
-        this.relativePath = relativePath;
     }
 
     @Override

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/compress/TarHelperTask.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/compress/TarHelperTask.java
@@ -43,11 +43,12 @@ public class TarHelperTask extends CompressedHelperTask {
 
                 boolean isInBaseDir = relativePath.equals("") && !name.contains(SEPARATOR);
                 boolean isInRelativeDir = name.contains(SEPARATOR)
-                        && name.substring(0, name.lastIndexOf(SEPARATOR)).equals(relativePath);
+                        && name.substring(0, name.lastIndexOf(SEPARATOR)+1).equals(relativePath);
 
                 if (isInBaseDir || isInRelativeDir) {
-                    elements.add(new CompressedObjectParcelable(entry.getName(),
-                            entry.getLastModifiedDate().getTime(), entry.getSize(), entry.isDirectory()));
+                    elements.add(new CompressedObjectParcelable(getName(entry.getName(), SEPARATOR),
+                            entry.getName(), entry.getLastModifiedDate().getTime(), entry.getSize(),
+                            entry.isDirectory()));
                 }
             }
         } catch (IOException e) {

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/compress/TarHelperTask.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/compress/TarHelperTask.java
@@ -21,13 +21,12 @@ import static com.amaze.filemanager.filesystem.compressed.CompressedHelper.SEPAR
 
 public class TarHelperTask extends CompressedHelperTask {
 
-    private String filePath, relativePath;
+    private String filePath;
 
     public TarHelperTask(String filePath, String relativePath, boolean goBack,
                          OnAsyncTaskFinished<ArrayList<CompressedObjectParcelable>> l) {
-        super(goBack, l);
+        super(relativePath, goBack, l);
         this.filePath = filePath;
-        this.relativePath = relativePath;
     }
 
     @Override

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/compress/ZipHelperTask.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/compress/ZipHelperTask.java
@@ -24,7 +24,6 @@ public class ZipHelperTask extends CompressedHelperTask {
 
     private WeakReference<Context> context;
     private Uri fileLocation;
-    private String relativePath;
 
     /**
      * AsyncTask to load ZIP file items.
@@ -33,10 +32,9 @@ public class ZipHelperTask extends CompressedHelperTask {
      */
     public ZipHelperTask(Context c, String realFileDirectory, String dir, boolean goback,
                          OnAsyncTaskFinished<ArrayList<CompressedObjectParcelable>> l) {
-        super(goback, l);
+        super(dir, goback, l);
         context = new WeakReference<>(c);
         fileLocation = Uri.parse(realFileDirectory);
-        relativePath = dir;
     }
 
     @Override

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/compress/ZipHelperTask.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/compress/ZipHelperTask.java
@@ -15,6 +15,8 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 import java.util.zip.ZipInputStream;
 
+import static com.amaze.filemanager.filesystem.compressed.CompressedHelper.SEPARATOR;
+
 /**
  * Created by Vishal on 11/23/2014 edited by Emmanuel Messulam<emmanuelbendavid@gmail.com>
  */
@@ -22,7 +24,7 @@ public class ZipHelperTask extends CompressedHelperTask {
 
     private WeakReference<Context> context;
     private Uri fileLocation;
-    private String relativeDirectory;
+    private String relativePath;
 
     /**
      * AsyncTask to load ZIP file items.
@@ -34,76 +36,45 @@ public class ZipHelperTask extends CompressedHelperTask {
         super(goback, l);
         context = new WeakReference<>(c);
         fileLocation = Uri.parse(realFileDirectory);
-        relativeDirectory = dir;
+        relativePath = dir;
     }
 
     @Override
     void addElements(ArrayList<CompressedObjectParcelable> elements) {
         try {
-            ArrayList<CompressedObjectParcelable> wholelist = new ArrayList<>();
             if (new File(fileLocation.getPath()).canRead()) {
                 ZipFile zipfile = new ZipFile(fileLocation.getPath());
                 for (Enumeration e = zipfile.entries(); e.hasMoreElements(); ) {
                     ZipEntry entry = (ZipEntry) e.nextElement();
-                    wholelist.add(new CompressedObjectParcelable(entry.getName(), entry.getTime(), entry.getSize(), entry.isDirectory()));
+                    checkAndAdd(elements, entry);
                 }
             } else {
                 ZipInputStream zipfile1 = new ZipInputStream(context.get().getContentResolver().openInputStream(fileLocation));
                 for (ZipEntry entry = zipfile1.getNextEntry(); entry != null; entry = zipfile1.getNextEntry()) {
-                    wholelist.add(new CompressedObjectParcelable(entry.getName(), entry.getTime(), entry.getSize(), entry.isDirectory()));
-                }
-            }
-
-            ArrayList<String> strings = new ArrayList<>();
-
-            for (CompressedObjectParcelable entry : wholelist) {
-                File file = new File(entry.name);
-                if (relativeDirectory == null || relativeDirectory.trim().length() == 0) {
-                    String y = entry.name;
-                    if (y.startsWith("/"))
-                        y = y.substring(1, y.length());
-                    if (file.getParent() == null || file.getParent().length() == 0 || file.getParent().equals("/")) {
-                        if (!strings.contains(y)) {
-                            elements.add(new CompressedObjectParcelable(y, entry.date, entry.size, entry.directory));
-                            strings.add(y);
-                        }
-                    } else {
-                        String path = y.substring(0, y.indexOf("/") + 1);
-                        if (!strings.contains(path)) {
-                            CompressedObjectParcelable zipObj = new CompressedObjectParcelable(path, entry.date, entry.size, true);
-                            strings.add(path);
-                            elements.add(zipObj);
-                        }
-                    }
-                } else {
-                    String y = entry.name;
-                    if (entry.name.startsWith("/"))
-                        y = y.substring(1, y.length());
-
-                    if (file.getParent() != null && (file.getParent().equals(relativeDirectory) || file.getParent().equals("/" + relativeDirectory))) {
-                        if (!strings.contains(y)) {
-                            elements.add(new CompressedObjectParcelable(y, entry.date, entry.size, entry.directory));
-                            strings.add(y);
-                        }
-                    } else {
-                        if (y.startsWith(relativeDirectory + "/") && y.length() > relativeDirectory.length() + 1) {
-                            String path1 = y.substring(relativeDirectory.length() + 1, y.length());
-
-                            int index = relativeDirectory.length() + 1 + path1.indexOf("/");
-                            String path = y.substring(0, index + 1);
-                            if (!strings.contains(path)) {
-                                CompressedObjectParcelable zipObj = new CompressedObjectParcelable(y.substring(0, index + 1), entry.date, entry.size, true);
-                                strings.add(path);
-                                elements.add(zipObj);
-                            }
-                        }
-                    }
-
+                    checkAndAdd(elements, entry);
                 }
             }
         } catch (IOException e) {
             e.printStackTrace();
         }
+    }
+
+    private void checkAndAdd(ArrayList<CompressedObjectParcelable> elements, ZipEntry entry) {
+        String name = entry.getName();
+        if (name.endsWith(SEPARATOR)) name = name.substring(0, name.length() - 1);
+
+        boolean isInBaseDir = relativePath.equals("") && !name.contains(SEPARATOR);
+        boolean isInRelativeDir = name.contains(SEPARATOR)
+                && name.substring(0, name.lastIndexOf(SEPARATOR)+1).equals(relativePath);
+
+        if (isInBaseDir || isInRelativeDir) {
+            elements.add(processEntry(entry));
+        }
+    }
+
+    private CompressedObjectParcelable processEntry(ZipEntry entry) {
+        return new CompressedObjectParcelable(getName(entry.getName(), SEPARATOR), entry.getName(),
+                entry.getTime(), entry.getSize(), entry.isDirectory());
     }
 
 }

--- a/app/src/main/java/com/amaze/filemanager/filesystem/compressed/extractcontents/Extractor.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/compressed/extractcontents/Extractor.java
@@ -29,7 +29,11 @@ public abstract class Extractor {
 
     public void extractFiles(String[] files) throws IOException {
         HashSet<String> filesToExtract = new HashSet<>(files.length);
-        Collections.addAll(filesToExtract, files);
+        for (String file : files) {
+            if(file.endsWith("/")) file = file.substring(0, file.length()-1);
+
+            filesToExtract.add(file);
+        }
 
         extractWithFilter((relativePath, isDir) -> {
             if(filesToExtract.contains(relativePath)) {

--- a/app/src/main/java/com/amaze/filemanager/filesystem/compressed/showcontents/Decompressor.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/compressed/showcontents/Decompressor.java
@@ -31,7 +31,6 @@ public abstract class Decompressor {
 
     /**
      * Separator must be "/"
-     * @param path end with "/" if it is a directory, does not if it's a file
      */
     public abstract CompressedHelperTask changePath(String path, boolean addGoBackItem,
                                                     OnAsyncTaskFinished<ArrayList<CompressedObjectParcelable>> onFinish);

--- a/app/src/main/java/com/amaze/filemanager/fragments/CompressedExplorerFragment.java
+++ b/app/src/main/java/com/amaze/filemanager/fragments/CompressedExplorerFragment.java
@@ -315,7 +315,7 @@ public class CompressedExplorerFragment extends Fragment implements BottomBarBut
 
                     String[] dirs = new String[compressedExplorerAdapter.getCheckedItemPositions().size()];
                     for (int i = 0; i < dirs.length; i++) {
-                        dirs[i] = elements.get(compressedExplorerAdapter.getCheckedItemPositions().get(i)).name;
+                        dirs[i] = elements.get(compressedExplorerAdapter.getCheckedItemPositions().get(i)).path;
                     }
 
                     decompressor.decompress(null, dirs);


### PR DESCRIPTION
Decompression returns separate name and path. Added `path` field to `CompressedObjectParcelable`.
Also rewrote zip decompression.
Fixes #1036.