### PR TITLE
Add support for save files to external storage via ACTION_SEND intent

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/activities/MainActivity.java
+++ b/app/src/main/java/com/amaze/filemanager/activities/MainActivity.java
@@ -186,7 +186,7 @@ public class MainActivity extends ThemedActivity implements OnRequestPermissions
     public ArrayList<String> oppatheList;
 
     // This holds the Uris to be written at initFabToSave()
-    private List<Uri> urisToBeSaved;
+    private ArrayList<Uri> urisToBeSaved;
 
     /**
      * @deprecated use getCurrentMainFragment()
@@ -490,7 +490,7 @@ public class MainActivity extends ThemedActivity implements OnRequestPermissions
             } else if (actionIntent.equals(Intent.ACTION_SEND) && type != null) {
                 // save a single file to filesystem
                 Uri uri = intent.getParcelableExtra(Intent.EXTRA_STREAM);
-                List<Uri> uris = new ArrayList<>();
+                ArrayList<Uri> uris = new ArrayList<>();
                 uris.add(uri);
                 initFabToSave(uris);
 
@@ -500,7 +500,7 @@ public class MainActivity extends ThemedActivity implements OnRequestPermissions
             } else if (actionIntent.equals(Intent.ACTION_SEND_MULTIPLE) && type != null) {
                 // save multiple files to filesystem
 
-                List<Uri> arrayList = intent.getParcelableArrayListExtra(Intent.EXTRA_STREAM);
+                ArrayList<Uri> arrayList = intent.getParcelableArrayListExtra(Intent.EXTRA_STREAM);
                 initFabToSave(arrayList);
 
                 // disable screen rotation just for convenience purpose
@@ -513,7 +513,7 @@ public class MainActivity extends ThemedActivity implements OnRequestPermissions
     /**
      * Initializes the floating action button to act as to save data from an external intent
      */
