### PR TITLE
UtilsHandler method refractorization

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -80,8 +80,10 @@ dependencies {
 
     //For tests
     androidTestImplementation 'junit:junit:4.12'//tests the app logic
-    testImplementation "org.robolectric:robolectric:3.6.1"//tests android interaction
-    testImplementation "org.robolectric:shadows-multidex:3.6.1"//tests android interaction
+    testImplementation "org.robolectric:robolectric:3.7"//tests android interaction
+    testImplementation "org.robolectric:shadows-multidex:3.7"//tests android interaction
+
+    testImplementation "org.apache.sshd:sshd-core:1.7.0"
 
     //Detect memory leaks
     debugImplementation 'com.squareup.leakcanary:leakcanary-android:1.5.3'
@@ -111,7 +113,7 @@ dependencies {
     // https://mvnrepository.com/artifact/org.slf4j/slf4j-api
     implementation group: 'org.slf4j', name: 'slf4j-api', version: '1.7.25'
     // https://mvnrepository.com/artifact/org.slf4j/slf4j-simple
-    implementation group: 'org.slf4j', name: 'slf4j-simple', version: '1.7.21'
+    implementation group: 'org.slf4j', name: 'slf4j-simple', version: '1.7.25'
 
     //implementation files('libs/ftplet-api-1.1.0-SNAPSHOT.jar')
     // https://mvnrepository.com/artifact/org.apache.ftpserver/ftplet-api

--- a/app/src/main/java/com/amaze/filemanager/activities/MainActivity.java
+++ b/app/src/main/java/com/amaze/filemanager/activities/MainActivity.java
@@ -964,7 +964,8 @@ public class MainActivity extends ThemedActivity implements OnRequestPermissions
                 if (ma.IS_LIST) {
                     if (pathLayout == DataUtils.LIST) {
                         AppConfig.runInBackground(() -> {
-                            utilsHandler.removeListViewPath(mainFragment.getCurrentPath());
+                            utilsHandler.removeFromDatabase(new OperationData(UtilsHandler.Operation.LIST,
+                                    mainFragment.getCurrentPath()));
                         });
                     }
                     utilsHandler.saveToDatabase(new OperationData(UtilsHandler.Operation.GRID,
@@ -974,7 +975,8 @@ public class MainActivity extends ThemedActivity implements OnRequestPermissions
                 } else {
                     if (pathLayout == DataUtils.GRID) {
                         AppConfig.runInBackground(() -> {
-                            utilsHandler.removeGridViewPath(mainFragment.getCurrentPath());
+                            utilsHandler.removeFromDatabase(new OperationData(UtilsHandler.Operation.GRID,
+                                    mainFragment.getCurrentPath()));
                         });
                     }
 
@@ -1713,7 +1715,8 @@ public class MainActivity extends ThemedActivity implements OnRequestPermissions
             dataUtils.removeServer(i);
 
             AppConfig.runInBackground(() -> {
-                utilsHandler.removeSmbPath(name, path);
+                utilsHandler.removeFromDatabase(new OperationData(UtilsHandler.Operation.SMB, name,
+                        path));
             });
             //grid.removePath(name, path, DataUtils.SMB);
             drawer.refreshDrawer();
@@ -1728,7 +1731,7 @@ public class MainActivity extends ThemedActivity implements OnRequestPermissions
 
     @Override
     public void onHiddenFileRemoved(String path) {
-        utilsHandler.removeHiddenPath(path);
+        utilsHandler.removeFromDatabase(new OperationData(UtilsHandler.Operation.HIDDEN, path));
     }
 
     @Override
@@ -1749,7 +1752,8 @@ public class MainActivity extends ThemedActivity implements OnRequestPermissions
 
     @Override
     public void delete(String title, String path) {
-        utilsHandler.removeBookmarksPath(title, path);
+        utilsHandler.removeFromDatabase(new OperationData(UtilsHandler.Operation.BOOKMARKS, title,
+                path));
         drawer.refreshDrawer();
 
     }

--- a/app/src/main/java/com/amaze/filemanager/activities/MainActivity.java
+++ b/app/src/main/java/com/amaze/filemanager/activities/MainActivity.java
@@ -1747,7 +1747,7 @@ public class MainActivity extends ThemedActivity implements OnRequestPermissions
 
     @Override
     public void onHistoryCleared() {
-        utilsHandler.clearHistoryTable();
+        utilsHandler.clearTable(UtilsHandler.Operation.HISTORY);
     }
 
     @Override

--- a/app/src/main/java/com/amaze/filemanager/activities/MainActivity.java
+++ b/app/src/main/java/com/amaze/filemanager/activities/MainActivity.java
@@ -81,6 +81,7 @@ import com.amaze.filemanager.database.CryptHandler;
 import com.amaze.filemanager.database.TabHandler;
 import com.amaze.filemanager.database.UtilsHandler;
 import com.amaze.filemanager.database.models.CloudEntry;
+import com.amaze.filemanager.database.models.OperationData;
 import com.amaze.filemanager.database.models.Tab;
 import com.amaze.filemanager.exceptions.CloudPluginException;
 import com.amaze.filemanager.filesystem.FileUtil;
@@ -966,10 +967,8 @@ public class MainActivity extends ThemedActivity implements OnRequestPermissions
                             utilsHandler.removeListViewPath(mainFragment.getCurrentPath());
                         });
                     }
-
-                    AppConfig.runInBackground(() -> {
-                        utilsHandler.addGridView(mainFragment.getCurrentPath());
-                    });
+                    utilsHandler.saveToDatabase(new OperationData(UtilsHandler.Operation.GRID,
+                            mainFragment.getCurrentPath()));
 
                     dataUtils.setPathAsGridOrList(ma.getCurrentPath(), DataUtils.GRID);
                 } else {
@@ -979,9 +978,8 @@ public class MainActivity extends ThemedActivity implements OnRequestPermissions
                         });
                     }
 
