### PR TITLE
Add 7zip Types

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -111,6 +111,8 @@ dependencies {
     implementation group: 'org.slf4j', name: 'slf4j-api', version: '1.7.25'
     // https://mvnrepository.com/artifact/org.slf4j/slf4j-simple
     implementation group: 'org.slf4j', name: 'slf4j-simple', version: '1.7.21'
+    // Dependency for 7zip Decompression
+    implementation group: 'org.tukaani', name: 'xz', version: '1.8'
 
     //implementation files('libs/ftplet-api-1.1.0-SNAPSHOT.jar')
     // https://mvnrepository.com/artifact/org.apache.ftpserver/ftplet-api

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -75,6 +75,7 @@
                 <data android:mimeType="application/zip" />
                 <data android:mimeType="application/rar" />
                 <data android:mimeType="application/x-rar-compressed"/><!--<category android:name="android.intent.category.OPENABLE" />-->
+                <data android:mimeType="application/x-7z-compressed" />
                 <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
 

--- a/app/src/main/java/com/amaze/filemanager/adapters/CompressedExplorerAdapter.java
+++ b/app/src/main/java/com/amaze/filemanager/adapters/CompressedExplorerAdapter.java
@@ -212,7 +212,7 @@ public class CompressedExplorerAdapter extends RecyclerView.Adapter<CompressedIt
                 holder.genericIcon.setImageDrawable(folder);
                 gradientDrawable.setColor(Color.parseColor(compressedExplorerFragment.iconskin));
                 if (stringBuilder.toString().length() > 0) {
-                    stringBuilder.deleteCharAt(rowItem.name.length() - 1);
+                    if (rowItem.name.endsWith(CompressedHelper.SEPARATOR)) stringBuilder.deleteCharAt(rowItem.name.length() - 1);
                     try {
                         holder.txtTitle.setText(stringBuilder.toString().substring(stringBuilder.toString().lastIndexOf("/") + 1));
                     } catch (Exception e) {
@@ -264,7 +264,7 @@ public class CompressedExplorerAdapter extends RecyclerView.Adapter<CompressedIt
                     toggleChecked(position, holder.checkImageView);
                 } else {
                     final StringBuilder stringBuilder = new StringBuilder(rowItem.name);
-                    if (rowItem.directory)
+                    if (rowItem.name.endsWith(CompressedHelper.SEPARATOR))
                         stringBuilder.deleteCharAt(rowItem.name.length() - 1);
 
                     if (rowItem.directory) {

--- a/app/src/main/java/com/amaze/filemanager/adapters/RecyclerAdapter.java
+++ b/app/src/main/java/com/amaze/filemanager/adapters/RecyclerAdapter.java
@@ -861,7 +861,8 @@ public class RecyclerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
 
             if (description.endsWith(".zip") || description.endsWith(".jar")
                     || description.endsWith(".apk") || description.endsWith(".rar")
-                    || description.endsWith(".tar") || description.endsWith(".tar.gz"))
+                    || description.endsWith(".tar") || description.endsWith(".tar.gz")
+                    || description.endsWith(".7z"))
                 popupMenu.getMenu().findItem(R.id.ex).setVisible(true);
 
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/compress/SevenZipHelperTask.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/compress/SevenZipHelperTask.java
@@ -31,8 +31,7 @@ public class SevenZipHelperTask extends CompressedHelperTask {
         try {
             sevenzFile = new SevenZFile(new File(filePath));
 
-            SevenZArchiveEntry entry;
-            while ((entry = sevenzFile.getNextEntry()) != null) {
+            for (SevenZArchiveEntry entry : sevenzFile.getEntries()) {
                 String name = entry.getName();
                 if (name.endsWith(SEPARATOR)) name = name.substring(0, name.length() - 1);
 

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/compress/SevenZipHelperTask.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/compress/SevenZipHelperTask.java
@@ -1,0 +1,54 @@
+package com.amaze.filemanager.asynchronous.asynctasks.compress;
+
+import com.amaze.filemanager.adapters.data.CompressedObjectParcelable;
+import com.amaze.filemanager.filesystem.compressed.CompressedHelper;
+import com.amaze.filemanager.utils.OnAsyncTaskFinished;
+
+import org.apache.commons.compress.archivers.sevenz.SevenZArchiveEntry;
+import org.apache.commons.compress.archivers.sevenz.SevenZFile;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+
+import static com.amaze.filemanager.filesystem.compressed.CompressedHelper.SEPARATOR;
+
+public class SevenZipHelperTask extends CompressedHelperTask {
+
+    private String filePath, relativePath;
+
+    public SevenZipHelperTask(String filePath, String relativePath, boolean goBack,
+                         OnAsyncTaskFinished<ArrayList<CompressedObjectParcelable>> l) {
+        super(goBack, l);
+        this.filePath = filePath;
+        this.relativePath = relativePath;
+    }
+
+    @Override
+    void addElements(ArrayList<CompressedObjectParcelable> elements) {
+        SevenZFile sevenzFile = null;
+        try {
+            sevenzFile = new SevenZFile(new File(filePath));
+
+            SevenZArchiveEntry entry;
+            while ((entry = sevenzFile.getNextEntry()) != null) {
+                String name = entry.getName();
+                if (name.endsWith(SEPARATOR)) name = name.substring(0, name.length() - 1);
+
+                boolean isInBaseDir = relativePath.equals("") && !name.contains(SEPARATOR);
+                boolean isInRelativeDir = name.contains(SEPARATOR)
+                        && name.substring(0, name.lastIndexOf(SEPARATOR)).equals(relativePath);
+
+                if (isInBaseDir || isInRelativeDir) {
+                    elements.add(new CompressedObjectParcelable(entry.getName(),
+                            entry.getLastModifiedDate().getTime(), entry.getSize(), entry.isDirectory()));
+                }
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+    }
+
+}

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/compress/SevenZipHelperTask.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/compress/SevenZipHelperTask.java
@@ -1,14 +1,12 @@
 package com.amaze.filemanager.asynchronous.asynctasks.compress;
 
 import com.amaze.filemanager.adapters.data.CompressedObjectParcelable;
-import com.amaze.filemanager.filesystem.compressed.CompressedHelper;
 import com.amaze.filemanager.utils.OnAsyncTaskFinished;
 
 import org.apache.commons.compress.archivers.sevenz.SevenZArchiveEntry;
 import org.apache.commons.compress.archivers.sevenz.SevenZFile;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 
@@ -33,8 +31,6 @@ public class SevenZipHelperTask extends CompressedHelperTask {
 
             for (SevenZArchiveEntry entry : sevenzFile.getEntries()) {
                 String name = entry.getName();
-                if (name.endsWith(SEPARATOR)) name = name.substring(0, name.length() - 1);
-
                 boolean isInBaseDir = relativePath.equals("") && !name.contains(SEPARATOR);
                 boolean isInRelativeDir = name.contains(SEPARATOR)
                         && name.substring(0, name.lastIndexOf(SEPARATOR)).equals(relativePath);

--- a/app/src/main/java/com/amaze/filemanager/filesystem/compressed/CompressedHelper.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/compressed/CompressedHelper.java
@@ -8,9 +8,11 @@ import com.amaze.filemanager.filesystem.compressed.showcontents.helpers.GzipDeco
 import com.amaze.filemanager.filesystem.compressed.showcontents.helpers.RarDecompressor;
 import com.amaze.filemanager.filesystem.compressed.showcontents.helpers.ZipDecompressor;
 import com.amaze.filemanager.filesystem.compressed.showcontents.helpers.TarDecompressor;
+import com.amaze.filemanager.filesystem.compressed.showcontents.helpers.SevenZipDecompressor;
 import com.amaze.filemanager.filesystem.compressed.extractcontents.Extractor;
 import com.amaze.filemanager.filesystem.compressed.extractcontents.helpers.TarExtractor;
 import com.amaze.filemanager.filesystem.compressed.extractcontents.helpers.ZipExtractor;
+import com.amaze.filemanager.filesystem.compressed.extractcontents.helpers.SevenZipExtractor;
 import com.amaze.filemanager.filesystem.compressed.showcontents.Decompressor;
 import com.amaze.filemanager.utils.Utils;
 
@@ -33,6 +35,7 @@ public class CompressedHelper {
     public static final String fileExtensionTar = "tar";
     public static final String fileExtensionGzipTar = "tar.gz";
     public static final String fileExtensionRar = "rar";
+    public static final String fileExtension7zip = "7z";
 
     /**
      * To add compatibility with other compressed file types edit this method
@@ -50,6 +53,8 @@ public class CompressedHelper {
             extractor = new TarExtractor(context, file.getPath(), outputPath, listener);
         } else if(isGzippedTar(type)) {
             extractor = new GzipExtractor(context, file.getPath(), outputPath, listener);
+        } else if(is7zip(type)) {
+            extractor = new SevenZipExtractor(context, file.getPath(), outputPath, listener);
         } else {
             return null;
         }
@@ -72,6 +77,8 @@ public class CompressedHelper {
             decompressor = new TarDecompressor(context);
         } else if(isGzippedTar(type)) {
             decompressor = new GzipDecompressor(context);
+        } else if(is7zip(type)) {
+            decompressor = new SevenZipDecompressor(context);
         } else {
             return null;
         }
@@ -83,7 +90,7 @@ public class CompressedHelper {
     public static boolean isFileExtractable(String path) {
         String type = getExtension(path);
 
-        return isZip(type) || isTar(type) || isRar(type) || isGzippedTar(type);
+        return isZip(type) || isTar(type) || isRar(type) || isGzippedTar(type) || is7zip(type);
     }
 
     /**
@@ -94,7 +101,7 @@ public class CompressedHelper {
      */
     public static String getFileName(String compressedName) {
         compressedName = compressedName.toLowerCase();
-        if(isZip(compressedName) || isTar(compressedName) || isRar(compressedName)) {
+        if(isZip(compressedName) || isTar(compressedName) || isRar(compressedName) || is7zip(compressedName)) {
             return compressedName.substring(0, compressedName.lastIndexOf("."));
         } else if (isGzippedTar(compressedName)) {
             return compressedName.substring(0,
@@ -119,6 +126,10 @@ public class CompressedHelper {
 
     private static boolean isRar(String type) {
         return type.endsWith(fileExtensionRar);
+    }
+    
+    private static boolean is7zip(String type) {
+        return type.endsWith(fileExtension7zip);
     }
 
     private static String getExtension(String path) {

--- a/app/src/main/java/com/amaze/filemanager/filesystem/compressed/extractcontents/helpers/SevenZipExtractor.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/compressed/extractcontents/helpers/SevenZipExtractor.java
@@ -1,0 +1,82 @@
+package com.amaze.filemanager.filesystem.compressed.extractcontents.helpers;
+
+import android.content.Context;
+import android.support.annotation.NonNull;
+
+import com.amaze.filemanager.filesystem.FileUtil;
+import com.amaze.filemanager.filesystem.compressed.CompressedHelper;
+import com.amaze.filemanager.filesystem.compressed.extractcontents.Extractor;
+import com.amaze.filemanager.utils.ServiceWatcherUtil;
+import com.amaze.filemanager.utils.files.GenericCopyUtil;
+
+import org.apache.commons.compress.archivers.sevenz.SevenZArchiveEntry;
+import org.apache.commons.compress.archivers.sevenz.SevenZFile;
+import org.apache.commons.compress.archivers.sevenz.SevenZMethodConfiguration;
+import org.apache.commons.compress.archivers.sevenz.SevenZOutputFile;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+
+public class SevenZipExtractor extends Extractor {
+
+    public SevenZipExtractor(Context context, String filePath, String outputPath, OnUpdate listener) {
+        super(context, filePath, outputPath, listener);
+    }
+
+    @Override
+    protected void extractWithFilter(@NonNull Filter filter) throws IOException {
+        long totalBytes = 0;
+        SevenZFile sevenzFile = new SevenZFile(new File(filePath));
+        ArrayList<SevenZArchiveEntry> arrayList = new ArrayList<>();
+
+        // iterating archive elements to find file names that are to be extracted
+        for (SevenZArchiveEntry entry : sevenzFile.getEntries()) {
+            if (filter.shouldExtract(entry.getName(), entry.isDirectory())) {
+                // Entry to be extracted is atleast the entry path (may be more, when it is a directory)
+                arrayList.add(entry);
+                totalBytes += entry.getSize();
+            }
+        }
+
+        listener.onStart(totalBytes, arrayList.get(0).getName());
+
+        SevenZArchiveEntry entry;
+        while ((entry = sevenzFile.getNextEntry()) != null) {
+            if (!listener.isCancelled()) {
+                listener.onUpdate(entry.getName());
+                extractEntry(context, sevenzFile, entry, outputPath);
+            }
+        }
+        listener.onFinish(); 
+    }
+
+    private void extractEntry(@NonNull final Context context, SevenZFile sevenzFile, SevenZArchiveEntry entry, String outputDir)
+            throws IOException {
+        String name = entry.getName();
+
+        if (entry.isDirectory()) {
+            FileUtil.mkdir(new File(outputDir, name), context);
+            return;
+        }
+        File outputFile = new File(outputDir, name);
+        if (!outputFile.getParentFile().exists()) {
+            FileUtil.mkdir(outputFile.getParentFile(), context);
+        }
+        //	Log.i("Amaze", "Extracting: " + entry);
+
+        BufferedOutputStream outputStream = new BufferedOutputStream(
+                FileUtil.getOutputStream(outputFile, context));
+        try {
+            // No specific File Streams, only for the Full Archive, therefore no buffering...
+            byte content[] = new byte[(int)entry.getSize()];
+            ServiceWatcherUtil.position += sevenzFile.read(content, 0, content.length);
+            outputStream.write(content, 0, content.length);
+        } finally {
+            outputStream.close();
+        }
+    }
+
+}

--- a/app/src/main/java/com/amaze/filemanager/filesystem/compressed/extractcontents/helpers/SevenZipExtractor.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/compressed/extractcontents/helpers/SevenZipExtractor.java
@@ -66,18 +66,23 @@ public class SevenZipExtractor extends Extractor {
         if (!outputFile.getParentFile().exists()) {
             FileUtil.mkdir(outputFile.getParentFile(), context);
         }
-        //	Log.i("Amaze", "Extracting: " + entry);
+        // Log.i("Amaze", "Extracting: " + entry);
 
         BufferedOutputStream outputStream = new BufferedOutputStream(
                 FileUtil.getOutputStream(outputFile, context));
+ 
+        byte[] content = new byte[GenericCopyUtil.DEFAULT_BUFFER_SIZE];
+        long progress=0;
         try {
-            // No specific File Streams, only for the Full Archive, therefore no buffering...
-            byte content[] = new byte[(int)entry.getSize()];
-            int len;
-            len = sevenzFile.read(content, 0, content.length);
-            ServiceWatcherUtil.position += len;
-            outputStream.write(content, 0, content.length);
-
+            while (progress<entry.getSize()) {
+                int length;
+                int bytesLeft = new Long(entry.getSize()-progress).intValue();
+                length = sevenzFile.read(content, 0,
+                        bytesLeft>GenericCopyUtil.DEFAULT_BUFFER_SIZE ? GenericCopyUtil.DEFAULT_BUFFER_SIZE : bytesLeft);
+                outputStream.write(content, 0, length);
+                ServiceWatcherUtil.position+=length;
+                progress+=length;
+            }
         } finally {
             outputStream.close();
         }

--- a/app/src/main/java/com/amaze/filemanager/filesystem/compressed/showcontents/helpers/SevenZipDecompressor.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/compressed/showcontents/helpers/SevenZipDecompressor.java
@@ -1,0 +1,24 @@
+package com.amaze.filemanager.filesystem.compressed.showcontents.helpers;
+
+import android.content.Context;
+
+import com.amaze.filemanager.asynchronous.asynctasks.compress.SevenZipHelperTask;
+import com.amaze.filemanager.adapters.data.CompressedObjectParcelable;
+import com.amaze.filemanager.filesystem.compressed.CompressedHelper;
+import com.amaze.filemanager.filesystem.compressed.showcontents.Decompressor;
+import com.amaze.filemanager.utils.OnAsyncTaskFinished;
+
+import java.util.ArrayList;
+
+public class SevenZipDecompressor extends Decompressor {
+
+    public SevenZipDecompressor(Context context) {
+        super(context);
+    }
+
+    @Override
+    public SevenZipHelperTask changePath(String path, boolean addGoBackItem,
+                                       OnAsyncTaskFinished<ArrayList<CompressedObjectParcelable>> onFinish) {
+        return new SevenZipHelperTask(filePath, path, addGoBackItem, onFinish);
+    }
+}

--- a/app/src/main/java/com/amaze/filemanager/ui/icons/MimeTypes.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/icons/MimeTypes.java
@@ -84,6 +84,7 @@ public final class MimeTypes {
         MIME_TYPES.put("bz2", "application/x-bzip2");
         MIME_TYPES.put("cab", "application/vnd.ms-cab-compressed");
         MIME_TYPES.put("gz", "application/x-gzip");
+        MIME_TYPES.put("7z", "application/x-7z-compressed");
         MIME_TYPES.put("lrf", "application/octet-stream");
         MIME_TYPES.put("jar", "application/java-archive");
         MIME_TYPES.put("xz", "application/x-xz");


### PR DESCRIPTION
Closes #163 

## Background:
I wanted an open-source File Manager. Found this one, seemed nice.
OH NOES! IT DOES NOT SUPPORT MY FAVOURITE ARCHIVE FORMAT (7z)!
Good thing I know some ʳᵉᵃᶫᶫʸ, ʳᵉᵃᶫᶫʸ ᵇᵃᵈ Java and it's open-source after all!

## Implementation:
- One added Dependency: XZ for Java. Commons-Compress requires XZ for Java for 7zip (http://commons.apache.org/proper/commons-compress/limitations.html)
- Add 7z extension to RecyclerAdapter, CompressedHelper and MimeTypes
- Implements SevenZipHelperTask, SevenZipExtractor, SevenZipDecompressor

- SevenZipHelperTask is pretty much copy-pasted from Gzip and rebranded
- SevenZipExtractor is not as good as could be, I admit. It does is job though. One problem: It doesn't buffer, as I couldn't find a way to do it with commons-compress
- SevenZipDecompressor is also copy-pasted from Gzip, rebranded

This is probably my first and last meaningful addition here, cuz I really don't know that much about file managers :P 

Sorry for it being this bad, just wanted some 7z support.

And lastly, thank you for making this app!

P.S. "7zip type**s**", as 7zip archives can use different compression algorithms