### PR TITLE
Use FolderChooser to choose FTP server share path & archive extract/zip creation paths

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -96,6 +96,7 @@ dependencies {
     }
 
     implementation 'com.afollestad.material-dialogs:core:0.9.6.0'
+    implementation 'com.afollestad.material-dialogs:commons:0.9.6.0'
 
     //FTP Server
     /*

--- a/app/src/main/java/com/amaze/filemanager/activities/PreferencesActivity.java
+++ b/app/src/main/java/com/amaze/filemanager/activities/PreferencesActivity.java
@@ -29,6 +29,7 @@ import android.graphics.drawable.BitmapDrawable;
 import android.os.Bundle;
 import android.preference.PreferenceFragment;
 import android.preference.PreferenceManager;
+import android.support.annotation.NonNull;
 import android.support.annotation.StringRes;
 import android.support.v7.widget.Toolbar;
 import android.view.MenuItem;
@@ -37,6 +38,7 @@ import android.view.Window;
 import android.view.WindowManager;
 import android.widget.FrameLayout;
 
+import com.afollestad.materialdialogs.folderselector.FolderChooserDialog;
 import com.amaze.filemanager.R;
 import com.amaze.filemanager.activities.superclasses.ThemedActivity;
 import com.amaze.filemanager.fragments.preference_fragments.AdvancedSearchPref;
@@ -51,9 +53,11 @@ import com.amaze.filemanager.utils.color.ColorUsage;
 import com.amaze.filemanager.utils.theme.AppTheme;
 import com.readystatesoftware.systembartint.SystemBarTintManager;
 
+import java.io.File;
+
 import static android.os.Build.VERSION.SDK_INT;
 
-public class PreferencesActivity extends ThemedActivity {
+public class PreferencesActivity extends ThemedActivity implements FolderChooserDialog.FolderCallback {
 
     //Start is the first activity you see
     public static final int START_PREFERENCE = 0;
@@ -245,4 +249,35 @@ public class PreferencesActivity extends ThemedActivity {
         getSupportActionBar().setTitle(titleBarName);
     }
 
+    /**
+     * Update preference key with selected path.
+     *
+     * @see PrefFrag
+     * @see FolderChooserDialog
+     * @see com.afollestad.materialdialogs.folderselector.FolderChooserDialog.FolderCallback
+     * @param dialog
+     * @param folder selected folder
+     */
+    @Override
+    public void onFolderSelection(@NonNull FolderChooserDialog dialog, @NonNull File folder) {
+        //Just to be safe
+        if (folder.exists() && folder.isDirectory()) {
+            //Write settings to preferences
+            SharedPreferences sharedPref = PreferenceManager.getDefaultSharedPreferences(this);
+            sharedPref.edit().putString(dialog.getTag(), folder.getAbsolutePath()).commit();
+        }
+        dialog.dismiss();
+    }
+
+    /**
+     * Do nothing other than dismissing the folder selection dialog.
+     *
+     * @see FolderChooserDialog
+     * @see com.afollestad.materialdialogs.folderselector.FolderChooserDialog.FolderCallback
+     * @param dialog
+     */
+    @Override
+    public void onFolderChooserDismissed(@NonNull FolderChooserDialog dialog) {
+        dialog.dismiss();
+    }
 }

