### PR TITLE
Fix load SMB connections on app startup

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/database/UtilsHandler.java
+++ b/app/src/main/java/com/amaze/filemanager/database/UtilsHandler.java
@@ -266,31 +266,26 @@ public class UtilsHandler extends SQLiteOpenHelper {
 
         Cursor cursor = sqLiteDatabase.query(getTableForOperation(Operation.SMB), null,
                 null, null, null, null, null);
-        cursor.moveToFirst();
+        boolean hasNext = cursor.moveToFirst();
         ArrayList<String[]> row = new ArrayList<>();
-        try {
+        while (hasNext) {
+            try {
+                row.add(new String[] {
+                        cursor.getString(cursor.getColumnIndex(COLUMN_NAME)),
+                        SmbUtil.getSmbDecryptedPath(context, cursor.getString(cursor.getColumnIndex(COLUMN_PATH)))
+                });
+            } catch (GeneralSecurityException | IOException e) {
+                e.printStackTrace();
 
-            while (cursor.moveToNext()) {
-                try {
-                    row.add(new String[] {
-                            cursor.getString(cursor.getColumnIndex(COLUMN_NAME)),
-                            SmbUtil.getSmbDecryptedPath(context, cursor.getString(cursor.getColumnIndex(COLUMN_PATH)))
-                    });
-                } catch (GeneralSecurityException | IOException e) {
-                    e.printStackTrace();
-
-                    // failing to decrypt the path, removing entry from database
-                    Toast.makeText(context,
-                            context.getResources().getString(R.string.failed_smb_decrypt_path),
-                            Toast.LENGTH_LONG).show();
-                    removeSmbPath(cursor.getString(cursor.getColumnIndex(COLUMN_NAME)),
-                            "");
-                    continue;
-                }
+                // failing to decrypt the path, removing entry from database
+                Toast.makeText(context, context.getResources().getString(R.string.failed_smb_decrypt_path), Toast.LENGTH_LONG).show();
+                removeSmbPath(cursor.getString(cursor.getColumnIndex(COLUMN_NAME)),
+                        "");
+                continue;
             }
-        } finally {
-            cursor.close();
+            hasNext = cursor.moveToNext();
         }
+        cursor.close();
         return row;
     }
 


### PR DESCRIPTION
Steps to reproduce the symptom:

1. Fresh install
2. Create a new SMB connection
3. Verify SMB connection is loaded correctly, and drawer has the connection item
4. Close app by keep tapping back or force quit
5. Launch app again
6. The SMB connection created in 2 disappeared

The second, third... other SMB connections are not affected, only the first one. This fix is going to fix this glitch.

Fix is borrowed from code when I worked on #863, while keeping the `try/catch` block.