-                    AppConfig.runInBackground(() -> {
-                        utilsHandler.addListView(mainFragment.getCurrentPath());
-                    });
+                    utilsHandler.saveToDatabase(new OperationData(UtilsHandler.Operation.LIST,
+                            mainFragment.getCurrentPath()));
 
                     dataUtils.setPathAsGridOrList(ma.getCurrentPath(), DataUtils.LIST);
                 }
@@ -1681,9 +1679,8 @@ public class MainActivity extends ThemedActivity implements OnRequestPermissions
                 dataUtils.addServer(s);
                 drawer.refreshDrawer();
 
-                AppConfig.runInBackground(() -> {
-                    utilsHandler.addSmb(name, encryptedPath);
-                });
+                utilsHandler.saveToDatabase(new OperationData(UtilsHandler.Operation.SMB, name, encryptedPath));
+
                 //grid.addPath(name, encryptedPath, DataUtils.SMB, 1);
                 MainFragment ma = getCurrentMainFragment();
                 if (ma != null) getCurrentMainFragment().loadlist(path, false, OpenMode.UNKNOWN);
@@ -1726,7 +1723,7 @@ public class MainActivity extends ThemedActivity implements OnRequestPermissions
 
     @Override
     public void onHiddenFileAdded(String path) {
-        utilsHandler.addHidden(path);
+        utilsHandler.saveToDatabase(new OperationData(UtilsHandler.Operation.HIDDEN, path));
     }
 
     @Override
@@ -1736,12 +1733,12 @@ public class MainActivity extends ThemedActivity implements OnRequestPermissions
 
     @Override
     public void onHistoryAdded(String path) {
-        utilsHandler.addHistory(path);
+        utilsHandler.saveToDatabase(new OperationData(UtilsHandler.Operation.HISTORY, path));
     }
 
     @Override
     public void onBookAdded(String[] path, boolean refreshdrawer) {
-        utilsHandler.addBookmark(path[0], path[1]);
+        utilsHandler.saveToDatabase(new OperationData(UtilsHandler.Operation.BOOKMARKS, path[0], path[1]));
         if (refreshdrawer) drawer.refreshDrawer();
     }
 

--- a/app/src/main/java/com/amaze/filemanager/activities/MainActivity.java
+++ b/app/src/main/java/com/amaze/filemanager/activities/MainActivity.java
@@ -1679,7 +1679,7 @@ public class MainActivity extends ThemedActivity implements OnRequestPermissions
                 dataUtils.addServer(s);
                 drawer.refreshDrawer();
 
-                utilsHandler.saveToDatabase(new OperationData(UtilsHandler.Operation.SMB, name, encryptedPath));
+                utilsHandler.saveToDatabase(new OperationData(UtilsHandler.Operation.SMB, encryptedPath, name));
 
                 //grid.addPath(name, encryptedPath, DataUtils.SMB, 1);
                 MainFragment ma = getCurrentMainFragment();

