### PR TITLE
FileUtil.writeUriToStorage: Reject overwriting file if file of same name exists

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/activities/MainActivity.java
+++ b/app/src/main/java/com/amaze/filemanager/activities/MainActivity.java
@@ -521,6 +521,9 @@ public class MainActivity extends ThemedActivity implements OnRequestPermissions
             Toast.makeText(MainActivity.this, getResources().getString(R.string.saving), Toast.LENGTH_LONG).show();
             finish();
         });
+        //Ensure the FAB menu is visible
+        floatingActionButton.setVisibility(View.VISIBLE);
+        floatingActionButton.getMenuButton().show();
     }
 
     /**

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -624,5 +624,6 @@
     <string name="no_file_error">Something went wrong, there\'s nothing to open</string>
     <string name="file_read_only">The file opened is a read-only.</string>
     <string name="got_it">Got it!</string>
+    <string name="cannot_overwrite">Cannot overwrite file.</string>
 </resources>
 


### PR DESCRIPTION
Temporary solution to fix #1214.

Certainly I'll want to give a bigger refactoring for better user experience, like ask user for overwrite or not, or specify new filename for the saved file; this is just a quick and dirty solution to the problem, and hopefully, safe to be included in `release-3.3.0` branch.

Files written to local, OTG and SMB destinations via Amaze "Save as" calling `FileUtil.writeUriToStorage()` will perform such checking. If the destination folder has the file of the same name, file will not be overwritten but Toast user that file cannot be overwritten.

Additionally cherry-picked 69ca334 from #1209 to make sure the FAB menu button is visible when "Save as" action is triggered when Amaze is running in the background.