--- a/app/src/main/java/com/amaze/filemanager/fragments/FTPServerFragment.java
+++ b/app/src/main/java/com/amaze/filemanager/fragments/FTPServerFragment.java
@@ -174,7 +174,7 @@ public class FTPServerFragment extends Fragment {
                 return true;
             case R.id.ftp_path:
                 FolderChooserDialog.Builder dialogBuilder = new FolderChooserDialog.Builder(getActivity());
-                dialogBuilder.chooseButton(R.string.change)
+                dialogBuilder.chooseButton(R.string.choose_folder)
                         .initialPath(getDefaultPathFromPreferences())
                         .cancelButton(R.string.cancel)
                         .tag(TAG)

--- a/app/src/main/java/com/amaze/filemanager/fragments/FTPServerFragment.java
+++ b/app/src/main/java/com/amaze/filemanager/fragments/FTPServerFragment.java
@@ -176,6 +176,7 @@ public class FTPServerFragment extends Fragment {
                 FolderChooserDialog.Builder dialogBuilder = new FolderChooserDialog.Builder(getActivity());
                 dialogBuilder.chooseButton(R.string.choose_folder)
                         .initialPath(getDefaultPathFromPreferences())
+                        .goUpLabel(getString(R.string.folder_go_up_one_level))
                         .cancelButton(R.string.cancel)
                         .tag(TAG)
                         .build().show(getActivity());

--- a/app/src/main/java/com/amaze/filemanager/fragments/FTPServerFragment.java
+++ b/app/src/main/java/com/amaze/filemanager/fragments/FTPServerFragment.java
@@ -30,6 +30,7 @@ import android.widget.TextView;
 import android.widget.Toast;
 
 import com.afollestad.materialdialogs.MaterialDialog;
+import com.afollestad.materialdialogs.folderselector.FolderChooserDialog;
 import com.amaze.filemanager.R;
 import com.amaze.filemanager.activities.MainActivity;
 import com.amaze.filemanager.asynchronous.services.ftp.FTPService;
@@ -38,7 +39,6 @@ import com.amaze.filemanager.utils.color.ColorUsage;
 import com.amaze.filemanager.utils.files.CryptUtil;
 import com.amaze.filemanager.utils.theme.AppTheme;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.InetAddress;
@@ -49,6 +49,8 @@ import java.security.GeneralSecurityException;
  * Edited by Luca D'Amico (Luca91) on 25 Jul 2017 (Fixed FTP Server while using Eth connection)
  */
 public class FTPServerFragment extends Fragment {
+
+    public static final String TAG = "FTPServerFragment";
 
     private TextView statusText, username, password, port, sharedPath;
     private AppCompatEditText usernameEditText, passwordEditText;
@@ -171,48 +173,12 @@ public class FTPServerFragment extends Fragment {
                         .show();
                 return true;
             case R.id.ftp_path:
-                MaterialDialog.Builder dialogBuilder = new MaterialDialog.Builder(getActivity());
-                dialogBuilder.title(getString(R.string.ftp_path));
-                dialogBuilder.input(getString(R.string.ftp_path_hint),
-                        getDefaultPathFromPreferences(),
-                        false, (dialog, input) -> {});
-                dialogBuilder.onPositive((dialog, which) -> {
-                    EditText editText = dialog.getInputEditText();
-                    if (editText != null) {
-                        String path = editText.getText().toString();
-
-                        File pathFile = new File(path);
-                        if (pathFile.exists() && pathFile.isDirectory()) {
-
-                            changeFTPServerPath(pathFile.getPath());
-
-                            Toast.makeText(getActivity(), R.string.ftp_path_change_success,
-                                    Toast.LENGTH_SHORT)
-                                    .show();
-                        } else {
-                            // try to get parent
-                            File pathParentFile = new File(pathFile.getParent());
-                            if (pathParentFile.exists() && pathParentFile.isDirectory()) {
-
-                                changeFTPServerPath(pathParentFile.getPath());
-                                Toast.makeText(getActivity(), R.string.ftp_path_change_success,
-                                        Toast.LENGTH_SHORT)
-                                        .show();
-                            } else {
-                                // don't have access, print error
-
-                                Toast.makeText(getActivity(), R.string.ftp_path_change_error_invalid,
-                                        Toast.LENGTH_SHORT)
-                                        .show();
-                            }
-                        }
-                    }
-                });
-
-                dialogBuilder.positiveText(getResources().getString(R.string.change).toUpperCase())
-                        .negativeText(R.string.cancel)
-                        .build()
-                        .show();
+                FolderChooserDialog.Builder dialogBuilder = new FolderChooserDialog.Builder(getActivity());
+                dialogBuilder.chooseButton(R.string.change)
+                        .initialPath(getDefaultPathFromPreferences())
+                        .cancelButton(R.string.cancel)
+                        .tag(TAG)
+                        .build().show(getActivity());
                 return true;
             case R.id.ftp_login:
                 MaterialDialog.Builder loginDialogBuilder = new MaterialDialog.Builder(getActivity());
@@ -576,7 +542,7 @@ public class FTPServerFragment extends Fragment {
         updateStatus();
     }
 
-    private void changeFTPServerPath(String path) {
+    public void changeFTPServerPath(String path) {
         SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(getActivity());
         preferences.edit().putString(FTPService.KEY_PREFERENCE_PATH, path).apply();
 

--- a/app/src/main/java/com/amaze/filemanager/fragments/preference_fragments/PrefFrag.java
+++ b/app/src/main/java/com/amaze/filemanager/fragments/preference_fragments/PrefFrag.java
@@ -299,7 +299,7 @@ public class PrefFrag extends PreferenceFragment implements Preference.OnPrefere
             case PreferencesConstants.PREFERENCE_ZIP_EXTRACT_PATH:
                 new FolderChooserDialog.Builder(getActivity())
                         .tag(PreferencesConstants.PREFERENCE_ZIP_EXTRACT_PATH)
-                        .chooseButton(R.string.select)
+                        .chooseButton(R.string.choose_folder)
                         .cancelButton(R.string.cancel)
                         .initialPath(sharedPref.getString(PreferencesConstants.PREFERENCE_ZIP_EXTRACT_PATH, Environment.getExternalStorageDirectory().getPath()))
                         .build().show((PreferencesActivity)getActivity());
@@ -307,7 +307,7 @@ public class PrefFrag extends PreferenceFragment implements Preference.OnPrefere
             case PreferencesConstants.PREFERENCE_ZIP_CREATE_PATH:
                 new FolderChooserDialog.Builder(getActivity())
                         .tag(PreferencesConstants.PREFERENCE_ZIP_CREATE_PATH)
-                        .chooseButton(R.string.select)
+                        .chooseButton(R.string.choose_folder)
                         .cancelButton(R.string.cancel)
                         .initialPath(sharedPref.getString(PreferencesConstants.PREFERENCE_ZIP_CREATE_PATH, Environment.getExternalStorageDirectory().getPath()))
                         .build().show((PreferencesActivity)getActivity());

--- a/app/src/main/java/com/amaze/filemanager/fragments/preference_fragments/PrefFrag.java
+++ b/app/src/main/java/com/amaze/filemanager/fragments/preference_fragments/PrefFrag.java
@@ -31,6 +31,7 @@ import android.hardware.fingerprint.FingerprintManager;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
+import android.os.Environment;
 import android.preference.Preference;
 import android.preference.PreferenceFragment;
 import android.preference.PreferenceManager;
@@ -41,6 +42,7 @@ import android.widget.Toast;
 
 import com.afollestad.materialdialogs.DialogAction;
 import com.afollestad.materialdialogs.MaterialDialog;
+import com.afollestad.materialdialogs.folderselector.FolderChooserDialog;
 import com.amaze.filemanager.R;
 import com.amaze.filemanager.activities.AboutActivity;
 import com.amaze.filemanager.activities.PreferencesActivity;
@@ -64,7 +66,8 @@ public class PrefFrag extends PreferenceFragment implements Preference.OnPrefere
             PreferencesConstants.PREFERENCE_SHOW_HIDDENFILES, PreferencesConstants.FRAGMENT_FEEDBACK,
             PreferencesConstants.FRAGMENT_ABOUT, PreferencesConstants.FRAGMENT_COLORS,
             PreferencesConstants.FRAGMENT_FOLDERS, PreferencesConstants.FRAGMENT_QUICKACCESSES,
-            PreferencesConstants.FRAGMENT_ADVANCED_SEARCH};
+            PreferencesConstants.FRAGMENT_ADVANCED_SEARCH,
+            PreferencesConstants.PREFERENCE_ZIP_CREATE_PATH, PreferencesConstants.PREFERENCE_ZIP_EXTRACT_PATH};
 
     private UtilitiesProvider utilsProvider;
     private SharedPreferences sharedPref;
@@ -291,6 +294,23 @@ public class PrefFrag extends PreferenceFragment implements Preference.OnPrefere
                 });
 
                 masterPasswordDialogBuilder.build().show();
+                return true;
+            //If there is no directory set, default to storage root (/storage/sdcard...)
+            case PreferencesConstants.PREFERENCE_ZIP_EXTRACT_PATH:
+                new FolderChooserDialog.Builder(getActivity())
+                        .tag(PreferencesConstants.PREFERENCE_ZIP_EXTRACT_PATH)
+                        .chooseButton(R.string.select)
+                        .cancelButton(R.string.cancel)
+                        .initialPath(sharedPref.getString(PreferencesConstants.PREFERENCE_ZIP_EXTRACT_PATH, Environment.getExternalStorageDirectory().getPath()))
+                        .build().show((PreferencesActivity)getActivity());
+                return true;
+            case PreferencesConstants.PREFERENCE_ZIP_CREATE_PATH:
+                new FolderChooserDialog.Builder(getActivity())
+                        .tag(PreferencesConstants.PREFERENCE_ZIP_CREATE_PATH)
+                        .chooseButton(R.string.select)
+                        .cancelButton(R.string.cancel)
+                        .initialPath(sharedPref.getString(PreferencesConstants.PREFERENCE_ZIP_CREATE_PATH, Environment.getExternalStorageDirectory().getPath()))
+                        .build().show((PreferencesActivity)getActivity());
                 return true;
         }
 

--- a/app/src/main/java/com/amaze/filemanager/fragments/preference_fragments/PrefFrag.java
+++ b/app/src/main/java/com/amaze/filemanager/fragments/preference_fragments/PrefFrag.java
@@ -299,6 +299,7 @@ public class PrefFrag extends PreferenceFragment implements Preference.OnPrefere
             case PreferencesConstants.PREFERENCE_ZIP_EXTRACT_PATH:
                 new FolderChooserDialog.Builder(getActivity())
                         .tag(PreferencesConstants.PREFERENCE_ZIP_EXTRACT_PATH)
+                        .goUpLabel(getString(R.string.folder_go_up_one_level))
                         .chooseButton(R.string.choose_folder)
                         .cancelButton(R.string.cancel)
                         .initialPath(sharedPref.getString(PreferencesConstants.PREFERENCE_ZIP_EXTRACT_PATH, Environment.getExternalStorageDirectory().getPath()))
@@ -307,6 +308,7 @@ public class PrefFrag extends PreferenceFragment implements Preference.OnPrefere
             case PreferencesConstants.PREFERENCE_ZIP_CREATE_PATH:
                 new FolderChooserDialog.Builder(getActivity())
                         .tag(PreferencesConstants.PREFERENCE_ZIP_CREATE_PATH)
+                        .goUpLabel(getString(R.string.folder_go_up_one_level))
                         .chooseButton(R.string.choose_folder)
                         .cancelButton(R.string.cancel)
                         .initialPath(sharedPref.getString(PreferencesConstants.PREFERENCE_ZIP_CREATE_PATH, Environment.getExternalStorageDirectory().getPath()))

--- a/app/src/main/java/com/amaze/filemanager/fragments/preference_fragments/PreferencesConstants.java
+++ b/app/src/main/java/com/amaze/filemanager/fragments/preference_fragments/PreferencesConstants.java
@@ -45,6 +45,9 @@ public class PreferencesConstants {
     public static final String PREFERENCE_CRYPT_MASTER_PASSWORD_DEFAULT = "";
     public static final boolean PREFERENCE_CRYPT_FINGERPRINT_DEFAULT = false;
     public static final boolean PREFERENCE_CRYPT_WARNING_REMEMBER_DEFAULT = false;
+
+    public static final String PREFERENCE_ZIP_EXTRACT_PATH = "extractpath";
+    public static final String PREFERENCE_ZIP_CREATE_PATH = "zippath";
     //END preferences.xml constants
 
     //START color_prefs.xml constants

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -572,4 +572,5 @@
   <string name="license">版權宣告</string>
   <string name="libraries">第三方程式庫</string>
   <string name="ssh_select_pem">選擇認證時使用的 SSH私鑰</string>
+  <string name="choose_folder">選擇此檔案夾</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -619,5 +619,6 @@
     <string name="reopen_from_source">Can\'t, please reopen from last app</string>
     <string name="no_file_error">Something went wrong, there\'s nothing to open</string>
     <string name="choose_folder">Choose This Folder</string>
+    <string name="folder_go_up_one_level" translatable="false">..</string>
 </resources>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -618,5 +618,6 @@
     <string name="no_obtainable_info">There\'s no info about this file</string>
     <string name="reopen_from_source">Can\'t, please reopen from last app</string>
     <string name="no_file_error">Something went wrong, there\'s nothing to open</string>
+    <string name="choose_folder">Choose This Folder</string>
 </resources>
 

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -104,16 +104,16 @@
     </PreferenceCategory>
 
     <PreferenceCategory android:title="@string/archive_preferences">
-        <EditTextPreference
+        <Preference
             android:key="extractpath"
             android:summary="@string/archive_summary"
             android:title="@string/archive_extract_folder">
-        </EditTextPreference>
-        <EditTextPreference
+        </Preference>
+        <Preference
             android:key="zippath"
             android:summary="@string/zip_summary"
             android:title="@string/zip_create_folder">
-        </EditTextPreference>
+        </Preference>
     </PreferenceCategory>
 
     <PreferenceCategory android:title="@string/security">


### PR DESCRIPTION
Fixes #811, using MaterialDialog's FolderChooser.

While working on #811, also took the time to change archive extraction and zip creation paths to use FolderChooser too.

Sorry for scattered callbacks of the folder chooser dialogs, but seems it's the way for FolderChooser to work.