### PR TITLE
Broadcast Intent on copy to device finished

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/DeleteTask.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/DeleteTask.java
@@ -152,7 +152,7 @@ public class DeleteTask extends AsyncTask<ArrayList<HybridFileParcelable>, Strin
                 }
             } catch (Exception e) {
                 for (HybridFileParcelable f : files) {
-                    FileUtils.scanFile(f.getPath(), cd);
+                    FileUtils.scanFile(f.getFile(), cd);
                 }
             }
         }

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/MoveFiles.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/MoveFiles.java
@@ -159,8 +159,8 @@ public class MoveFiles extends AsyncTask<ArrayList<String>, Void, Boolean> {
 
             for (int i = 0; i < paths.size(); i++) {
                 for (HybridFileParcelable f : files.get(i)) {
-                    FileUtils.scanFile(f.getPath(), context);
-                    FileUtils.scanFile(paths.get(i) + "/" + f.getName(), context);
+                    FileUtils.scanFile(f.getFile(), context);
+                    FileUtils.scanFile(new File(paths.get(i) + "/" + f.getName()), context);
                 }
             }
 

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/services/CopyService.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/services/CopyService.java
@@ -405,7 +405,7 @@ public class CopyService extends AbstractProgressiveService {
                     failedFOps.add(sourceFile);
                     e.printStackTrace();
                 }
-                FileUtils.scanFile(targetFile.getPath(), c);
+                FileUtils.scanFile(targetFile.getFile(), c);
             }
 
             private void copyFiles(final HybridFileParcelable sourceFile, final HybridFile targetFile,

--- a/app/src/main/java/com/amaze/filemanager/fragments/MainFragment.java
+++ b/app/src/main/java/com/amaze/filemanager/fragments/MainFragment.java
@@ -803,7 +803,7 @@ public class MainFragment extends android.support.v4.app.Fragment implements Bot
                             mediaScannerConnection = new MediaScannerConnection(context, mediaScannerConnectionClient);
                             //FileUtils.scanFile(context, mediaScannerConnection, path);
                         } else {
-                            FileUtils.scanFile(arg, context);
+                            FileUtils.scanFile(new File(arg), context);
                         }
                     }
                     //break;
