### PR TITLE
Fix USB OTG

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/activities/MainActivity.java
+++ b/app/src/main/java/com/amaze/filemanager/activities/MainActivity.java
@@ -46,7 +46,6 @@ import android.os.HandlerThread;
 import android.service.quicksettings.TileService;
 import android.support.annotation.NonNull;
 import android.support.design.widget.AppBarLayout;
-import android.support.design.widget.CoordinatorLayout;
 import android.support.design.widget.Snackbar;
 import android.support.v4.app.ActivityCompat.OnRequestPermissionsResultCallback;
 import android.support.v4.app.Fragment;
@@ -65,7 +64,6 @@ import android.view.Window;
 import android.view.WindowManager;
 import android.view.animation.DecelerateInterpolator;
 import android.widget.FrameLayout;
-import android.widget.LinearLayout;
 import android.widget.Toast;
 
 import com.afollestad.materialdialogs.DialogAction;
@@ -1568,7 +1566,7 @@ public class MainActivity extends ThemedActivity implements OnRequestPermissions
                 if (b) {
                     tabHandler.clear();
 
-                    if (drawer.getStorageCount() > 1) {
+                    if (drawer.getPhoneStorageCount() > 1) {
                         tabHandler.addTab(new Tab(1, drawer.getSecondPath(), "/"));
                     } else {
                         tabHandler.addTab(new Tab(1, "/", "/"));

--- a/app/src/main/java/com/amaze/filemanager/activities/MainActivity.java
+++ b/app/src/main/java/com/amaze/filemanager/activities/MainActivity.java
@@ -1316,16 +1316,18 @@ public class MainActivity extends ThemedActivity implements OnRequestPermissions
                     mainActivityHelper.compressFiles(new File(oppathe), oparrayList);
             }
             operation = -1;
-        } else if (requestCode == REQUEST_CODE_SAF && responseCode == Activity.RESULT_OK) {
-            // otg access
-            String usbOtgRoot = intent.getData() != null? intent.getData().toString():null;
-            UsbOtgSingleton.getInstance().setUsbOtgRoot(usbOtgRoot);
+        } else if (requestCode == REQUEST_CODE_SAF) {
+            if (responseCode == Activity.RESULT_OK) {
+                // otg access
+                String usbOtgRoot = intent.getData() != null ? intent.getData().toString() : null;
+                UsbOtgSingleton.getInstance().setUsbOtgRoot(usbOtgRoot);
 
-            drawer.closeIfNotLocked();
-            if(drawer.isLocked()) drawer.onDrawerClosed();
-        } else if (requestCode == REQUEST_CODE_SAF && responseCode != Activity.RESULT_OK) {
-            // otg access not provided
-            drawer.resetPendingPath();
+                drawer.closeIfNotLocked();
+                if (drawer.isLocked()) drawer.onDrawerClosed();
+            } else {
+                // otg access not provided
+                drawer.resetPendingPath();
+            }
         }
     }
 

