### PR TITLE
Display error messages as Toast and finish TextEditorActivity on load file problems

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/activities/TextEditorActivity.java
+++ b/app/src/main/java/com/amaze/filemanager/activities/TextEditorActivity.java
@@ -31,6 +31,7 @@ import android.graphics.drawable.BitmapDrawable;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
+import android.support.design.widget.Snackbar;
 import android.text.Editable;
 import android.text.Spanned;
 import android.text.TextWatcher;
@@ -285,8 +286,7 @@ public class TextEditorActivity extends ThemedActivity implements TextWatcher, V
      * on a worker thread
      */
     private void load() {
-        Toast.makeText(getApplicationContext(), R.string.loading, Toast.LENGTH_SHORT).show();
-        //mInput.setHint();
+        Snackbar.make(scrollView, R.string.loading, Snackbar.LENGTH_SHORT).show();
 
         new ReadFileTask(getContentResolver(), mFile, getExternalCacheDir(), (data) -> {
             switch (data.error) {
@@ -297,7 +297,7 @@ public class TextEditorActivity extends ThemedActivity implements TextWatcher, V
                     try {
                         mInput.setText(data.fileContents);
                         if (data.fileContents.isEmpty()) {
-                            Toast.makeText(getApplicationContext(), R.string.file_empty, Toast.LENGTH_SHORT).show();
+                            mInput.setHint(R.string.file_empty);
                         } else {
                             mInput.setHint(null);
                         }

--- a/app/src/main/java/com/amaze/filemanager/activities/TextEditorActivity.java
+++ b/app/src/main/java/com/amaze/filemanager/activities/TextEditorActivity.java
@@ -285,7 +285,8 @@ public class TextEditorActivity extends ThemedActivity implements TextWatcher, V
      * on a worker thread
      */
     private void load() {
-        mInput.setHint(R.string.loading);
+        Toast.makeText(getApplicationContext(), R.string.loading, Toast.LENGTH_SHORT).show();
+        //mInput.setHint();
 
         new ReadFileTask(getContentResolver(), mFile, getExternalCacheDir(), (data) -> {
             switch (data.error) {
@@ -296,19 +297,22 @@ public class TextEditorActivity extends ThemedActivity implements TextWatcher, V
                     try {
                         mInput.setText(data.fileContents);
                         if (data.fileContents.isEmpty()) {
-                            mInput.setHint(R.string.file_empty);
+                            Toast.makeText(getApplicationContext(), R.string.file_empty, Toast.LENGTH_SHORT).show();
                         } else {
                             mInput.setHint(null);
                         }
                     } catch (OutOfMemoryError e) {
-                        mInput.setHint(R.string.error);
+                        Toast.makeText(getApplicationContext(), R.string.error, Toast.LENGTH_SHORT).show();
+                        finish();
                     }
                     break;
                 case ReadFileTask.EXCEPTION_STREAM_NOT_FOUND:
-                    mInput.setHint(R.string.error_file_not_found);
+                    Toast.makeText(getApplicationContext(), R.string.error_file_not_found, Toast.LENGTH_SHORT).show();
+                    finish();
                     break;
                 case ReadFileTask.EXCEPTION_IO:
-                    mInput.setHint(R.string.error_io);
+                    Toast.makeText(getApplicationContext(), R.string.error_io, Toast.LENGTH_SHORT).show();
+                    finish();
                     break;
             }
         }).execute();


### PR DESCRIPTION
An effort to fix #1033.

It's probably a bad idea to call `finish()` to end TextEditorActivity, so feel free to put forward other better ideas.