-    private void initFabToSave(final List<Uri> uris) {
+    private void initFabToSave(final ArrayList<Uri> uris) {
         floatingActionButton.removeButton(findViewById(R.id.menu_new_folder));
         floatingActionButton.removeButton(findViewById(R.id.menu_new_file));
         floatingActionButton.removeButton(findViewById(R.id.menu_new_cloud));

--- a/app/src/main/java/com/amaze/filemanager/activities/MainActivity.java
+++ b/app/src/main/java/com/amaze/filemanager/activities/MainActivity.java
@@ -1,6 +1,8 @@
 /*
- * Copyright (C) 2014 Arpit Khurana <arpitkh96@gmail.com>, Vishal Nehra <vishalmeham2@gmail.com>,
- *                      Emmanuel Messulam<emmanuelbendavid@gmail.com>
+ * MainActivity.java
+ *
+ * Copyright (C) 2014-2018 Arpit Khurana <arpitkh96@gmail.com>, Vishal Nehra <vishalmeham2@gmail.com>,
+ * Emmanuel Messulam<emmanuelbendavid@gmail.com>, Raymond Lai <airwave209gt at gmail.com> and Contributors.
  *
  * This file is part of Amaze File Manager.
  *
@@ -521,10 +523,12 @@ public class MainActivity extends ThemedActivity implements OnRequestPermissions
             if(uris != null && uris.size() > 0) {
                 if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
                     File folder = new File(getCurrentMainFragment().getCurrentPath());
-                    if(mainActivityHelper.checkFolder(folder, MainActivity.this) == MainActivityHelper.WRITABLE_OR_ON_SDCARD){
+                    int result = mainActivityHelper.checkFolder(folder, MainActivity.this);
+                    if(result == MainActivityHelper.WRITABLE_OR_ON_SDCARD){
                         FileUtil.writeUriToStorage(MainActivity.this, uris, getContentResolver(), getCurrentMainFragment().getCurrentPath());
                         finish();
                     } else {
+                        //Trigger SAF intent, keep uri until finish
                         operation = DataUtils.SAVE_FILE;
                         urisToBeSaved = uris;
                         mainActivityHelper.checkFolder(folder, MainActivity.this);

--- a/app/src/main/java/com/amaze/filemanager/activities/MainActivity.java
+++ b/app/src/main/java/com/amaze/filemanager/activities/MainActivity.java
@@ -54,6 +54,7 @@ import android.support.v4.app.FragmentTransaction;
 import android.support.v4.app.LoaderManager;
 import android.support.v4.content.CursorLoader;
 import android.support.v4.content.Loader;
+import android.support.v4.provider.DocumentFile;
 import android.text.TextUtils;
 import android.view.KeyEvent;
 import android.view.Menu;
@@ -513,9 +514,18 @@ public class MainActivity extends ThemedActivity implements OnRequestPermissions
 
         floatingActionButton.setMenuButtonIcon(R.drawable.ic_file_download_white_24dp);
         floatingActionButton.getMenuButton().setOnClickListener(v -> {
-            FileUtil.writeUriToStorage(MainActivity.this, uris, getContentResolver(), getCurrentMainFragment().getCurrentPath());
-            Toast.makeText(MainActivity.this, getResources().getString(R.string.saving), Toast.LENGTH_LONG).show();
-            finish();
+            if(uris != null && uris.size() > 0) {
+                if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                    File folder = new File(getCurrentMainFragment().getCurrentPath());
+                    if(mainActivityHelper.checkFolder(folder, MainActivity.this) != MainActivityHelper.CAN_CREATE_FILES){
+                        Toast.makeText(MainActivity.this, R.string.not_allowed, Toast.LENGTH_SHORT).show();
+                        finish();
+                    }
+                }
+                FileUtil.writeUriToStorage(MainActivity.this, uris, getContentResolver(), getCurrentMainFragment().getCurrentPath());
+                Toast.makeText(MainActivity.this, getResources().getString(R.string.saving), Toast.LENGTH_LONG).show();
+                finish();
+            }
         });
         //Ensure the FAB menu is visible
         floatingActionButton.setVisibility(View.VISIBLE);

--- a/app/src/main/java/com/amaze/filemanager/filesystem/FileUtil.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/FileUtil.java
@@ -230,10 +230,11 @@ public abstract class FileUtil {
                             case FILE:
                             case ROOT:
                                 File targetFile = new File(finalFilePath);
-                                if (!FileUtil.isWritableNormalOrSaf(new File(finalFilePath).getParentFile(), mainActivity.getApplicationContext())) {
+                                if (!FileUtil.isWritableNormalOrSaf(targetFile.getParentFile(), mainActivity.getApplicationContext())) {
                                     AppConfig.toast(mainActivity, mainActivity.getResources().getString(R.string.not_allowed));
                                     return null;
                                 }
+                                
                                 DocumentFile targetDocumentFile = getDocumentFile(targetFile, false, mainActivity.getApplicationContext());
 
                                 //Fallback, in case getDocumentFile() didn't properly return a DocumentFile instance

--- a/app/src/main/java/com/amaze/filemanager/filesystem/FileUtil.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/FileUtil.java
@@ -211,8 +211,16 @@ public abstract class FileUtil {
 
                     try {
                         DocumentFile documentFile = DocumentFile.fromSingleUri(mainActivity, uri);
+                        String filename = documentFile.getName();
+                        if(filename == null) {
+                            filename = uri.getLastPathSegment();
 
-                        String finalFilePath = currentPath + "/" + documentFile.getName();
+                            //For cleaning up slashes. Back in #1217 there is a case of Uri.getLastPathSegment() end up with a full file path
+                            if (filename.contains("/"))
+                                filename = filename.substring(filename.lastIndexOf('/') + 1);
+                        }
+
+                        String finalFilePath = currentPath + "/" + filename;
                         DataUtils dataUtils = DataUtils.getInstance();
 
                         HybridFile hFile = new HybridFile(OpenMode.UNKNOWN, currentPath);

--- a/app/src/main/java/com/amaze/filemanager/filesystem/FileUtil.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/FileUtil.java
@@ -234,7 +234,7 @@ public abstract class FileUtil {
                                     AppConfig.toast(mainActivity, mainActivity.getResources().getString(R.string.not_allowed));
                                     return null;
                                 }
-                                
+
                                 DocumentFile targetDocumentFile = getDocumentFile(targetFile, false, mainActivity.getApplicationContext());
 
                                 //Fallback, in case getDocumentFile() didn't properly return a DocumentFile instance
@@ -243,7 +243,7 @@ public abstract class FileUtil {
 
                                 //Lazy check... and in fact, different apps may pass in URI in different formats, so we could only check filename matches
                                 //FIXME?: Prompt overwrite instead of simply blocking
-                                if (targetDocumentFile.exists()) {
+                                if (targetDocumentFile.exists() && targetDocumentFile.length() > 0) {
                                     AppConfig.toast(mainActivity, mainActivity.getString(R.string.cannot_overwrite));
                                     return null;
                                 }

--- a/app/src/main/java/com/amaze/filemanager/filesystem/FileUtil.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/FileUtil.java
@@ -660,6 +660,7 @@ public abstract class FileUtil {
      * @return true if it is possible to write in this directory.
      */
     public static boolean isWritableNormalOrSaf(final File folder, Context c) {
+        Log.d("DEBUG.isWritableNormal", folder.getAbsolutePath());
         // Verify that this is a directory.
         if (folder == null)
             return false;

--- a/app/src/main/java/com/amaze/filemanager/filesystem/FileUtil.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/FileUtil.java
@@ -660,7 +660,7 @@ public abstract class FileUtil {
      * @return true if it is possible to write in this directory.
      */
     public static boolean isWritableNormalOrSaf(final File folder, Context c) {
-        Log.d("DEBUG.isWritableNormal", folder.getAbsolutePath());
+        Log.e("DEBUG.isWritableNormal", folder.getAbsolutePath(), new Exception());
         // Verify that this is a directory.
         if (folder == null)
             return false;

--- a/app/src/main/java/com/amaze/filemanager/filesystem/FileUtil.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/FileUtil.java
@@ -1,3 +1,24 @@
+/*
+ * FileUtil.java
+ *
+ * Copyright (C) 2015-2018 Arpit Khurana <arpitkh96@gmail.com>, Vishal Nehra <vishalmeham2@gmail.com>,
+ * Emmanuel Messulam<emmanuelbendavid@gmail.com>, Raymond Lai <airwave209gt at gmail.com> and Contributors.
+ *
+ * This file is part of Amaze File Manager.
+ *
+ * Amaze File Manager is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package com.amaze.filemanager.filesystem;
 
 import android.annotation.TargetApi;
@@ -54,8 +75,6 @@ import static android.os.Build.VERSION.SDK_INT;
 
 /**
  * Utility class for helping parsing file systems.
- * <p>
- * Created by Arpit on 04-06-2015.
  */
 public abstract class FileUtil {
 
@@ -191,8 +210,8 @@ public abstract class FileUtil {
                     BufferedOutputStream bufferedOutputStream = null;
 
                     try {
-
                         DocumentFile documentFile = DocumentFile.fromSingleUri(mainActivity, uri);
+
                         String finalFilePath = currentPath + "/" + documentFile.getName();
                         DataUtils dataUtils = DataUtils.getInstance();
 
@@ -207,7 +226,6 @@ public abstract class FileUtil {
                                     AppConfig.toast(mainActivity, mainActivity.getResources().getString(R.string.not_allowed));
                                     return null;
                                 }
-
                                 DocumentFile targetDocumentFile = getDocumentFile(targetFile, false, mainActivity.getApplicationContext());
 
                                 //Fallback, in case getDocumentFile() didn't properly return a DocumentFile instance
@@ -660,7 +678,7 @@ public abstract class FileUtil {
      * @return true if it is possible to write in this directory.
      */
     public static boolean isWritableNormalOrSaf(final File folder, Context c) {
-        Log.e("DEBUG.isWritableNormal", folder.getAbsolutePath(), new Exception());
+
         // Verify that this is a directory.
         if (folder == null)
             return false;
@@ -789,6 +807,10 @@ public abstract class FileUtil {
      * @return The DocumentFile
      */
     public static DocumentFile getDocumentFile(final File file, final boolean isDirectory, Context context) {
+
+        if(Build.VERSION.SDK_INT <= Build.VERSION_CODES.KITKAT)
+            return DocumentFile.fromFile(file);
+
         String baseFolder = getExtSdCardFolder(file, context);
         boolean originalDirectory = false;
         if (baseFolder == null) {

--- a/app/src/main/java/com/amaze/filemanager/utils/DataUtils.java
+++ b/app/src/main/java/com/amaze/filemanager/utils/DataUtils.java
@@ -33,7 +33,7 @@ import java.util.List;
 public class DataUtils {
 
     public static final int DELETE = 0, COPY = 1, MOVE = 2, NEW_FOLDER = 3,
-            RENAME = 4, NEW_FILE = 5, EXTRACT = 6, COMPRESS = 7;
+            RENAME = 4, NEW_FILE = 5, EXTRACT = 6, COMPRESS = 7, SAVE_FILE = 8;
 
     private ConcurrentRadixTree<VoidValue> hiddenfiles = new ConcurrentRadixTree<>(new DefaultCharArrayNodeFactory());
 

--- a/app/src/main/java/com/amaze/filemanager/utils/DataUtils.java
+++ b/app/src/main/java/com/amaze/filemanager/utils/DataUtils.java
@@ -1,3 +1,24 @@
+/*
+ * DataUtils.java
+ *
+ * Copyright (C) 2016-2018 Arpit Khurana <arpitkh96@gmail.com>, Vishal Nehra <vishalmeham2@gmail.com>,
+ * Emmanuel Messulam<emmanuelbendavid@gmail.com>, Raymond Lai <airwave209gt at gmail.com> and Contributors.
+ *
+ * This file is part of Amaze File Manager.
+ *
+ * Amaze File Manager is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package com.amaze.filemanager.utils;
 
 import android.support.annotation.Nullable;
@@ -24,8 +45,6 @@ import java.util.LinkedList;
 import java.util.List;
 
 /**
- * Created by arpitkh996 on 20-01-2016.
- *
  * Singleton class to handle data for various services
  */
 

--- a/app/src/main/java/com/amaze/filemanager/utils/MainActivityHelper.java
+++ b/app/src/main/java/com/amaze/filemanager/utils/MainActivityHelper.java
@@ -8,6 +8,7 @@ import android.content.SharedPreferences;
 import android.os.AsyncTask;
 import android.os.Build;
 import android.os.Bundle;
+import android.support.annotation.Nullable;
 import android.support.annotation.StringRes;
 import android.support.design.widget.BottomSheetDialogFragment;
 import android.support.v4.app.Fragment;
@@ -15,6 +16,7 @@ import android.support.v4.app.FragmentManager;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.EditText;
+import android.view.WindowManager;
 import android.widget.ImageView;
 import android.widget.TextView;
 import android.widget.Toast;
@@ -43,6 +45,7 @@ import com.amaze.filemanager.utils.files.CryptUtil;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.concurrent.CountDownLatch;
 
 /**
  * Created by root on 11/22/15, modified by Emmanuel Messulam<emmanuelbendavid@gmail.com>
@@ -332,6 +335,7 @@ public class MainActivityHelper {
 
                 // On Android 5, trigger storage access framework.
                 if (!FileUtil.isWritableNormalOrSaf(folder, context)) {
+                    android.util.Log.d(getClass().getSimpleName(), "Trigger LEXA for " + folder.getAbsolutePath());
                     guideDialogForLEXA(folder.getPath());
                     return CAN_CREATE_FILES;
                 }

--- a/app/src/main/java/com/amaze/filemanager/utils/MainActivityHelper.java
+++ b/app/src/main/java/com/amaze/filemanager/utils/MainActivityHelper.java
@@ -1,3 +1,24 @@
+/*
+ * MainActivityHelper.java
+ *
+ * Copyright (C) 2015-2018 Arpit Khurana <arpitkh96@gmail.com>, Vishal Nehra <vishalmeham2@gmail.com>,
+ * Emmanuel Messulam<emmanuelbendavid@gmail.com>, Raymond Lai <airwave209gt at gmail.com> and Contributors.
+ *
+ * This file is part of Amaze File Manager.
+ *
+ * Amaze File Manager is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package com.amaze.filemanager.utils;
 
 import android.app.Activity;
@@ -8,7 +29,6 @@ import android.content.SharedPreferences;
 import android.os.AsyncTask;
 import android.os.Build;
 import android.os.Bundle;
-import android.support.annotation.Nullable;
 import android.support.annotation.StringRes;
 import android.support.design.widget.BottomSheetDialogFragment;
 import android.support.v4.app.Fragment;
@@ -45,7 +65,6 @@ import com.amaze.filemanager.utils.files.CryptUtil;
 
 import java.io.File;
 import java.util.ArrayList;
-import java.util.concurrent.CountDownLatch;
 
 /**
  * Created by root on 11/22/15, modified by Emmanuel Messulam<emmanuelbendavid@gmail.com>
@@ -335,7 +354,6 @@ public class MainActivityHelper {
 
                 // On Android 5, trigger storage access framework.
                 if (!FileUtil.isWritableNormalOrSaf(folder, context)) {
-                    android.util.Log.d(getClass().getSimpleName(), "Trigger LEXA for " + folder.getAbsolutePath());
                     guideDialogForLEXA(folder.getPath());
                     return CAN_CREATE_FILES;
                 }

--- a/app/src/main/java/com/amaze/filemanager/utils/MainActivityHelper.java
+++ b/app/src/main/java/com/amaze/filemanager/utils/MainActivityHelper.java
@@ -230,21 +230,12 @@ public class MainActivityHelper {
         TextView textView = view.findViewById(R.id.description);
         textView.setText(mainActivity.getString(R.string.needsaccesssummary) + path + mainActivity.getString(R.string.needsaccesssummary1));
         ((ImageView) view.findViewById(R.id.icon)).setImageResource(R.drawable.sd_operate_step);
-        x.positiveText(R.string.open);
-        x.negativeText(R.string.cancel);
-        x.positiveColor(accentColor);
-        x.negativeColor(accentColor);
-        x.callback(new MaterialDialog.ButtonCallback() {
-            @Override
-            public void onPositive(MaterialDialog materialDialog) {
-                triggerStorageAccessFramework();
-            }
-
-            @Override
-            public void onNegative(MaterialDialog materialDialog) {
-                Toast.makeText(mainActivity, R.string.error, Toast.LENGTH_SHORT).show();
-            }
-        });
+        x.positiveText(R.string.open)
+            .negativeText(R.string.cancel)
+            .positiveColor(accentColor)
+            .negativeColor(accentColor)
+            .onPositive((dialog, which)->triggerStorageAccessFramework())
+            .onNegative((dialog, which)->Toast.makeText(mainActivity, R.string.error, Toast.LENGTH_SHORT).show());
         final MaterialDialog y = x.build();
         y.show();
     }

--- a/app/src/main/java/com/amaze/filemanager/utils/application/AppConfig.java
+++ b/app/src/main/java/com/amaze/filemanager/utils/application/AppConfig.java
@@ -122,7 +122,7 @@ public class AppConfig extends GlideApplication {
                 }
 
                 @Override
-                protected Void doInBackground(Object... params) {
+                protected Object doInBackground(Object... params) {
                     return customAsyncCallbacks.doInBackground();
                 }
 

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -594,4 +594,6 @@
   <string name="encrypt_file_save_as">儲存加密檔案為……</string>
   <string name="encrypt_folder_save_as">儲存加密檔案夾為……</string>
   <string name="filename">檔案名稱</string>
+  <string name="saved_single_file">檔案 \'%s\'已儲存。</string>
+  <string name="saved_multi_files">儲存了 %d個檔案。</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -632,5 +632,7 @@
     <string name="encrypt_folder_save_as">Save Encrypted Folder As&#8230;</string>
     <string name="encrypt_file_must_end_with_aze">Encrypted files must use \".aze\" as the file extension.</string>
     <string name="cannot_overwrite">Cannot overwrite file.</string>
+    <string name="saved_single_file">File saved as \'%s\'.</string>
+    <string name="saved_multi_files">%d files saved.</string>
 </resources>
 


### PR DESCRIPTION
Fixes #1073.

Note: this won't fix sharing some selected text to device via Amaze - can't find the exact issue #, that will be fixed in separate PR once #1201 is merged. However on such intents which has no Uri but data content this PR should prevent Amaze from crashing.

Test case for verification:
1. Open a web page with images with Firefox/Chrome
2. Long tap an image
3. Select Amaze "Save As..."
4. Amaze FM pops up, FAB menu button shows a download symbol
5. Select external storage via the drawer or enter path
6. On devices running Android versions that have SAF enabled, dialog prompting user to select external device's directory will be displayed
7. Select the external storage device's directory and the file will be saved there

Not easy to write test case, but did tested on Oneplus One running Slim7 (7.1.2), Nougat emulator (Pixel 2 with external SD card), Galaxy S2 running SlimLP (5.1.1) with 64GB micro SD and GPD XD running LegacyROM (4.4.4) with 64GB micro SD.

One thing that concerned me was `MainActivityHelper.checkFolder()` was called twice, with only the second call would keep the SAF prompt dialog on the screen - so feel free to improve this.