### PR TITLE
Fix Travis CI build failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ android:
   components:
     - platform-tools
     - tools
-    - build-tools-26.0.2
+    - build-tools-27.0.3
     - android-26
     - extra-google-m2repository
 


### PR DESCRIPTION
Change Android build tools in travis.yml to in sync with build.gradle to fix Travis build failures.