--- a/app/src/main/java/com/amaze/filemanager/database/UtilsHandler.java
+++ b/app/src/main/java/com/amaze/filemanager/database/UtilsHandler.java
@@ -151,6 +151,30 @@ public class UtilsHandler extends SQLiteOpenHelper {
         });
     }
 
+    public void removeFromDatabase(OperationData operationData) {
+        AppConfig.runInBackground(() -> {
+            switch (operationData.type) {
+                case HIDDEN:
+                case HISTORY:
+                case LIST:
+                case GRID:
+                    removePath(operationData.type, operationData.path);
+                    break;
+                case BOOKMARKS:
+                    removeBookmarksPath(operationData.name, operationData.path);
+                    break;
+                case SMB:
+                    removeSmbPath(operationData.name, operationData.path);
+                    break;
+                case SFTP:
+                    removeSftpPath(operationData.name, operationData.path);
+                    break;
+                default:
+                    throw new IllegalStateException("Unidentified operation!");
+            }
+        });
+    }
+
     public void addCommonBookmarks() {
         String sd = Environment.getExternalStorageDirectory() + "/";
 
@@ -380,24 +404,8 @@ public class UtilsHandler extends SQLiteOpenHelper {
             return null;
         }
     }
-
-    public void removeHistoryPath(String path) {
-        removePath(Operation.HISTORY, path);
-    }
-
-    public void removeHiddenPath(String path) {
-        removePath(Operation.HIDDEN, path);
-    }
-
-    public void removeListViewPath(String path) {
-        removePath(Operation.LIST, path);
-    }
-
-    public void removeGridViewPath(String path) {
-        removePath(Operation.GRID, path);
-    }
-
-    public void removeBookmarksPath(String name, String path) {
+    
+    private void removeBookmarksPath(String name, String path) {
 
         SQLiteDatabase sqLiteDatabase = getWritableDatabase();
 
@@ -410,7 +418,7 @@ public class UtilsHandler extends SQLiteOpenHelper {
      * @param path the path we get from saved runtime variables is a decrypted, to remove entry,
      *             we must encrypt it's password fiend first first
      */
-    public void removeSmbPath(String name, String path) {
+    private void removeSmbPath(String name, String path) {
 
         SQLiteDatabase sqLiteDatabase = getWritableDatabase();
 
@@ -431,7 +439,7 @@ public class UtilsHandler extends SQLiteOpenHelper {
         }
     }
 
-    public void removeSftpPath(String name, String path) {
+    private void removeSftpPath(String name, String path) {
 
         SQLiteDatabase sqLiteDatabase = getWritableDatabase();
 

--- a/app/src/main/java/com/amaze/filemanager/database/UtilsHandler.java
+++ b/app/src/main/java/com/amaze/filemanager/database/UtilsHandler.java
@@ -163,32 +163,8 @@ public class UtilsHandler extends SQLiteOpenHelper {
         };
 
         for (String dir : dirs) {
-            addBookmark(new File(dir).getName(), dir);
+            saveToDatabase(new OperationData(Operation.BOOKMARKS, dir, new File(dir).getName()));
         }
-    }
-
-    public void addHistory(String path) {
-        setPath(Operation.HISTORY, path);
-    }
-
-    public void addHidden(String path) {
-        setPath(Operation.HIDDEN, path);
-    }
-
-    public void addListView(String path) {
-        setPath(Operation.LIST, path);
-    }
-
-    public void addGridView(String path) {
-        setPath(Operation.GRID, path);
-    }
-
-    public void addBookmark(String name, String path) {
-        setPath(Operation.BOOKMARKS, name, path);
-    }
-
-    public void addSmb(String name, String path) {
-        setPath(Operation.SMB, name, path);
     }
 
     public void addSsh(String name, String path, String hostKey, String sshKeyName, String sshKey) {

--- a/app/src/main/java/com/amaze/filemanager/database/UtilsHandler.java
+++ b/app/src/main/java/com/amaze/filemanager/database/UtilsHandler.java
@@ -404,7 +404,7 @@ public class UtilsHandler extends SQLiteOpenHelper {
             return null;
         }
     }
-    
+
     private void removeBookmarksPath(String name, String path) {
 
         SQLiteDatabase sqLiteDatabase = getWritableDatabase();
@@ -463,32 +463,6 @@ public class UtilsHandler extends SQLiteOpenHelper {
         }
     }
 
-    public void clearHistoryTable() {
-        clearTable(Operation.HISTORY);
-    }
-
-    public void clearHiddenTable() {
-        clearTable(Operation.HIDDEN);
-    }
-
-    public void clearListViewTable() {
-        clearTable(Operation.LIST);
-    }
-
-    public void clearGridViewTable() {
-        clearTable(Operation.GRID);
-    }
-
-    public void clearBookmarksTable() {
-        clearTable(Operation.BOOKMARKS);
-    }
-
-    public void clearSmbTable() {
-        clearTable(Operation.SMB);
-    }
-
-    public void clearSshTable() { clearTable(Operation.SFTP); }
-
     public void renameBookmark(String oldName, String oldPath, String newName, String newPath) {
         renamePath(Operation.BOOKMARKS, oldName, oldPath, newName, newPath);
     }
@@ -545,7 +519,7 @@ public class UtilsHandler extends SQLiteOpenHelper {
                 new String[] {path});
     }
 
-    private void clearTable(Operation table) {
+    public void clearTable(Operation table) {
         getWritableDatabase().delete(getTableForOperation(table), null, null);
     }
 

--- a/app/src/main/java/com/amaze/filemanager/database/UtilsHandler.java
+++ b/app/src/main/java/com/amaze/filemanager/database/UtilsHandler.java
@@ -163,7 +163,7 @@ public class UtilsHandler extends SQLiteOpenHelper {
         };
 
         for (String dir : dirs) {
-            saveToDatabase(new OperationData(Operation.BOOKMARKS, dir, new File(dir).getName()));
+            saveToDatabase(new OperationData(Operation.BOOKMARKS, new File(dir).getName(), dir));
         }
     }
 

--- a/app/src/main/java/com/amaze/filemanager/database/models/OperationData.java
+++ b/app/src/main/java/com/amaze/filemanager/database/models/OperationData.java
@@ -1,0 +1,69 @@
+package com.amaze.filemanager.database.models;
+
+import com.amaze.filemanager.database.UtilsHandler.Operation;
+
+import static com.amaze.filemanager.database.UtilsHandler.Operation.BOOKMARKS;
+import static com.amaze.filemanager.database.UtilsHandler.Operation.GRID;
+import static com.amaze.filemanager.database.UtilsHandler.Operation.HIDDEN;
+import static com.amaze.filemanager.database.UtilsHandler.Operation.HISTORY;
+import static com.amaze.filemanager.database.UtilsHandler.Operation.LIST;
+import static com.amaze.filemanager.database.UtilsHandler.Operation.SFTP;
+import static com.amaze.filemanager.database.UtilsHandler.Operation.SMB;
+
+public class OperationData {
+    public final Operation type;
+    public final String path;
+    public final String name;
+    public final String hostKey;
+    public final String sshKeyName;
+    public final String sshKey;
+
+    /**
+     * Constructor for types {@link Operation#HIDDEN}, {@link Operation#HISTORY},
+     * {@link Operation#LIST} or {@link Operation#GRID}
+     */
+    public OperationData(Operation type, String path) {
+        if(type != HIDDEN && type != HISTORY && type != LIST && type != GRID) {
+            throw new IllegalArgumentException("Wrong constructor for object type");
+        }
+
+        this.type = type;
+        this.path = path;
+
+        name = null;
+        hostKey = null;
+        sshKeyName = null;
+        sshKey = null;
+    }
+
+    /**
+     * Constructor for types {@link Operation#BOOKMARKS} or {@link Operation#SMB}
+     */
+    public OperationData(Operation type, String path, String name) {
+        if(type != BOOKMARKS && type != SMB) throw new IllegalArgumentException("Wrong constructor for object type");
+
+        this.type = type;
+        this.path = path;
+        this.name = name;
+
+        hostKey = null;
+        sshKeyName = null;
+        sshKey = null;
+    }
+
+    /**
+     * Constructor for {@link Operation#SFTP}
+     */
+    public OperationData(Operation type, String path, String name, String hostKey, String sshKeyName,
+                         String sshKey) {
+        if(type != SFTP) throw new IllegalArgumentException("Wrong constructor for object type");
+
+        this.type = type;
+        this.path = path;
+        this.name = name;
+        this.hostKey = hostKey;
+        this.sshKeyName = sshKeyName;
+        this.sshKey = sshKey;
+    }
+
+}

--- a/app/src/main/java/com/amaze/filemanager/database/models/OperationData.java
+++ b/app/src/main/java/com/amaze/filemanager/database/models/OperationData.java
@@ -1,5 +1,6 @@
 package com.amaze.filemanager.database.models;
 
+import com.amaze.filemanager.database.UtilsHandler;
 import com.amaze.filemanager.database.UtilsHandler.Operation;
 
 import static com.amaze.filemanager.database.UtilsHandler.Operation.BOOKMARKS;
@@ -53,6 +54,8 @@ public class OperationData {
 
     /**
      * Constructor for {@link Operation#SFTP}
+     * {@param hostKey}, {@param sshKeyName} and {@param sshKey} may be null for when
+     * {@link OperationData} is used for {@link UtilsHandler#removeFromDatabase(OperationData)}
      */
     public OperationData(Operation type, String path, String name, String hostKey, String sshKeyName,
                          String sshKey) {

--- a/app/src/main/java/com/amaze/filemanager/database/models/OperationData.java
+++ b/app/src/main/java/com/amaze/filemanager/database/models/OperationData.java
@@ -1,5 +1,7 @@
 package com.amaze.filemanager.database.models;
 
+import android.text.TextUtils;
+
 import com.amaze.filemanager.database.UtilsHandler;
 import com.amaze.filemanager.database.UtilsHandler.Operation;
 
@@ -69,4 +71,17 @@ public class OperationData {
         this.sshKey = sshKey;
     }
 
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder("OperationData type=[").append(type).append("],path=[")
+                .append(path).append("]");
+
+        if(!TextUtils.isEmpty(hostKey))
+            sb.append(",hostKey=[").append(hostKey).append(']');
+
+        if(!TextUtils.isEmpty(sshKeyName))
+            sb.append(",sshKeyName=[").append(sshKeyName).append("],sshKey=[redacted]");
+
+        return sb.toString();
+    }
 }

--- a/app/src/main/java/com/amaze/filemanager/database/models/OperationData.java
+++ b/app/src/main/java/com/amaze/filemanager/database/models/OperationData.java
@@ -39,7 +39,7 @@ public class OperationData {
     /**
      * Constructor for types {@link Operation#BOOKMARKS} or {@link Operation#SMB}
      */
-    public OperationData(Operation type, String path, String name) {
+    public OperationData(Operation type, String name, String path) {
         if(type != BOOKMARKS && type != SMB) throw new IllegalArgumentException("Wrong constructor for object type");
 
         this.type = type;

--- a/app/src/main/java/com/amaze/filemanager/filesystem/ssh/SshClientUtils.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/ssh/SshClientUtils.java
@@ -46,6 +46,7 @@ import net.schmizz.sshj.sftp.SFTPClient;
 import java.io.File;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
+import java.security.KeyPair;
 import java.util.List;
 
 import static com.amaze.filemanager.filesystem.ssh.SshConnectionPool.SSH_URI_PREFIX;
@@ -262,5 +263,13 @@ public abstract class SshClientUtils
                 e.printStackTrace();
             }
         }).start();
+    }
+
+    //Decide the SSH URL depends on password/selected KeyPair
+    public static String deriveSftpPathFrom(String hostname, int port, String username, String password,
+                                      KeyPair selectedParsedKeyPair) {
+        return (selectedParsedKeyPair != null || password == null) ?
+                String.format("ssh://%s@%s:%d", username, hostname, port) :
+                String.format("ssh://%s:%s@%s:%d", username, password, hostname, port);
     }
 }

--- a/app/src/main/java/com/amaze/filemanager/fragments/preference_fragments/FoldersPref.java
+++ b/app/src/main/java/com/amaze/filemanager/fragments/preference_fragments/FoldersPref.java
@@ -221,8 +221,8 @@ public class FoldersPref extends PreferenceFragment implements Preference.OnPref
 
                     dataUtils.removeBook(position.get(p));
 
-                    AppConfig.runInBackground(() -> utilsHandler.removeBookmarksPath(p.getTitle().toString(),
-                            p.getSummary().toString()));
+                    utilsHandler.removeFromDatabase(new OperationData(UtilsHandler.Operation.BOOKMARKS,
+                            p.getTitle().toString(), p.getSummary().toString()));
 
                     getPreferenceScreen().removePreference(p);
                     position.remove(p);

--- a/app/src/main/java/com/amaze/filemanager/fragments/preference_fragments/FoldersPref.java
+++ b/app/src/main/java/com/amaze/filemanager/fragments/preference_fragments/FoldersPref.java
@@ -137,7 +137,7 @@ public class FoldersPref extends PreferenceFragment implements Preference.OnPref
 
                     dataUtils.addBook(values);
                     utilsHandler.saveToDatabase(new OperationData(UtilsHandler.Operation.BOOKMARKS,
-                            editText1.getText().toString(), editText2.getText().toString()));
+                            editText2.getText().toString(), editText1.getText().toString()));
 
                     dialog.dismiss();
                 });

