### PR TITLE
Fixed drawer item '/' not appearing after activating root explorer

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/activities/MainActivity.java
+++ b/app/src/main/java/com/amaze/filemanager/activities/MainActivity.java
@@ -635,8 +635,9 @@ public class MainActivity extends ThemedActivity implements OnRequestPermissions
                     rv.add(s);
             }
         }
-        if (ThemedActivity.rootMode)
+        if (isRootExplorer()){
             rv.add("/");
+        }
         File usb = getUsbDrive();
         if (usb != null && !rv.contains(usb.getPath())) rv.add(usb.getPath());
 
@@ -1094,6 +1095,7 @@ public class MainActivity extends ThemedActivity implements OnRequestPermissions
             materialDialog = null;
         }
 
+        drawer.refreshDrawer();
         drawer.deselectEverything();
 
         IntentFilter newFilter = new IntentFilter();

--- a/app/src/main/java/com/amaze/filemanager/activities/superclasses/PreferenceActivity.java
+++ b/app/src/main/java/com/amaze/filemanager/activities/superclasses/PreferenceActivity.java
@@ -4,6 +4,8 @@ import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
 
+import com.amaze.filemanager.fragments.preference_fragments.PreferencesConstants;
+
 /**
  * @author Emmanuel
  *         on 24/8/2017, at 23:13.
@@ -22,6 +24,10 @@ public class PreferenceActivity extends BasicActivity {
 
     public SharedPreferences getPrefs() {
         return sharedPrefs;
+    }
+
+    public boolean isRootExplorer() {
+        return sharedPrefs.getBoolean(PreferencesConstants.PREFERENCE_ROOTMODE, false);
     }
 
 }

--- a/app/src/main/java/com/amaze/filemanager/activities/superclasses/ThemedActivity.java
+++ b/app/src/main/java/com/amaze/filemanager/activities/superclasses/ThemedActivity.java
@@ -20,6 +20,9 @@ import com.amaze.filemanager.utils.theme.AppTheme;
  */
 public class ThemedActivity extends PreferenceActivity {
 
+    /**
+     * @deprecated Use PreferenceActivity.isRootExplorer()
+     */
     public static boolean rootMode;
     public boolean checkStorage = true;
 


### PR DESCRIPTION
* Fixed drawer item '/' not appearing after activiating root explorer
* Deprecated ThemedActivity.rootMode in favor of `PreferenceActivity.isRootExplorer()`

Fixes #1058.