### PR TITLE
Update gradle, build tools, Glide and FABsMenu

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -138,14 +138,14 @@ dependencies {
     implementation 'com.madgag.spongycastle:prov:1.58.0.0'
 
     //Glide: loads icons seemlessly
-    implementation 'com.github.bumptech.glide:glide:4.4.0'
-    implementation ("com.github.bumptech.glide:recyclerview-integration:4.3.1") {
+    implementation 'com.github.bumptech.glide:glide:4.6.1'
+    implementation ("com.github.bumptech.glide:recyclerview-integration:4.6.1") {
         // Excludes the support library because it's already included by Glide.
         transitive = false
     }
-    annotationProcessor 'com.github.bumptech.glide:compiler:4.4.0'
+    annotationProcessor 'com.github.bumptech.glide:compiler:4.6.1'
 
-    implementation 'com.github.jahirfiquitiva:FABsMenu:1.1.1'//Floating Action Buttons Menu (aka expandable FAB)
+    implementation 'com.github.jahirfiquitiva:FABsMenu:1.1.3'//Floating Action Buttons Menu (aka expandable FAB)
 
     //Simple library show
     implementation('com.mikepenz:aboutlibraries:6.0.3@aar') {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 26
-    buildToolsVersion '26.0.2'
+    buildToolsVersion '27.0.3'
 
     dexOptions {
         jumboMode = true

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.1.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Dec 07 11:22:00 IST 2017
+#Fri Mar 30 13:57:42 ART 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip


### PR DESCRIPTION
Update gradle, build tools, Glide and FABsMenu. FABsMenu update fixes a crash on API 15.