### PR TITLE
Fix remote file list item not responding on tap, and launchSMB in Android 7

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/fragments/MainFragment.java
+++ b/app/src/main/java/com/amaze/filemanager/fragments/MainFragment.java
@@ -906,12 +906,7 @@ public class MainFragment extends android.support.v4.app.Fragment implements Bot
                     } else {
                         switch (e.getMode()) {
                             case SMB:
-                                try {
-                                    SmbFile smbFile = new SmbFile(e.desc);
-                                    launchSMB(smbFile, e.longSize, getMainActivity());
-                                } catch (MalformedURLException ex) {
-                                    ex.printStackTrace();
-                                }
+                                launchSMB(e.generateBaseFile(), getMainActivity());
                                 break;
                             case SFTP:
                                 Toast.makeText(getContext(), getResources().getString(R.string.please_wait), Toast.LENGTH_LONG).show();
@@ -1648,7 +1643,7 @@ public class MainFragment extends android.support.v4.app.Fragment implements Bot
         }.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
     }
 
-    public static void launchSMB(final SmbFile smbFile, final long si, final Activity activity) {
+    public static void launchSMB(final HybridFileParcelable baseFile, final Activity activity) {
         final Streamer s = Streamer.getInstance();
         new Thread() {
             public void run() {
@@ -1663,12 +1658,12 @@ public class MainFragment extends android.support.v4.app.Fragment implements Bot
                     }
                     */
 
-                    s.setStreamSrc(smbFile, si);
+                    s.setStreamSrc(new SmbFile(baseFile.getPath()), baseFile.getSize());
                     activity.runOnUiThread(() -> {
                         try {
-                            Uri uri = Uri.parse(Streamer.URL + Uri.fromFile(new File(Uri.parse(smbFile.getPath()).getPath())).getEncodedPath());
+                            Uri uri = Uri.parse(Streamer.URL + Uri.fromFile(new File(Uri.parse(baseFile.getPath()).getPath())).getEncodedPath());
                             Intent i = new Intent(Intent.ACTION_VIEW);
-                            i.setDataAndType(uri, MimeTypes.getMimeType(smbFile.getPath(), smbFile.isDirectory()));
+                            i.setDataAndType(uri, MimeTypes.getMimeType(baseFile.getPath(), baseFile.isDirectory()));
                             PackageManager packageManager = activity.getPackageManager();
                             List<ResolveInfo> resInfos = packageManager.queryIntentActivities(i, 0);
                             if (resInfos != null && resInfos.size() > 0)
@@ -1677,7 +1672,7 @@ public class MainFragment extends android.support.v4.app.Fragment implements Bot
                                 Toast.makeText(activity,
                                         activity.getResources().getString(R.string.smb_launch_error),
                                         Toast.LENGTH_SHORT).show();
-                        } catch (ActivityNotFoundException | SmbException e) {
+                        } catch (ActivityNotFoundException e) {
                             e.printStackTrace();
                         }
                     });

--- a/app/src/main/java/com/amaze/filemanager/utils/SmbStreamer/StreamServer.java
+++ b/app/src/main/java/com/amaze/filemanager/utils/SmbStreamer/StreamServer.java
@@ -7,6 +7,7 @@ package com.amaze.filemanager.utils.SmbStreamer;
 import android.net.Uri;
 import android.util.Log;
 
+import com.amaze.filemanager.utils.cloud.CloudStreamer;
 import com.amaze.filemanager.utils.cloud.CloudUtil;
 
 import java.io.BufferedReader;
@@ -19,6 +20,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.PrintWriter;
+import java.net.BindException;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.util.Date;
@@ -170,7 +172,7 @@ public abstract class StreamServer {
     public StreamServer( int port, File wwwroot ) throws IOException {
         myTcpPort = port;
         this.myRootDir = wwwroot;
-        myServerSocket = new ServerSocket( myTcpPort );
+        myServerSocket = tryBind(myTcpPort);
         myThread = new Thread(() -> {
             try {
                 while (true) {
@@ -194,6 +196,25 @@ public abstract class StreamServer {
             myThread.join();
         } catch (IOException | InterruptedException e) {
         }
+    }
+
+    /**
+     * Since CloudStreamServer and Streamer both uses the same port, shutdown the CloudStreamer before
+     * acquiring the port.
+     *
+     * @param port
+     * @return ServerSocket
+     * @throws IOException
+     */
+    private ServerSocket tryBind(int port) throws IOException {
+        ServerSocket socket;
+        try {
+            socket = new ServerSocket(port);
+        } catch (BindException ifPortIsOccupiedByCloudStreamer) {
+            CloudStreamer.getInstance().stop();
+            socket = new ServerSocket(port);
+        }
+        return socket;
     }
 
     /**

--- a/app/src/main/java/com/amaze/filemanager/utils/SmbStreamer/Streamer.java
+++ b/app/src/main/java/com/amaze/filemanager/utils/SmbStreamer/Streamer.java
@@ -54,6 +54,12 @@ public class Streamer extends StreamServer {
     }
 
     @Override
+    public void stop() {
+        super.stop();
+        instance = null;
+    }
+
+    @Override
     public Response serve(String uri, String method, Properties header, Properties parms, Properties files) {
         Response res = null;
         try {

--- a/app/src/main/java/com/amaze/filemanager/utils/cloud/CloudStreamer.java
+++ b/app/src/main/java/com/amaze/filemanager/utils/cloud/CloudStreamer.java
@@ -52,6 +52,12 @@ public class CloudStreamer extends CloudStreamServer {
     }
 
     @Override
+    public void stop() {
+        super.stop();
+        instance = null;
+    }
+
+    @Override
     public CloudStreamServer.Response serve(String uri, String method, Properties header, Properties parms, Properties files) {
         CloudStreamServer.Response res = null;
         try {


### PR DESCRIPTION
It was found that after opening a file through `CloudStreamer`, file list item will not respond to taps (view action gesture) if it requires using `Streamer`, and vice versa.

In short, open a file e.g. on a storage cloud (Onedrive, Dropbox, Google Drive, etc) followed by open a file on a SMB server will fail.

Allocating `CloudStreamer` and `Streamer` to different ports is a quick fix; in this PR `CloudStreamer` will close `Streamer` instance on acquiring the listening port, and vice versa.

Additionally, this PR also fixes `MainFragment.launchSMB()` which caused app to crash from `android.os.NetworkOnMainThreadException` in Android 7, when attempt to open a file on a SMB server.

Tested with Oneplus One running Slim7 (7.1.2), Galaxy S2 running SlimLP (5.1.1) and Nougat emulator.