### PR TITLE
Fix NullPointerException thrown on deleting folders outside storage

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/DeleteTask.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/DeleteTask.java
@@ -127,14 +127,20 @@ public class DeleteTask extends AsyncTask<ArrayList<HybridFileParcelable>, Strin
                 }
             }
         } else {
-
-            for(HybridFileParcelable a : files)
+            for(HybridFileParcelable a : files) {
                 try {
-                    (a).delete(cd, rootMode);
+                    boolean result = (a).delete(cd, rootMode);
+                    if (!result && b) {
+                        b = false;
+                        return b;
+                    }
+                    else
+                        b = true;
                 } catch (ShellNotRunningException e) {
                     e.printStackTrace();
                     b = false;
                 }
+            }
         }
 
         // delete file from media database

--- a/app/src/main/java/com/amaze/filemanager/filesystem/FileUtil.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/FileUtil.java
@@ -530,7 +530,7 @@ public abstract class FileUtil {
      * @param file The folder name.
      * @return true if successful.
      */
-    private static boolean rmdir(final File file, Context context) {
+    private static boolean rmdir(@NonNull final File file, Context context) {
         if (!file.exists()) return true;
 
         File[] files = file.listFiles();

--- a/app/src/main/java/com/amaze/filemanager/filesystem/FileUtil.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/FileUtil.java
@@ -310,7 +310,7 @@ public abstract class FileUtil {
     static boolean deleteFile(@NonNull final File file, Context context) {
         // First try the normal deletion.
         if (file == null) return true;
-        boolean fileDelete = deleteFilesInFolder(file, context);
+        boolean fileDelete = rmdir(file, context);
         if (file.delete() || fileDelete)
             return true;
 
@@ -529,39 +529,19 @@ public abstract class FileUtil {
      * @param file The folder name.
      * @return true if successful.
      */
-    private static boolean rmdir1(final File file, Context context) {
-        if (file == null)
-            return false;
-        boolean b = true;
-        for (File file1 : file.listFiles()) {
-            if (file1.isDirectory()) {
-                if (!rmdir1(file1, context)) b = false;
-            } else {
-                if (!deleteFile(file1, context)) b = false;
-            }
-        }
-        return b;
-    }
-
     private static boolean rmdir(final File file, Context context) {
+
         if (file == null)
             return false;
-        if (!file.exists()) {
+        if (!file.exists())
             return true;
+
+        File[] files = file.listFiles();
+        if (files != null && files.length > 0) {
+            for(File _file : files)
+                rmdir(_file, context);
         }
-        if (!file.isDirectory()) {
-            return false;
-        }
-        String[] fileList = file.list();
-        if (fileList != null && fileList.length > 0) {
-            //  empty the folder.
-            rmdir1(file, context);
-        }
-        String[] fileList1 = file.list();
-        if (fileList1 != null && fileList1.length > 0) {
-            // Delete only empty folder.
-            return false;
-        }
+
         // Try the normal way
         if (file.delete()) {
             return true;
@@ -570,7 +550,7 @@ public abstract class FileUtil {
         // Try with Storage Access Framework.
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
             DocumentFile document = getDocumentFile(file, true, context);
-            return document.delete();
+            return (document != null) ? document.delete() : false;
         }
 
         // Try the Kitkat workaround.
@@ -586,31 +566,6 @@ public abstract class FileUtil {
         }
 
         return !file.exists();
-    }
-
-    /**
-     * Delete all files in a folder.
-     *
-     * @param folder the folder
-     * @return true if successful.
-     */
-    private static final boolean deleteFilesInFolder(final File folder, Context context) {
-        boolean totalSuccess = true;
-        if (folder == null)
-            return false;
-        if (folder.isDirectory()) {
-            for (File child : folder.listFiles()) {
-                deleteFilesInFolder(child, context);
-            }
-
-            if (!folder.delete())
-                totalSuccess = false;
-        } else {
-
-            if (!folder.delete())
-                totalSuccess = false;
-        }
-        return totalSuccess;
     }
 
     /**

--- a/app/src/main/java/com/amaze/filemanager/filesystem/HybridFile.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/HybridFile.java
@@ -13,7 +13,6 @@ import com.amaze.filemanager.database.CloudHandler;
 import com.amaze.filemanager.exceptions.CloudPluginException;
 import com.amaze.filemanager.exceptions.ShellNotRunningException;
 import com.amaze.filemanager.filesystem.ssh.Statvfs;
-import com.amaze.filemanager.fragments.MainFragment;
 import com.amaze.filemanager.fragments.preference_fragments.PreferencesConstants;
 
 import com.amaze.filemanager.filesystem.ssh.SFtpClientTemplate;
@@ -28,7 +27,6 @@ import com.amaze.filemanager.utils.OpenMode;
 import com.amaze.filemanager.utils.RootUtils;
 import com.amaze.filemanager.utils.cloud.CloudUtil;
 import com.amaze.filemanager.utils.files.FileUtils;
-import com.amaze.filemanager.utils.provider.UtilitiesProvider;
 import com.cloudrail.si.interfaces.CloudStorage;
 import com.cloudrail.si.types.SpaceAllocation;
 
@@ -1253,10 +1251,8 @@ public class HybridFile {
         } else {
             if (isRoot() && rootmode) {
                 setMode(OpenMode.ROOT);
-
                 RootUtils.delete(getPath());
             } else {
-
                 FileUtil.deleteFile(new File(path), context);
             }
         }


### PR DESCRIPTION
Fixes #1102. Deleting folders outside storage area is still not possible (either with or without root) after this change, but you'll get an error Toast instead of an app crash.

I'm still not sure if I should fix deleting folders outside storage with root (currently calls to `HybridFile.delete()` never seen went to `RootUtils.delete()`) as it is dangerous. That will be in another PR anyway.

Changes:
- Code cleanups at FileUtil: remove rmdir1() and deleteFilesInFolder()
- Fix FileUtil.rmdir()
- Fix DeleteTask, display error Toast on problem during deleting folder