### PR TITLE
build.gradle: change compile -> implementation

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -152,7 +152,7 @@ dependencies {
         transitive = true
     }
 
-    compile 'com.android.support:multidex:1.0.2'//Multiple dex files
+    implementation 'com.android.support:multidex:1.0.2'//Multiple dex files
 }
 
 configurations.all {


### PR DESCRIPTION
A trivial change, per notification after upgrading my environment to Android Studio 3.1.

This needs to be changed anyway; all other environment updates (build tools version, gradle plugin versions...) brought from Android Studio's upgrade are not pushed here (yet).