--- a/app/src/main/java/com/amaze/filemanager/activities/MainActivity.java
+++ b/app/src/main/java/com/amaze/filemanager/activities/MainActivity.java
@@ -634,8 +634,7 @@ public class MainActivity extends ThemedActivity implements OnRequestPermissions
      * @return true if device is connected
      */
     private boolean isUsbDeviceConnected() {
-        UsbManager usbManager = (UsbManager) getSystemService(USB_SERVICE);
-        if (usbManager.getDeviceList().size()!=0) {
+        if (OTGUtil.isMassStorageDeviceConnected(this)) {
             // we need to set this every time as there is no way to know that whether USB device was
             // disconnected after closing the app and another one was connected
             // in that case the URI will obviously change

--- a/app/src/main/java/com/amaze/filemanager/activities/MainActivity.java
+++ b/app/src/main/java/com/amaze/filemanager/activities/MainActivity.java
@@ -633,12 +633,14 @@ public class MainActivity extends ThemedActivity implements OnRequestPermissions
      */
     private boolean isUsbDeviceConnected() {
         if (OTGUtil.isMassStorageDeviceConnected(this)) {
-            // we need to set this every time as there is no way to know that whether USB device was
-            // disconnected after closing the app and another one was connected
-            // in that case the URI will obviously change
-            // other wise we could persist the URI even after reopening the app by not writing
-            // this preference when it's not null
-            UsbOtgSingleton.getInstance().setUsbOtgRoot(null);
+            if(!UsbOtgSingleton.getInstance().hasRootBeenRequested()) {
+                UsbOtgSingleton.getInstance().setHasRootBeenRequested(false);
+                // we need to set this every time as there is no way to know that whether USB device was
+                // disconnected after closing the app and another one was connected in that case
+                // the URI will obviously change otherwise we could persist the URI even after
+                // reopening the app by not writing this preference when it's not null
+                UsbOtgSingleton.getInstance().setUsbOtgRoot(null);
+            }
             return true;
         } else {
             UsbOtgSingleton.getInstance().setUsbOtgRoot(null);
@@ -1319,7 +1321,7 @@ public class MainActivity extends ThemedActivity implements OnRequestPermissions
         } else if (requestCode == REQUEST_CODE_SAF) {
             if (responseCode == Activity.RESULT_OK && intent.getData() != null) {
                 // otg access
-                String usbOtgRoot = intent.getData().toString();
+                Uri usbOtgRoot = Uri.parse(intent.getData().toString());
                 UsbOtgSingleton.getInstance().setUsbOtgRoot(usbOtgRoot);
 
                 drawer.closeIfNotLocked();

--- a/app/src/main/java/com/amaze/filemanager/activities/MainActivity.java
+++ b/app/src/main/java/com/amaze/filemanager/activities/MainActivity.java
@@ -87,7 +87,7 @@ import com.amaze.filemanager.filesystem.HybridFile;
 import com.amaze.filemanager.filesystem.HybridFileParcelable;
 import com.amaze.filemanager.filesystem.PasteHelper;
 import com.amaze.filemanager.filesystem.RootHelper;
-import com.amaze.filemanager.filesystem.UsbOtgSingleton;
+import com.amaze.filemanager.filesystem.SingletonUsbOtg;
 import com.amaze.filemanager.filesystem.ssh.CustomSshJConfig;
 import com.amaze.filemanager.filesystem.ssh.SshConnectionPool;
 import com.amaze.filemanager.fragments.AppsListFragment;
@@ -633,17 +633,17 @@ public class MainActivity extends ThemedActivity implements OnRequestPermissions
      */
     private boolean isUsbDeviceConnected() {
         if (OTGUtil.isMassStorageDeviceConnected(this)) {
-            if(!UsbOtgSingleton.getInstance().hasRootBeenRequested()) {
-                UsbOtgSingleton.getInstance().setHasRootBeenRequested(false);
+            if(!SingletonUsbOtg.getInstance().hasRootBeenRequested()) {
+                SingletonUsbOtg.getInstance().setHasRootBeenRequested(false);
                 // we need to set this every time as there is no way to know that whether USB device was
                 // disconnected after closing the app and another one was connected in that case
                 // the URI will obviously change otherwise we could persist the URI even after
                 // reopening the app by not writing this preference when it's not null
-                UsbOtgSingleton.getInstance().setUsbOtgRoot(null);
+                SingletonUsbOtg.getInstance().setUsbOtgRoot(null);
             }
             return true;
         } else {
-            UsbOtgSingleton.getInstance().setUsbOtgRoot(null);
+            SingletonUsbOtg.getInstance().setUsbOtgRoot(null);
             return false;
         }
     }
@@ -1099,10 +1099,10 @@ public class MainActivity extends ThemedActivity implements OnRequestPermissions
         @Override
         public void onReceive(Context context, Intent intent) {
             if (intent.getAction().equals(UsbManager.ACTION_USB_DEVICE_ATTACHED)) {
-                UsbOtgSingleton.getInstance().setUsbOtgRoot(null);
+                SingletonUsbOtg.getInstance().setUsbOtgRoot(null);
                 drawer.refreshDrawer();
             } else if (intent.getAction().equals(UsbManager.ACTION_USB_DEVICE_DETACHED)) {
-                UsbOtgSingleton.getInstance().setUsbOtgRoot(null);
+                SingletonUsbOtg.getInstance().setUsbOtgRoot(null);
                 drawer.refreshDrawer();
                 goToMain(null);
             }
@@ -1322,7 +1322,7 @@ public class MainActivity extends ThemedActivity implements OnRequestPermissions
             if (responseCode == Activity.RESULT_OK && intent.getData() != null) {
                 // otg access
                 Uri usbOtgRoot = Uri.parse(intent.getData().toString());
-                UsbOtgSingleton.getInstance().setUsbOtgRoot(usbOtgRoot);
+                SingletonUsbOtg.getInstance().setUsbOtgRoot(usbOtgRoot);
 
                 drawer.closeIfNotLocked();
                 if (drawer.isLocked()) drawer.onDrawerClosed();
@@ -1540,7 +1540,7 @@ public class MainActivity extends ThemedActivity implements OnRequestPermissions
 
             if (SDK_INT >= Build.VERSION_CODES.KITKAT) {
                 if (intent.getAction().equals(UsbManager.ACTION_USB_DEVICE_DETACHED)) {
-                    UsbOtgSingleton.getInstance().setUsbOtgRoot(null);
+                    SingletonUsbOtg.getInstance().setUsbOtgRoot(null);
                     drawer.refreshDrawer();
                 }
             }

--- a/app/src/main/java/com/amaze/filemanager/activities/MainActivity.java
+++ b/app/src/main/java/com/amaze/filemanager/activities/MainActivity.java
@@ -1317,14 +1317,15 @@ public class MainActivity extends ThemedActivity implements OnRequestPermissions
             }
             operation = -1;
         } else if (requestCode == REQUEST_CODE_SAF) {
-            if (responseCode == Activity.RESULT_OK) {
+            if (responseCode == Activity.RESULT_OK && intent.getData() != null) {
                 // otg access
-                String usbOtgRoot = intent.getData() != null ? intent.getData().toString() : null;
+                String usbOtgRoot = intent.getData().toString();
                 UsbOtgSingleton.getInstance().setUsbOtgRoot(usbOtgRoot);
 
                 drawer.closeIfNotLocked();
                 if (drawer.isLocked()) drawer.onDrawerClosed();
             } else {
+                Toast.makeText(this, R.string.error, Toast.LENGTH_SHORT).show();
                 // otg access not provided
                 drawer.resetPendingPath();
             }

--- a/app/src/main/java/com/amaze/filemanager/filesystem/HybridFile.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/HybridFile.java
@@ -2,6 +2,7 @@ package com.amaze.filemanager.filesystem;
 
 import android.content.ContentResolver;
 import android.content.Context;
+import android.content.SharedPreferences;
 import android.os.Build;
 import android.preference.PreferenceManager;
 import android.support.annotation.NonNull;

--- a/app/src/main/java/com/amaze/filemanager/filesystem/SingletonUsbOtg.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/SingletonUsbOtg.java
@@ -1,14 +1,13 @@
 package com.amaze.filemanager.filesystem;
 
 import android.net.Uri;
-import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
-public class UsbOtgSingleton {
-    private static UsbOtgSingleton instance = null;
+public class SingletonUsbOtg {
+    private static SingletonUsbOtg instance = null;
 
-    public static UsbOtgSingleton getInstance() {
-        if(instance == null) instance = new UsbOtgSingleton();
+    public static SingletonUsbOtg getInstance() {
+        if(instance == null) instance = new SingletonUsbOtg();
         return instance;
     }
 
@@ -18,7 +17,7 @@ public class UsbOtgSingleton {
      */
     private boolean hasRootBeenRequested = false;
 
-    private UsbOtgSingleton() { }
+    private SingletonUsbOtg() { }
 
     public void setUsbOtgRoot(@Nullable Uri root) {
         usbOtgRoot = root;

--- a/app/src/main/java/com/amaze/filemanager/filesystem/UsbOtgSingleton.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/UsbOtgSingleton.java
@@ -1,0 +1,26 @@
+package com.amaze.filemanager.filesystem;
+
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+public class UsbOtgSingleton {
+    private static UsbOtgSingleton instance = null;
+
+    public static UsbOtgSingleton getInstance() {
+        if(instance == null) instance = new UsbOtgSingleton();
+        return instance;
+    }
+
+    private String usbOtgRoot = null;
+
+    private UsbOtgSingleton() { }
+
+    public void setUsbOtgRoot(@Nullable String root) {
+        usbOtgRoot = root;
+    }
+
+    public @Nullable String getUsbOtgRoot() {
+        return usbOtgRoot;
+    }
+
+}

--- a/app/src/main/java/com/amaze/filemanager/filesystem/UsbOtgSingleton.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/UsbOtgSingleton.java
@@ -1,5 +1,6 @@
 package com.amaze.filemanager.filesystem;
 
+import android.net.Uri;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
@@ -11,16 +12,28 @@ public class UsbOtgSingleton {
         return instance;
     }
 
-    private String usbOtgRoot = null;
+    private Uri usbOtgRoot = null;
+    /**
+     * Indicates whether last app exit was for setting {@link #usbOtgRoot} or not
+     */
+    private boolean hasRootBeenRequested = false;
 
     private UsbOtgSingleton() { }
 
-    public void setUsbOtgRoot(@Nullable String root) {
+    public void setUsbOtgRoot(@Nullable Uri root) {
         usbOtgRoot = root;
     }
 
-    public @Nullable String getUsbOtgRoot() {
+    public @Nullable Uri getUsbOtgRoot() {
         return usbOtgRoot;
+    }
+
+    public void setHasRootBeenRequested(boolean hasRootBeenRequested) {
+        this.hasRootBeenRequested = hasRootBeenRequested;
+    }
+
+    public boolean hasRootBeenRequested() {
+        return hasRootBeenRequested;
     }
 
 }

--- a/app/src/main/java/com/amaze/filemanager/ui/views/drawer/Drawer.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/views/drawer/Drawer.java
@@ -31,6 +31,7 @@ import com.amaze.filemanager.activities.PreferencesActivity;
 import com.amaze.filemanager.database.CloudHandler;
 import com.amaze.filemanager.filesystem.HybridFile;
 import com.amaze.filemanager.filesystem.RootHelper;
+import com.amaze.filemanager.filesystem.UsbOtgSingleton;
 import com.amaze.filemanager.fragments.AppsListFragment;
 import com.amaze.filemanager.fragments.CloudSheetFragment;
 import com.amaze.filemanager.fragments.FTPServerFragment;
@@ -538,9 +539,7 @@ public class Drawer implements NavigationView.OnNavigationItemSelectedListener {
                 pendingPath = meta.path;
 
                 if (meta.path.contains(OTGUtil.PREFIX_OTG) &&
-                        mainActivity.getPrefs()
-                                .getString(MainActivity.KEY_PREF_OTG, null)
-                                .equals(MainActivity.VALUE_PREF_OTG_NULL)) {
+                        UsbOtgSingleton.getInstance().getUsbOtgRoot() == null) {
                     // we've not gotten otg path yet
                     // start system request for storage access framework
                     Toast.makeText(mainActivity, mainActivity.getString(R.string.otg_access), Toast.LENGTH_LONG).show();

--- a/app/src/main/java/com/amaze/filemanager/ui/views/drawer/Drawer.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/views/drawer/Drawer.java
@@ -58,6 +58,7 @@ import com.cloudrail.si.services.Box;
 import com.cloudrail.si.services.Dropbox;
 import com.cloudrail.si.services.GoogleDrive;
 import com.cloudrail.si.services.OneDrive;
+import com.squareup.haha.perflib.Main;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -542,13 +543,15 @@ public class Drawer implements NavigationView.OnNavigationItemSelectedListener {
 
                 pendingPath = meta.path;
 
-                if (meta.path.contains(OTGUtil.PREFIX_OTG) &&
-                        UsbOtgSingleton.getInstance().getUsbOtgRoot() == null) {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP
+                        && meta.path.contains(OTGUtil.PREFIX_OTG)
+                        && UsbOtgSingleton.getInstance().getUsbOtgRoot() == null) {
                     // we've not gotten otg path yet
                     // start system request for storage access framework
                     Toast.makeText(mainActivity, mainActivity.getString(R.string.otg_access), Toast.LENGTH_LONG).show();
                     Intent safIntent = new Intent(Intent.ACTION_OPEN_DOCUMENT_TREE);
-                    mainActivity.startActivityForResult(safIntent, mainActivity.REQUEST_CODE_SAF);
+
+                    mainActivity.startActivityForResult(safIntent, MainActivity.REQUEST_CODE_SAF);
                 } else {
                     closeIfNotLocked();
                     if (isLocked()) { onDrawerClosed(); }

--- a/app/src/main/java/com/amaze/filemanager/ui/views/drawer/Drawer.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/views/drawer/Drawer.java
@@ -88,7 +88,7 @@ public class Drawer implements NavigationView.OnNavigationItemSelectedListener {
 
     private ActionViewStateManager actionViewStateManager;
     private boolean isSomethingSelected;
-    private volatile int storage_count = 0; // number of storage available (internal/external/otg etc)
+    private volatile int phoneStorageCount = 0; // number of storage available (internal/external/otg etc)
     private boolean isDrawerLocked = false;
     private FragmentTransaction pending_fragmentTransaction;
     private String pendingPath;
@@ -226,8 +226,14 @@ public class Drawer implements NavigationView.OnNavigationItemSelectedListener {
 
         int order = 0;
         ArrayList<String> storageDirectories = mainActivity.getStorageDirectories();
-        storage_count = 0;
+        phoneStorageCount = 0;
         for (String file : storageDirectories) {
+            if (file.contains(OTGUtil.PREFIX_OTG)) {
+                addNewItem(menu, STORAGES_GROUP, order++, "OTG", new MenuMetadata(file),
+                        R.drawable.ic_usb_white_24dp, R.drawable.ic_show_chart_black_24dp);
+                continue;
+            }
+
             File f = new File(file);
             String name;
             @DrawableRes int icon1 = R.drawable.ic_sd_storage_white_24dp;
@@ -238,17 +244,15 @@ public class Drawer implements NavigationView.OnNavigationItemSelectedListener {
             } else if ("/".equals(file)) {
                 name = resources.getString(R.string.rootdirectory);
                 icon1 = R.drawable.ic_drawer_root_white;
-            } else if (file.contains(OTGUtil.PREFIX_OTG)) {
-                name = "OTG";
-                icon1 = R.drawable.ic_usb_white_24dp;
             } else name = f.getName();
+
             if (f.isDirectory() || f.canExecute()) {
                 addNewItem(menu, STORAGES_GROUP, order++, name, new MenuMetadata(file), icon1,
                         R.drawable.ic_show_chart_black_24dp);
-                if(storage_count == 0) firstPath = file;
-                else if(storage_count == 1) secondPath = file;
+                if(phoneStorageCount == 0) firstPath = file;
+                else if(phoneStorageCount == 1) secondPath = file;
 
-                storage_count++;
+                phoneStorageCount++;
             }
         }
         dataUtils.setStorages(storageDirectories);
@@ -602,8 +606,8 @@ public class Drawer implements NavigationView.OnNavigationItemSelectedListener {
         isSomethingSelected = isSelected;
     }
 
-    public int getStorageCount() {
-        return storage_count;
+    public int getPhoneStorageCount() {
+        return phoneStorageCount;
     }
 
     public void setDrawerHeaderBackground() {

--- a/app/src/main/java/com/amaze/filemanager/ui/views/drawer/Drawer.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/views/drawer/Drawer.java
@@ -547,8 +547,9 @@ public class Drawer implements NavigationView.OnNavigationItemSelectedListener {
                     // we've not gotten otg path yet
                     // start system request for storage access framework
                     Toast.makeText(mainActivity, mainActivity.getString(R.string.otg_access), Toast.LENGTH_LONG).show();
-                    Intent safIntent = new Intent(Intent.ACTION_OPEN_DOCUMENT_TREE);
 
+                    UsbOtgSingleton.getInstance().setHasRootBeenRequested(true);
+                    Intent safIntent = new Intent(Intent.ACTION_OPEN_DOCUMENT_TREE);
                     mainActivity.startActivityForResult(safIntent, MainActivity.REQUEST_CODE_SAF);
                 } else {
                     pendingPath = meta.path;

--- a/app/src/main/java/com/amaze/filemanager/ui/views/drawer/Drawer.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/views/drawer/Drawer.java
@@ -31,7 +31,7 @@ import com.amaze.filemanager.activities.PreferencesActivity;
 import com.amaze.filemanager.database.CloudHandler;
 import com.amaze.filemanager.filesystem.HybridFile;
 import com.amaze.filemanager.filesystem.RootHelper;
-import com.amaze.filemanager.filesystem.UsbOtgSingleton;
+import com.amaze.filemanager.filesystem.SingletonUsbOtg;
 import com.amaze.filemanager.fragments.AppsListFragment;
 import com.amaze.filemanager.fragments.CloudSheetFragment;
 import com.amaze.filemanager.fragments.FTPServerFragment;
@@ -58,7 +58,6 @@ import com.cloudrail.si.services.Box;
 import com.cloudrail.si.services.Dropbox;
 import com.cloudrail.si.services.GoogleDrive;
 import com.cloudrail.si.services.OneDrive;
-import com.squareup.haha.perflib.Main;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -543,12 +542,12 @@ public class Drawer implements NavigationView.OnNavigationItemSelectedListener {
 
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP
                         && meta.path.contains(OTGUtil.PREFIX_OTG)
-                        && UsbOtgSingleton.getInstance().getUsbOtgRoot() == null) {
+                        && SingletonUsbOtg.getInstance().getUsbOtgRoot() == null) {
                     // we've not gotten otg path yet
                     // start system request for storage access framework
                     Toast.makeText(mainActivity, mainActivity.getString(R.string.otg_access), Toast.LENGTH_LONG).show();
 
-                    UsbOtgSingleton.getInstance().setHasRootBeenRequested(true);
+                    SingletonUsbOtg.getInstance().setHasRootBeenRequested(true);
                     Intent safIntent = new Intent(Intent.ACTION_OPEN_DOCUMENT_TREE);
                     mainActivity.startActivityForResult(safIntent, MainActivity.REQUEST_CODE_SAF);
                 } else {

--- a/app/src/main/java/com/amaze/filemanager/ui/views/drawer/Drawer.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/views/drawer/Drawer.java
@@ -541,8 +541,6 @@ public class Drawer implements NavigationView.OnNavigationItemSelectedListener {
                     CloudUtil.checkToken(meta.path, mainActivity);
                 }
 
-                pendingPath = meta.path;
-
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP
                         && meta.path.contains(OTGUtil.PREFIX_OTG)
                         && UsbOtgSingleton.getInstance().getUsbOtgRoot() == null) {
@@ -553,6 +551,7 @@ public class Drawer implements NavigationView.OnNavigationItemSelectedListener {
 
                     mainActivity.startActivityForResult(safIntent, MainActivity.REQUEST_CODE_SAF);
                 } else {
+                    pendingPath = meta.path;
                     closeIfNotLocked();
                     if (isLocked()) { onDrawerClosed(); }
                 }

--- a/app/src/main/java/com/amaze/filemanager/utils/OTGUtil.java
+++ b/app/src/main/java/com/amaze/filemanager/utils/OTGUtil.java
@@ -10,6 +10,7 @@ import android.util.Log;
 import com.amaze.filemanager.activities.MainActivity;
 import com.amaze.filemanager.filesystem.HybridFileParcelable;
 import com.amaze.filemanager.filesystem.RootHelper;
+import com.amaze.filemanager.filesystem.UsbOtgSingleton;
 
 import java.util.ArrayList;
 
@@ -45,8 +46,9 @@ public class OTGUtil {
      * @return an array of list of files at the path
      */
     public static void getDocumentFiles(String path, Context context, OnFileFound fileFound) {
-        SharedPreferences manager = PreferenceManager.getDefaultSharedPreferences(context);
-        String rootUriString = manager.getString(MainActivity.KEY_PREF_OTG, null);
+        String rootUriString = UsbOtgSingleton.getInstance().getUsbOtgRoot();
+        if(rootUriString == null) throw new NullPointerException("USB OTG root not set!");
+
         DocumentFile rootUri = DocumentFile.fromTreeUri(context, Uri.parse(rootUriString));
 
         String[] parts = path.split("/");
@@ -81,8 +83,8 @@ public class OTGUtil {
      *                        in case path is not present. Notably useful in opening an output stream.
      */
     public static DocumentFile getDocumentFile(String path, Context context, boolean createRecursive) {
-        SharedPreferences manager = PreferenceManager.getDefaultSharedPreferences(context);
-        String rootUriString = manager.getString(MainActivity.KEY_PREF_OTG, null);
+        String rootUriString = UsbOtgSingleton.getInstance().getUsbOtgRoot();
+        if(rootUriString == null) throw new NullPointerException("USB OTG root not set!");
 
         // start with root of SD card and then parse through document tree.
         DocumentFile rootUri = DocumentFile.fromTreeUri(context, Uri.parse(rootUriString));

--- a/app/src/main/java/com/amaze/filemanager/utils/OTGUtil.java
+++ b/app/src/main/java/com/amaze/filemanager/utils/OTGUtil.java
@@ -1,26 +1,20 @@
 package com.amaze.filemanager.utils;
 
 import android.content.Context;
-import android.content.SharedPreferences;
 import android.hardware.usb.UsbConstants;
 import android.hardware.usb.UsbDevice;
-import android.hardware.usb.UsbInterface;
 import android.hardware.usb.UsbManager;
 import android.net.Uri;
-import android.preference.PreferenceManager;
 import android.support.annotation.NonNull;
 import android.support.v4.provider.DocumentFile;
 import android.util.Log;
 
-import com.amaze.filemanager.activities.MainActivity;
 import com.amaze.filemanager.filesystem.HybridFileParcelable;
 import com.amaze.filemanager.filesystem.RootHelper;
-import com.amaze.filemanager.filesystem.UsbOtgSingleton;
+import com.amaze.filemanager.filesystem.SingletonUsbOtg;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.Map;
 
 import static android.content.Context.USB_SERVICE;
 
@@ -56,7 +50,7 @@ public class OTGUtil {
      * @return an array of list of files at the path
      */
     public static void getDocumentFiles(String path, Context context, OnFileFound fileFound) {
-        Uri rootUriString = UsbOtgSingleton.getInstance().getUsbOtgRoot();
+        Uri rootUriString = SingletonUsbOtg.getInstance().getUsbOtgRoot();
         if(rootUriString == null) throw new NullPointerException("USB OTG root not set!");
 
         DocumentFile rootUri = DocumentFile.fromTreeUri(context, rootUriString);
@@ -93,7 +87,7 @@ public class OTGUtil {
      *                        in case path is not present. Notably useful in opening an output stream.
      */
     public static DocumentFile getDocumentFile(String path, Context context, boolean createRecursive) {
-        Uri rootUriString = UsbOtgSingleton.getInstance().getUsbOtgRoot();
+        Uri rootUriString = SingletonUsbOtg.getInstance().getUsbOtgRoot();
         if(rootUriString == null) throw new NullPointerException("USB OTG root not set!");
 
         // start with root of SD card and then parse through document tree.

--- a/app/src/main/java/com/amaze/filemanager/utils/OTGUtil.java
+++ b/app/src/main/java/com/amaze/filemanager/utils/OTGUtil.java
@@ -56,10 +56,10 @@ public class OTGUtil {
      * @return an array of list of files at the path
      */
     public static void getDocumentFiles(String path, Context context, OnFileFound fileFound) {
-        String rootUriString = UsbOtgSingleton.getInstance().getUsbOtgRoot();
+        Uri rootUriString = UsbOtgSingleton.getInstance().getUsbOtgRoot();
         if(rootUriString == null) throw new NullPointerException("USB OTG root not set!");
 
-        DocumentFile rootUri = DocumentFile.fromTreeUri(context, Uri.parse(rootUriString));
+        DocumentFile rootUri = DocumentFile.fromTreeUri(context, rootUriString);
 
         String[] parts = path.split("/");
         for (String part : parts) {
@@ -93,11 +93,11 @@ public class OTGUtil {
      *                        in case path is not present. Notably useful in opening an output stream.
      */
     public static DocumentFile getDocumentFile(String path, Context context, boolean createRecursive) {
-        String rootUriString = UsbOtgSingleton.getInstance().getUsbOtgRoot();
+        Uri rootUriString = UsbOtgSingleton.getInstance().getUsbOtgRoot();
         if(rootUriString == null) throw new NullPointerException("USB OTG root not set!");
 
         // start with root of SD card and then parse through document tree.
-        DocumentFile rootUri = DocumentFile.fromTreeUri(context, Uri.parse(rootUriString));
+        DocumentFile rootUri = DocumentFile.fromTreeUri(context, rootUriString);
 
         String[] parts = path.split("/");
         for (String part : parts) {

--- a/app/src/main/java/com/amaze/filemanager/utils/OTGUtil.java
+++ b/app/src/main/java/com/amaze/filemanager/utils/OTGUtil.java
@@ -2,8 +2,13 @@ package com.amaze.filemanager.utils;
 
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.hardware.usb.UsbConstants;
+import android.hardware.usb.UsbDevice;
+import android.hardware.usb.UsbInterface;
+import android.hardware.usb.UsbManager;
 import android.net.Uri;
 import android.preference.PreferenceManager;
+import android.support.annotation.NonNull;
 import android.support.v4.provider.DocumentFile;
 import android.util.Log;
 
@@ -13,6 +18,11 @@ import com.amaze.filemanager.filesystem.RootHelper;
 import com.amaze.filemanager.filesystem.UsbOtgSingleton;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static android.content.Context.USB_SERVICE;
 
 /**
  * Created by Vishal on 27-04-2017.
@@ -104,4 +114,27 @@ public class OTGUtil {
 
         return rootUri;
     }
+
+    /**
+     * Checks if there is at least one USB device connected with class MASS STORAGE.
+     */
+    public static boolean isMassStorageDeviceConnected(@NonNull final Context context) {
+        UsbManager usbManager = (UsbManager) context.getSystemService(USB_SERVICE);
+        if(usbManager == null) return false;
+
+        HashMap<String, UsbDevice> devices = usbManager.getDeviceList();
+
+        for (String deviceName : devices.keySet()) {
+            UsbDevice device = devices.get(deviceName);
+
+            for (int i = 0; i < device.getInterfaceCount(); i++){
+                if (device.getInterface(i).getInterfaceClass() == UsbConstants.USB_CLASS_MASS_STORAGE){
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
 }


### PR DESCRIPTION
* USB OTG root path is now saved into a singleton
* Check if USB OTG is of class MASS STORAGE before showing it in Drawer
* Fixed detecting USB OTG, renamed storage_count to phoneStorageCount & it doesn't count OTG devices anymore
* Corrected race condition on USB OTG first opening
* Error toast if USB OTG root selection fails
* UsbOtgSingleton.usbOtgRoot is now Uri and fixed isUsbDeviceConnected() reseting it after connection

Fixes #1164 
Fixes #1162 
Fixes #1055

PS: ActionView in drawer is broken, this doesn't fix it.