### PR TITLE
Fix rename for SMB folder/files (#1100)

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/fragments/MainFragment.java
+++ b/app/src/main/java/com/amaze/filemanager/fragments/MainFragment.java
@@ -1219,10 +1219,6 @@ public class MainFragment extends android.support.v4.app.Fragment implements Bot
 
         builder.onPositive((dialog, which) -> {
             String name1 = dialog.getInputEditText().getText().toString();
-            if (f.isSmb()){
-                if (f.isDirectory() && !name1.endsWith("/"))
-                    name1 = name1 + "/";
-            }
             getMainActivity().mainActivityHelper.rename(openMode, f.getPath(),
                     CURRENT_PATH + "/" + name1, getActivity(), getMainActivity().isRootExplorer());
         });


### PR DESCRIPTION
Fixes #1100.

The extra handling for SMB files at `MainFragment.rename()` seems to be the culprit.

Tested on Oneplus One running Slim7 (7.1.2) and Galaxy S2 running SlimLP (5.1.1).