### PR TITLE
Fix first launch app crash on API 15

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/database/models/Tab.java
+++ b/app/src/main/java/com/amaze/filemanager/database/models/Tab.java
@@ -39,7 +39,7 @@ public class Tab {
     }
 
     public String getOriginalPath(boolean savePaths, SharedPreferences sharedPreferences){
-        if(savePaths && FileUtils.isPathAccesible(path, sharedPreferences)) {
+        if(savePaths && FileUtils.isPathAccessible(path, sharedPreferences)) {
             return path;
         } else {
             return home;

--- a/app/src/main/java/com/amaze/filemanager/fragments/preference_fragments/FoldersPref.java
+++ b/app/src/main/java/com/amaze/filemanager/fragments/preference_fragments/FoldersPref.java
@@ -177,7 +177,7 @@ public class FoldersPref extends PreferenceFragment implements Preference.OnPref
                 .build();
 
         dialog.getActionButton(DialogAction.POSITIVE)
-                .setEnabled(FileUtils.isPathAccesible(editText2.getText().toString(), sharedPrefs));
+                .setEnabled(FileUtils.isPathAccessible(editText2.getText().toString(), sharedPrefs));
 
         disableButtonIfTitleEmpty(editText1, dialog);
         disableButtonIfNotPath(editText2, dialog);
@@ -262,7 +262,7 @@ public class FoldersPref extends PreferenceFragment implements Preference.OnPref
             @Override
             public void afterTextChanged(Editable s) {
                 dialog.getActionButton(DialogAction.POSITIVE)
-                        .setEnabled(FileUtils.isPathAccesible(s.toString(), sharedPrefs));
+                        .setEnabled(FileUtils.isPathAccessible(s.toString(), sharedPrefs));
             }
         });
     }

--- a/app/src/main/java/com/amaze/filemanager/ui/dialogs/GeneralDialogCreation.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/dialogs/GeneralDialogCreation.java
@@ -11,7 +11,6 @@ import android.os.AsyncTask;
 import android.os.Build;
 import android.preference.PreferenceManager;
 import android.support.annotation.RequiresApi;
-import android.support.design.widget.TextInputEditText;
 import android.support.design.widget.TextInputLayout;
 import android.support.v7.widget.AppCompatButton;
 import android.support.v7.widget.AppCompatEditText;
@@ -21,7 +20,6 @@ import android.text.SpannableString;
 import android.text.TextUtils;
 import android.text.format.Formatter;
 import android.view.View;
-import android.view.WindowManager;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.Button;
 import android.widget.CheckBox;
@@ -33,7 +31,6 @@ import android.widget.Toast;
 import com.afollestad.materialdialogs.DialogAction;
 import com.afollestad.materialdialogs.MaterialDialog;
 import com.afollestad.materialdialogs.Theme;
-import com.afollestad.materialdialogs.util.DialogUtils;
 import com.amaze.filemanager.R;
 import com.amaze.filemanager.activities.MainActivity;
 import com.amaze.filemanager.activities.superclasses.BasicActivity;
@@ -73,7 +70,6 @@ import com.github.mikephil.charting.utils.ViewPortHandler;
 
 import java.io.File;
 import java.io.IOException;
-import java.lang.ref.WeakReference;
 import java.security.GeneralSecurityException;
 import java.util.ArrayList;
 import java.util.List;
@@ -1012,7 +1008,7 @@ public class GeneralDialogCreation {
         final MaterialDialog.Builder a = new MaterialDialog.Builder(mainActivity);
         a.input(null, mainActivity.getCurrentMainFragment().getCurrentPath(), false,
                 (dialog, charSequence) -> {
-                    boolean isAccessible = FileUtils.isPathAccesible(charSequence.toString(), prefs);
+                    boolean isAccessible = FileUtils.isPathAccessible(charSequence.toString(), prefs);
                     dialog.getActionButton(DialogAction.POSITIVE).setEnabled(isAccessible);
                 });
 

--- a/app/src/main/java/com/amaze/filemanager/ui/views/drawer/Drawer.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/views/drawer/Drawer.java
@@ -230,7 +230,7 @@ public class Drawer implements NavigationView.OnNavigationItemSelectedListener {
             File f = new File(file);
             String name;
             @DrawableRes int icon1 = R.drawable.ic_sd_storage_white_24dp;
-            if ("/storage/emulated/legacy".equals(file) || "/storage/emulated/0".equals(file)) {
+            if ("/storage/emulated/legacy".equals(file) || "/storage/emulated/0".equals(file) || "/mnt/sdcard".equals(file)) {
                 name = resources.getString(R.string.storage);
             } else if ("/storage/sdcard1".equals(file)) {
                 name = resources.getString(R.string.extstorage);
@@ -241,7 +241,7 @@ public class Drawer implements NavigationView.OnNavigationItemSelectedListener {
                 name = "OTG";
                 icon1 = R.drawable.ic_usb_white_24dp;
             } else name = f.getName();
-            if (!f.isDirectory() || f.canExecute()) {
+            if (f.isDirectory() || f.canExecute()) {
                 addNewItem(menu, STORAGES_GROUP, order++, name, new MenuMetadata(file), icon1,
                         R.drawable.ic_show_chart_black_24dp);
                 if(storage_count == 0) firstPath = file;

--- a/app/src/main/java/com/amaze/filemanager/utils/files/FileUtils.java
+++ b/app/src/main/java/com/amaze/filemanager/utils/files/FileUtils.java
@@ -935,7 +935,7 @@ public class FileUtils {
         return false;
     }
 
-    public static boolean isPathAccesible(String dir, SharedPreferences pref) {
+    public static boolean isPathAccessible(String dir, SharedPreferences pref) {
         File f = new File(dir);
         boolean showIfHidden = pref.getBoolean(PreferencesConstants.PREFERENCE_SHOW_HIDDENFILES, false),
                 isDirSelfOrParent = dir.endsWith("/.") || dir.endsWith("/.."),


### PR DESCRIPTION
Fixes #1135. Main change was at `Drawer.refreshDrawer()` (f980909).

Also added `/mnt/sdcard` to list of supported internal storage paths, which is reported by `MainActivity.getStorageDirectories()` on Nexus One ARM emulator running ICS (4.0.3, API 15 without Google API).

Verified with ICS emulator, Galaxy S2 running SlimLP (5.1.1) and Oneplus One running Slim7 (7.1.2) that storage paths are correctly populated into the Drawer.