### PR TITLE
Operations.mkfile(): Add null check for OutputStream for SFTP targets

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/filesystem/Operations.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/Operations.java
@@ -213,6 +213,10 @@ public class Operations {
                 }
                 if (file.isSftp()) {
                     OutputStream out = file.getOutputStream(context);
+                    if(out == null) {
+                        errorCallBack.done(file, false);
+                        return null;
+                    }
                     try {
                         out.close();
                         errorCallBack.done(file, true);


### PR DESCRIPTION
Fixes #1229. Check for null OutputStream if destination directory does not allow user to create file.