### PR TITLE
Fix redundant type parametrization

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/asynchronous/services/AbstractProgressiveService.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/services/AbstractProgressiveService.java
@@ -213,6 +213,16 @@ public abstract class AbstractProgressiveService extends Service implements Serv
         void refresh();
     }
 
+    @Override
+    public Context getApplicationContext() {
+        return super.getApplicationContext();
+    }
+
+    @Override
+    public boolean isDecryptService() {
+        return false;
+    }
+
     /**
      * Displays a notification, sends intent and cancels progress if there were some failures
      *

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/services/CopyService.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/services/CopyService.java
@@ -136,11 +136,6 @@ public class CopyService extends AbstractProgressiveService {
     }
 
     @Override
-    public CopyService getServiceType() {
-        return this;
-    }
-
-    @Override
     protected NotificationManager getNotificationManager() {
         return mNotifyManager;
     }

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/services/DecryptService.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/services/DecryptService.java
@@ -146,11 +146,6 @@ public class DecryptService extends AbstractProgressiveService {
     }
 
     @Override
-    public DecryptService getServiceType() {
-        return this;
-    }
-
-    @Override
     protected NotificationManager getNotificationManager() {
         return notificationManager;
     }
@@ -192,6 +187,11 @@ public class DecryptService extends AbstractProgressiveService {
     @Override
     protected ProgressHandler getProgressHandler() {
         return progressHandler;
+    }
+
+    @Override
+    public boolean isDecryptService() {
+        return true;
     }
 
     @Override

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/services/EncryptService.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/services/EncryptService.java
@@ -92,11 +92,6 @@ public class EncryptService extends AbstractProgressiveService {
     }
 
     @Override
-    public EncryptService getServiceType() {
-        return this;
-    }
-
-    @Override
     protected NotificationManager getNotificationManager() {
         return notificationManager;
     }

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/services/ExtractService.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/services/ExtractService.java
@@ -111,11 +111,6 @@ public class ExtractService extends AbstractProgressiveService {
     }
 
     @Override
-    public ExtractService getServiceType() {
-        return this;
-    }
-
-    @Override
     protected NotificationManager getNotificationManager() {
         return mNotifyManager;
     }

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/services/ZipService.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/services/ZipService.java
@@ -116,11 +116,6 @@ public class ZipService extends AbstractProgressiveService {
     }
 
     @Override
-    public ZipService getServiceType() {
-        return this;
-    }
-
-    @Override
     protected NotificationManager getNotificationManager() {
         return mNotifyManager;
     }

--- a/app/src/main/java/com/amaze/filemanager/utils/ServiceWatcherUtil.java
+++ b/app/src/main/java/com/amaze/filemanager/utils/ServiceWatcherUtil.java
@@ -79,14 +79,12 @@ public class ServiceWatcherUtil {
 
                     // new position is same as the last second position, and halt counter is past threshold
 
-                    String writtenSize = Formatter.formatShortFileSize(interactionInterface.getServiceType().getApplicationContext(),
+                    String writtenSize = Formatter.formatShortFileSize(interactionInterface.getApplicationContext(),
                             progressHandler.getWrittenSize());
-                    String totalSize = Formatter.formatShortFileSize(interactionInterface.getServiceType().getApplicationContext(),
+                    String totalSize = Formatter.formatShortFileSize(interactionInterface.getApplicationContext(),
                             progressHandler.getTotalSize());
 
-                    if (interactionInterface.getServiceType() instanceof DecryptService
-                            && writtenSize.equals(totalSize)) {
-
+                    if (interactionInterface.isDecryptService() && writtenSize.equals(totalSize)) {
                         // workaround for decryption when we have a length retrieved by
                         // CipherInputStream less than the original stream, and hence the total size
                         // we passed at the beginning is never reached
@@ -231,6 +229,11 @@ public class ServiceWatcherUtil {
          */
         void progressResumed();
 
-        <T extends Service> T getServiceType();
+        Context getApplicationContext();
+
+        /**
+         * This is for a hack, read about it where it's used
+         */
+        boolean isDecryptService();
     }
 }


### PR DESCRIPTION
Replaced `ServiceWatcherInteractionInterface.getServiceType()` with `getApplicationContext()` and `isDecryptService()`.