--- a/app/src/main/java/com/amaze/filemanager/fragments/preference_fragments/FoldersPref.java
+++ b/app/src/main/java/com/amaze/filemanager/fragments/preference_fragments/FoldersPref.java
@@ -17,6 +17,7 @@ import com.afollestad.materialdialogs.MaterialDialog;
 import com.amaze.filemanager.R;
 import com.amaze.filemanager.activities.PreferencesActivity;
 import com.amaze.filemanager.database.UtilsHandler;
+import com.amaze.filemanager.database.models.OperationData;
 import com.amaze.filemanager.ui.views.preference.PathSwitchPreference;
 import com.amaze.filemanager.utils.DataUtils;
 import com.amaze.filemanager.utils.SimpleTextWatcher;
@@ -135,8 +136,8 @@ public class FoldersPref extends PreferenceFragment implements Preference.OnPref
                             editText2.getText().toString()};
 
                     dataUtils.addBook(values);
-                    AppConfig.runInBackground(() -> utilsHandler.addBookmark(editText1.getText().toString(),
-                                    editText2.getText().toString()));
+                    utilsHandler.saveToDatabase(new OperationData(UtilsHandler.Operation.BOOKMARKS,
+                            editText1.getText().toString(), editText2.getText().toString()));
 
                     dialog.dismiss();
                 });

