### PR TITLE
Save the scroll state of PreferenceFragments

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/activities/PreferencesActivity.java
+++ b/app/src/main/java/com/amaze/filemanager/activities/PreferencesActivity.java
@@ -27,6 +27,7 @@ import android.content.SharedPreferences;
 import android.graphics.Color;
 import android.graphics.drawable.BitmapDrawable;
 import android.os.Bundle;
+import android.os.Parcelable;
 import android.preference.PreferenceFragment;
 import android.preference.PreferenceManager;
 import android.support.annotation.StringRes;
@@ -69,6 +70,9 @@ public class PreferencesActivity extends ThemedActivity {
     private PreferenceFragment currentFragment;
 
     private static final String KEY_CURRENT_FRAG_OPEN = "current_frag_open";
+    private static final int NUMBER_OF_PREFERENCES = 5;
+
+    private Parcelable[] fragmentsListViewParcelables = new Parcelable[NUMBER_OF_PREFERENCES];
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -142,6 +146,29 @@ public class PreferencesActivity extends ThemedActivity {
                 return true;
         }
         return false;
+    }
+
+    /**
+     * This is a hack, each PreferenceFragment has a ListView that loses it's state (specifically
+     * the scrolled position) when the user accesses another PreferenceFragment. To prevent this, the
+     * Activity saves the ListView's state, so that it can be restored when the user returns to the
+     * PreferenceFragment.
+     *
+     * We cannot use the normal save/restore state functions because they only get called when the
+     * OS kills the fragment, not the user. See https://stackoverflow.com/a/12793395/3124150 for a
+     * better explanation.
+     *
+     * We cannot save the Parcelable in the fragment because the fragment is destroyed.
+     */
+    public void saveListViewState(int prefFragment, Parcelable listViewState) {
+        fragmentsListViewParcelables[prefFragment] = listViewState;
+    }
+
+    /**
+     * This is a hack see {@link PreferencesActivity#saveListViewState(int, Parcelable)}
+     */
+    public Parcelable restoreListViewState(int prefFragment) {
+        return fragmentsListViewParcelables[prefFragment];
     }
 
     public void setRestartActivity() {

--- a/app/src/main/java/com/amaze/filemanager/fragments/preference_fragments/PrefFrag.java
+++ b/app/src/main/java/com/amaze/filemanager/fragments/preference_fragments/PrefFrag.java
@@ -31,12 +31,18 @@ import android.hardware.fingerprint.FingerprintManager;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
+import android.os.Parcelable;
 import android.preference.Preference;
 import android.preference.PreferenceFragment;
 import android.preference.PreferenceManager;
+import android.preference.PreferenceScreen;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.support.v4.app.ActivityCompat;
+import android.view.LayoutInflater;
 import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ListView;
 import android.widget.Toast;
 
 import com.afollestad.materialdialogs.DialogAction;
@@ -56,6 +62,7 @@ import java.security.GeneralSecurityException;
 import java.util.List;
 
 import static com.amaze.filemanager.R.string.feedback;
+import static com.amaze.filemanager.activities.PreferencesActivity.START_PREFERENCE;
 
 public class PrefFrag extends PreferenceFragment implements Preference.OnPreferenceClickListener {
 
@@ -68,6 +75,8 @@ public class PrefFrag extends PreferenceFragment implements Preference.OnPrefere
 
     private UtilitiesProvider utilsProvider;
     private SharedPreferences sharedPref;
+    /**This is a hack see {@link PreferencesActivity#saveListViewState(int, Parcelable)}*/
+    private ListView listView;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -306,6 +315,40 @@ public class PrefFrag extends PreferenceFragment implements Preference.OnPrefere
         activity.finish();
         activity.overridePendingTransition(enter_anim, exit_anim);
         activity.startActivity(activity.getIntent());
+    }
+
+    @Override
+    public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
+        View v =  super.onCreateView(inflater, container, savedInstanceState);
+        /**This is a hack see {@link PreferencesActivity#saveListViewState(int, Parcelable)}*/
+        listView = v.findViewById(android.R.id.list);
+        return v;
+    }
+
+    @Override
+    public void onPause() {
+        super.onPause();
+
+
+        if(listView != null) {
+            /**This is a hack see {@link PreferencesActivity#saveListViewState(int, Parcelable)}*/
+            ((PreferencesActivity) getActivity())
+                    .saveListViewState(START_PREFERENCE, listView.onSaveInstanceState());
+
+        }
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+
+        if(listView != null) {
+            /**This is a hack see {@link PreferencesActivity#saveListViewState(int, Parcelable)}*/
+            Parcelable restored = ((PreferencesActivity) getActivity()).restoreListViewState(START_PREFERENCE);
+            if(restored != null) {
+                listView.onRestoreInstanceState(restored);
+            }
+        }
     }
 
 }


### PR DESCRIPTION
* Save the scroll state of PreferenceFragments in the activity so that they can be restored, currently only implemented for start PreferenceFragment.

Fixes #1075.