@@ -1547,7 +1547,8 @@ public class MainFragment extends android.support.v4.app.Fragment implements Bot
     public void hide(String path) {
 
         dataUtils.addHiddenFile(path);
-        if (new File(path).isDirectory()) {
+        File file = new File(path);
+        if (file.isDirectory()) {
             File f1 = new File(path + "/" + ".nomedia");
             if (!f1.exists()) {
                 try {
@@ -1556,7 +1557,7 @@ public class MainFragment extends android.support.v4.app.Fragment implements Bot
                     e.printStackTrace();
                 }
             }
-            FileUtils.scanFile(path, getActivity());
+            FileUtils.scanFile(file, getActivity());
         }
 
     }

--- a/app/src/main/java/com/amaze/filemanager/utils/files/FileUtils.java
+++ b/app/src/main/java/com/amaze/filemanager/utils/files/FileUtils.java
@@ -212,11 +212,11 @@ public class FileUtils {
      * Calls {@link #scanFile(Uri, Context)} using {@link Uri}.
      *
      * @see {@link #scanFile(Uri, Context)}
-     * @param filePath File's absolute path
+     * @param file File to scan
      * @param c {@link Context}
      */
-    public static void scanFile(@NonNull String filePath, @NonNull Context c){
-        scanFile(Uri.fromFile(new File(filePath)), c);
+    public static void scanFile(@NonNull File file, @NonNull Context c){
+        scanFile(Uri.fromFile(file), c);
     }
 
     /**

--- a/app/src/main/java/com/amaze/filemanager/utils/files/FileUtils.java
+++ b/app/src/main/java/com/amaze/filemanager/utils/files/FileUtils.java
@@ -39,6 +39,7 @@ import android.os.CountDownTimer;
 import android.preference.PreferenceManager;
 import android.provider.BaseColumns;
 import android.provider.MediaStore;
+import android.support.annotation.NonNull;
 import android.support.v4.provider.DocumentFile;
 import android.text.TextUtils;
 import android.util.Log;
@@ -207,25 +208,26 @@ public class FileUtils {
         }
     }
 
-    public static void scanFile(String path, Context c) {
-        System.out.println(path + " " + Build.VERSION.SDK_INT);
-
-        Uri contentUri = Uri.fromFile(new File(path));
-        Intent mediaScanIntent = new Intent(Intent.ACTION_MEDIA_SCANNER_SCAN_FILE, contentUri);
-        c.sendBroadcast(mediaScanIntent);
+    /**
+     * Calls {@link #scanFile(Uri, Context)} using {@link Uri}.
+     *
+     * @see {@link #scanFile(Uri, Context)}
+     * @param filePath File's absolute path
+     * @param c {@link Context}
+     */
+    public static void scanFile(@NonNull String filePath, @NonNull Context c){
+        scanFile(Uri.fromFile(new File(filePath)), c);
     }
 
     /**
-     * Starts a media scanner to let file system know changes done to files
+     * Triggers {@link Intent#ACTION_MEDIA_SCANNER_SCAN_FILE} intent to refresh the media store.
+     *
+     * @param uri File's {@link Uri}
+     * @param c {@link Context}
      */
-    public static void scanFile(final Context context, final MediaScannerConnection mediaScannerConnection, final String[] paths) {
-
-        Log.d("SCAN started", paths[0]);
-
-        AppConfig.runInBackground(() -> {
-                mediaScannerConnection.connect();
-                MediaScannerConnection.scanFile(context, paths, null, null);
-        });
+    public static void scanFile(@NonNull Uri uri, @NonNull Context c){
+        Intent mediaScanIntent = new Intent(Intent.ACTION_MEDIA_SCANNER_SCAN_FILE, uri);
+        c.sendBroadcast(mediaScanIntent);
     }
 
     public static void crossfade(View buttons,final View pathbar) {

--- a/app/src/main/java/com/amaze/filemanager/utils/files/GenericCopyUtil.java
+++ b/app/src/main/java/com/amaze/filemanager/utils/files/GenericCopyUtil.java
@@ -299,10 +299,7 @@ public class GenericCopyUtil {
                 if(documentFile == null)
                     documentFile = DocumentFile.fromFile(mTargetFile.getFile());
 
-                Intent intent = new Intent();
-                intent.setAction(Intent.ACTION_MEDIA_SCANNER_SCAN_FILE);
-                intent.setData(documentFile.getUri());
-                mContext.sendBroadcast(intent);
+                FileUtils.scanFile(documentFile.getUri(), mContext);
             }
         }
     }

--- a/app/src/main/java/com/amaze/filemanager/utils/files/GenericCopyUtil.java
+++ b/app/src/main/java/com/amaze/filemanager/utils/files/GenericCopyUtil.java
@@ -1,7 +1,29 @@
+/*
+ * GenericCopyUtil.java
+ *
+ * Copyright © 2016 Vishal Nehra (vishalmeham2 at gmail.com)
+ *
+ * This file is part of AmazeFileManager.
+ *
+ * AmazeFileManager is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * AmazeFileManager is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with AmazeFileManager. If not, see <http ://www.gnu.org/licenses/>.
+ */
+
 package com.amaze.filemanager.utils.files;
 
 import android.content.ContentResolver;
 import android.content.Context;
+import android.content.Intent;
 import android.support.v4.provider.DocumentFile;
 import android.util.Log;
 
@@ -265,6 +287,22 @@ public class GenericCopyUtil {
             } catch (IOException e) {
                 e.printStackTrace();
                 // failure in closing stream
+            }
+
+            //If target file is copied onto the device and copy was successful, trigger media store
+            //rescan
+
+            if((mTargetFile.isLocal() || mTargetFile.isOtgFile()) && mTargetFile.exists(mContext)) {
+
+                DocumentFile documentFile = FileUtil.getDocumentFile(mTargetFile.getFile(), false, mContext);
+                //If FileUtil.getDocumentFile() returns null, fall back to DocumentFile.fromFile()
+                if(documentFile == null)
+                    documentFile = DocumentFile.fromFile(mTargetFile.getFile());
+
+                Intent intent = new Intent();
+                intent.setAction(Intent.ACTION_MEDIA_SCANNER_SCAN_FILE);
+                intent.setData(documentFile.getUri());
+                mContext.sendBroadcast(intent);
             }
         }
     }

--- a/app/src/main/java/com/amaze/filemanager/utils/files/GenericCopyUtil.java
+++ b/app/src/main/java/com/amaze/filemanager/utils/files/GenericCopyUtil.java
@@ -1,7 +1,8 @@
 /*
  * GenericCopyUtil.java
  *
- * Copyright © 2016 Vishal Nehra (vishalmeham2 at gmail.com)
+ * Copyright © 2016-2018 Vishal Nehra (vishalmeham2 at gmail.com),
+ * Raymond Lai (airwave209gt at gmail.com)
  *
  * This file is part of AmazeFileManager.
  *
@@ -53,8 +54,7 @@ import java.nio.channels.FileChannel;
 import java.nio.channels.ReadableByteChannel;
 
 /**
- * Created by vishal on 26/10/16.
- *
+ * 
  * Base class to handle file copy.
  */
 


### PR DESCRIPTION
Broadcast `ACTION_MEDIA_SCANNER_SCAN_FILE` Intent to notify MediaStore a new file had been copied to device.

Steps to reproduce the symptom:
 1. Connect to remote server
 2. Copy an audio file from the remote server to local storage
 3. Copied file won't show up on the music player until reboot or refresh MediaStore

Tested on Oneplus One running Slim7 (7.1.2). I'm using [PlayerPro music player](https://play.google.com/store/apps/details?id=com.tbig.playerpro).

Files copied to the device via embedded FTP server also has the same problem (that reboot or refresh MediaStore is required for it to appear on the device's MediaStore), but can only be fixed on FTP server's integration side - see #1008.

Also added license header per #985 recommended.