--- a/app/src/main/java/com/amaze/filemanager/ui/dialogs/SftpConnectDialog.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/dialogs/SftpConnectDialog.java
@@ -223,7 +223,8 @@ public class SftpConnectDialog extends DialogFragment {
                 DataUtils.getInstance().removeServer(i);
 
                 AppConfig.runInBackground(() -> {
-                    utilsHandler.removeSftpPath(connectionName, path);
+                    utilsHandler.removeFromDatabase(new OperationData(UtilsHandler.Operation.SFTP,
+                            connectionName, path, null, null, null));
                 });
                 ((MainActivity) getActivity()).getDrawer().refreshDrawer();
             }

--- a/app/src/main/java/com/amaze/filemanager/ui/dialogs/SftpConnectDialog.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/dialogs/SftpConnectDialog.java
@@ -44,6 +44,7 @@ import com.amaze.filemanager.R;
 import com.amaze.filemanager.activities.MainActivity;
 import com.amaze.filemanager.activities.superclasses.ThemedActivity;
 import com.amaze.filemanager.database.UtilsHandler;
+import com.amaze.filemanager.database.models.OperationData;
 import com.amaze.filemanager.filesystem.ssh.SshClientUtils;
 import com.amaze.filemanager.filesystem.ssh.SshConnectionPool;
 import com.amaze.filemanager.fragments.MainFragment;
@@ -321,8 +322,9 @@ public class SftpConnectDialog extends DialogFragment {
                         DataUtils.getInstance().addServer(new String[]{connectionName, path});
                         ((MainActivity) getActivity()).getDrawer().refreshDrawer();
 
-                        utilsHandler.addSsh(connectionName, encryptedPath, hostKeyFingerprint,
-                                selectedParsedKeyPairName, getPemContents());
+                        utilsHandler.saveToDatabase(new OperationData(UtilsHandler.Operation.SFTP,
+                                connectionName,encryptedPath, hostKeyFingerprint,
+                                selectedParsedKeyPairName, getPemContents()));
 
                         MainFragment ma = ((MainActivity)getActivity()).getCurrentMainFragment();
                         ma.loadlist(path, false, OpenMode.UNKNOWN);

--- a/app/src/test/java/com/amaze/filemanager/filesystem/ssh/CreateFileOnSshdTest.java
+++ b/app/src/test/java/com/amaze/filemanager/filesystem/ssh/CreateFileOnSshdTest.java
@@ -1,0 +1,77 @@
+package com.amaze.filemanager.filesystem.ssh;
+
+import android.os.Environment;
+
+import com.amaze.filemanager.BuildConfig;
+import com.amaze.filemanager.filesystem.ssh.test.BlockFileCreationFileSystemProvider;
+import com.amaze.filemanager.filesystem.ssh.test.TestKeyProvider;
+
+import org.apache.sshd.common.file.FileSystemFactory;
+import org.apache.sshd.common.file.virtualfs.VirtualFileSystemFactory;
+import org.apache.sshd.common.session.Session;
+import org.apache.sshd.server.SshServer;
+import org.apache.sshd.server.auth.pubkey.AcceptAllPublickeyAuthenticator;
+import org.apache.sshd.server.scp.ScpCommandFactory;
+import org.apache.sshd.server.subsystem.sftp.SftpSubsystemFactory;
+import org.junit.After;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+import org.robolectric.shadows.multidex.ShadowMultiDex;
+
+import java.io.IOException;
+import java.nio.file.FileSystem;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Collections;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(constants = BuildConfig.class, shadows = {ShadowMultiDex.class})
+public class CreateFileOnSshdTest {
+
+    private SshServer server;
+
+    private static TestKeyProvider hostKeyProvider;
+
+    @BeforeClass
+    public static void bootstrap() throws Exception {
+        hostKeyProvider = new TestKeyProvider();
+    }
+
+    @After
+    public void tearDown(){
+        if(server != null && server.isOpen())
+            server.close(true);
+    }
+
+    @Test
+    public void testCreateFileNormal() throws Exception {
+        createSshServer(new VirtualFileSystemFactory(Paths.get(Environment.getExternalStorageDirectory().getAbsolutePath())));
+    }
+
+    @Test
+    public void testCreateFilePermissionDenied() throws Exception{
+        createSshServer(new VirtualFileSystemFactory(){
+            @Override
+            public FileSystem createFileSystem(Session session) throws IOException {
+                return new BlockFileCreationFileSystemProvider().newFileSystem(Paths.get(Environment.getExternalStorageDirectory().getAbsolutePath()), Collections.emptyMap());
+            }
+        });
+    }
+
+    private void createSshServer(FileSystemFactory fileSystemFactory) throws Exception {
+        server = SshServer.setUpDefaultServer();
+
+        server.setFileSystemFactory(fileSystemFactory);
+        server.setPublickeyAuthenticator(AcceptAllPublickeyAuthenticator.INSTANCE);
+        server.setPort(22222);
+        server.setHost("127.0.0.1");
+        server.setKeyPairProvider(hostKeyProvider);
+        server.setCommandFactory(new ScpCommandFactory());
+        server.setSubsystemFactories(Arrays.asList(new SftpSubsystemFactory()));
+        server.setPasswordAuthenticator(((username, password, session) -> username.equals("testuser") && password.equals("testpassword")));
+        server.start();
+    }
+}

--- a/app/src/test/java/com/amaze/filemanager/filesystem/ssh/SshConnectionPoolTest.java
+++ b/app/src/test/java/com/amaze/filemanager/filesystem/ssh/SshConnectionPoolTest.java
@@ -1,0 +1,73 @@
+package com.amaze.filemanager.filesystem.ssh;
+
+import com.amaze.filemanager.BuildConfig;
+import com.amaze.filemanager.filesystem.ssh.test.TestKeyProvider;
+
+import net.schmizz.sshj.common.SecurityUtils;
+
+import org.apache.sshd.server.SshServer;
+import org.apache.sshd.server.auth.pubkey.AcceptAllPublickeyAuthenticator;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+import org.robolectric.shadows.multidex.ShadowMultiDex;
+
+import static org.junit.Assert.*;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(constants = BuildConfig.class, shadows = {ShadowMultiDex.class})
+public class SshConnectionPoolTest {
+
+    private static SshServer server;
+
+    private static TestKeyProvider hostKeyProvider, userKeyProvider;
+
+    @BeforeClass
+    public static void bootstrap() throws Exception {
+        hostKeyProvider = new TestKeyProvider();
+        userKeyProvider = new TestKeyProvider();
+        createSshServer();
+    }
+
+    @AfterClass
+    public static void shutdownServer(){
+        if(server != null && server.isOpen())
+            server.close(true);
+    }
+
+    @Test
+    public void testGetConnectionWithUsernameAndPassword(){
+        assertNotNull(SshConnectionPool.getInstance().getConnection("127.0.0.1", 22222,
+                SecurityUtils.getFingerprint(hostKeyProvider.getKeyPair().getPublic()),
+                "testuser", "testpassword", null));
+
+        assertNull(SshConnectionPool.getInstance().getConnection("127.0.0.1", 22222,
+                SecurityUtils.getFingerprint(hostKeyProvider.getKeyPair().getPublic()),
+                "invaliduser", "invalidpassword", null));
+    }
+
+    @Test
+    public void testGetConnectionWithUsernameAndKey(){
+        assertNotNull(SshConnectionPool.getInstance().getConnection("127.0.0.1", 22222,
+                SecurityUtils.getFingerprint(hostKeyProvider.getKeyPair().getPublic()),
+                "testuser", null, userKeyProvider.getKeyPair()));
+
+        assertNull(SshConnectionPool.getInstance().getConnection("127.0.0.1", 22222,
+                SecurityUtils.getFingerprint(hostKeyProvider.getKeyPair().getPublic()),
+                "invaliduser", null, userKeyProvider.getKeyPair()));
+    }
+
+    private static void createSshServer() throws Exception {
+        server = SshServer.setUpDefaultServer();
+        server.setPublickeyAuthenticator(AcceptAllPublickeyAuthenticator.INSTANCE);
+        server.setPort(22222);
+        server.setHost("127.0.0.1");
+        server.setKeyPairProvider(hostKeyProvider);
+        server.setPasswordAuthenticator(((username, password, session) -> username.equals("testuser") && password.equals("testpassword")));
+        server.setPublickeyAuthenticator((username, key, session) -> username.equals("testuser") && key.equals(userKeyProvider.getKeyPair().getPublic()));
+        server.start();
+    }
+}

--- a/app/src/test/java/com/amaze/filemanager/filesystem/ssh/test/BlockFileCreationFileSystemProvider.java
+++ b/app/src/test/java/com/amaze/filemanager/filesystem/ssh/test/BlockFileCreationFileSystemProvider.java
@@ -1,0 +1,39 @@
+package com.amaze.filemanager.filesystem.ssh.test;
+
+import org.apache.sshd.common.file.root.RootedFileSystem;
+import org.apache.sshd.common.file.root.RootedFileSystemProvider;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.channels.FileChannel;
+import java.nio.file.FileSystemException;
+import java.nio.file.OpenOption;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.FileAttribute;
+import java.nio.file.spi.FileSystemProvider;
+import java.util.Collections;
+import java.util.Set;
+
+public class BlockFileCreationFileSystemProvider extends RootedFileSystemProvider
+{
+    /**
+     * Read only.
+     * @param path
+     * @param options
+     * @param attrs
+     * @return
+     * @throws IOException
+     */
+    @Override
+    public FileChannel newFileChannel(Path path, Set<? extends OpenOption> options, FileAttribute<?>... attrs) throws IOException {
+        Path r = unroot(path);
+        FileSystemProvider p = provider(r);
+        return p.newFileChannel(r, Collections.singleton(StandardOpenOption.READ), attrs);
+    }
+
+    @Override
+    public OutputStream newOutputStream(Path path, OpenOption... options) throws IOException {
+        throw new FileSystemException("Unsupported operation");
+    }
+}

--- a/app/src/test/java/com/amaze/filemanager/filesystem/ssh/test/TestKeyProvider.java
+++ b/app/src/test/java/com/amaze/filemanager/filesystem/ssh/test/TestKeyProvider.java
@@ -1,0 +1,28 @@
+package com.amaze.filemanager.filesystem.ssh.test;
+
+import org.apache.sshd.common.keyprovider.KeyPairProvider;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.SecureRandom;
+import java.util.Collections;
+
+public class TestKeyProvider implements KeyPairProvider {
+
+    private KeyPair keyPair;
+
+    public TestKeyProvider() throws Exception {
+        KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("RSA", "BC");
+        keyPairGenerator.initialize(1024, new SecureRandom());
+        keyPair = keyPairGenerator.generateKeyPair();
+    }
+
+    @Override
+    public Iterable<KeyPair> loadKeys() {
+        return Collections.singleton(keyPair);
+    }
+
+    public KeyPair getKeyPair() {
+        return keyPair;
+    }
+}

--- a/app/src/test/resources/simplelogger.properties
+++ b/app/src/test/resources/simplelogger.properties
@@ -1,0 +1,1 @@
+org.slf4j.simpleLogger.defaultLogLevel=debug


### PR DESCRIPTION
* Refactor UtilsHandler to centralize saving to database via OperationData
* Removed UtilsHandler.add*() in favor of saveToDb()
* Fixed bookmark name and path getting switched
* Replaced UtilsHandler.delete*() with removeFromDatabase(OperationData)
* Removed HandlerUtils.clear*Table() and made public clearTable(Operation) 

PS: later we can put some of these methods in Operations enum.