### PR TITLE
Allow create file with filename ".txt"

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/ui/dialogs/GeneralDialogCreation.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/dialogs/GeneralDialogCreation.java
@@ -37,6 +37,7 @@ import android.support.design.widget.TextInputEditText;
 import android.support.v7.widget.AppCompatButton;
 import android.text.InputType;
 import android.text.SpannableString;
+import android.text.TextUtils;
 import android.text.TextWatcher;
 import android.text.format.Formatter;
 import android.view.View;
@@ -162,8 +163,11 @@ public class GeneralDialogCreation {
 
         MaterialDialog dialog = builder.show();
 
-        new WarnableTextInputValidator(builder.getContext(), textfield, tilTextfield,
+        WarnableTextInputValidator textInputValidator = new WarnableTextInputValidator(builder.getContext(), textfield, tilTextfield,
                 dialog.getActionButton(DialogAction.POSITIVE), validator);
+
+        if(!TextUtils.isEmpty(prefill))
+            textInputValidator.afterTextChanged(textfield.getText());
 
         return dialog;
     }

--- a/app/src/main/java/com/amaze/filemanager/utils/MainActivityHelper.java
+++ b/app/src/main/java/com/amaze/filemanager/utils/MainActivityHelper.java
@@ -8,6 +8,7 @@ import android.content.SharedPreferences;
 import android.os.AsyncTask;
 import android.os.Build;
 import android.os.Bundle;
+import android.preference.PreferenceManager;
 import android.support.annotation.StringRes;
 import android.support.design.widget.BottomSheetDialogFragment;
 import android.support.v4.app.Fragment;
@@ -37,6 +38,7 @@ import com.amaze.filemanager.fragments.CloudSheetFragment;
 import com.amaze.filemanager.fragments.MainFragment;
 import com.amaze.filemanager.fragments.SearchWorkerFragment;
 import com.amaze.filemanager.fragments.TabFragment;
+import com.amaze.filemanager.fragments.preference_fragments.PreferencesConstants;
 import com.amaze.filemanager.ui.dialogs.GeneralDialogCreation;
 import com.amaze.filemanager.ui.views.WarnableTextInputValidator;
 import com.amaze.filemanager.utils.files.CryptUtil;
@@ -146,9 +148,15 @@ public class MainActivityHelper {
             boolean isValidFilename = FileUtil.isValidFilename(text);
 
             //The redundant equalsIgnoreCase() is needed since ".txt" itself does not end with .txt (i.e. recommended as ".txt.txt"
-            if (isValidFilename && text.length() > 0 && (!text.toLowerCase().endsWith(NEW_FILE_TXT_EXTENSION) || text.equalsIgnoreCase(NEW_FILE_TXT_EXTENSION))) {
-                return new WarnableTextInputValidator.ReturnState(
-                        WarnableTextInputValidator.ReturnState.STATE_WARNING, R.string.create_file_suggest_txt_extension);
+            if (isValidFilename && text.length() > 0) {
+                SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(mainActivity);
+                if(text.startsWith(".") && !prefs.getBoolean(PreferencesConstants.PREFERENCE_SHOW_HIDDENFILES, false)){
+                    return new WarnableTextInputValidator.ReturnState(
+                            WarnableTextInputValidator.ReturnState.STATE_WARNING, R.string.create_hidden_file_warn);
+                } else if(!text.toLowerCase().endsWith(NEW_FILE_TXT_EXTENSION)) {
+                    return new WarnableTextInputValidator.ReturnState(
+                            WarnableTextInputValidator.ReturnState.STATE_WARNING, R.string.create_file_suggest_txt_extension);
+                }
             } else {
                 if (!isValidFilename) {
                     return new WarnableTextInputValidator.ReturnState(

--- a/app/src/main/java/com/amaze/filemanager/utils/MainActivityHelper.java
+++ b/app/src/main/java/com/amaze/filemanager/utils/MainActivityHelper.java
@@ -51,6 +51,8 @@ public class MainActivityHelper {
 
     public static final int NEW_FOLDER = 0, NEW_FILE = 1, NEW_SMB = 2, NEW_CLOUD = 3;
 
+    private static final String NEW_FILE_TXT_EXTENSION = ".txt";
+
     private MainActivity mainActivity;
     private DataUtils dataUtils = DataUtils.getInstance();
     private int accentColor;
@@ -136,14 +138,15 @@ public class MainActivityHelper {
      * @param ma       {@link MainFragment} current fragment
      */
     void mkfile(final OpenMode openMode, final String path, final MainFragment ma) {
-        mk(R.string.newfile, ".txt", (dialog, which) -> {
+        mk(R.string.newfile,  NEW_FILE_TXT_EXTENSION, (dialog, which) -> {
             EditText textfield = dialog.getCustomView().findViewById(R.id.singleedittext_input);
             mkFile(new HybridFile(openMode, path + "/" + textfield.getText().toString()), ma);
             dialog.dismiss();
         }, (text) -> {
             boolean isValidFilename = FileUtil.isValidFilename(text);
 
-            if (isValidFilename && text.length() > 0 && !text.toLowerCase().endsWith(".txt")) {
+            //The redundant equalsIgnoreCase() is needed since ".txt" itself does not end with .txt (i.e. recommended as ".txt.txt"
+            if (isValidFilename && text.length() > 0 && (!text.toLowerCase().endsWith(NEW_FILE_TXT_EXTENSION) || text.equalsIgnoreCase(NEW_FILE_TXT_EXTENSION))) {
                 return new WarnableTextInputValidator.ReturnState(
                         WarnableTextInputValidator.ReturnState.STATE_WARNING, R.string.create_file_suggest_txt_extension);
             } else {

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -594,4 +594,5 @@
   <string name="encrypt_file_save_as">儲存加密檔案為……</string>
   <string name="encrypt_folder_save_as">儲存加密檔案夾為……</string>
   <string name="filename">檔案名稱</string>
+  <string name="create_hidden_file_warn">此檔案將會從檔案列表中隱藏。</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -632,6 +632,6 @@
     <string name="encrypt_folder_save_as">Save Encrypted Folder As&#8230;</string>
     <string name="encrypt_file_must_end_with_aze">Encrypted files must use \".aze\" as the file extension.</string>
     <string name="cannot_overwrite">Cannot overwrite file.</string>
-    <string name="create_hidden_file_warn">The created file will be hidden in the File List.</string>
+    <string name="create_hidden_file_warn">The created file will be hidden in the file list.</string>
 </resources>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -632,5 +632,6 @@
     <string name="encrypt_folder_save_as">Save Encrypted Folder As&#8230;</string>
     <string name="encrypt_file_must_end_with_aze">Encrypted files must use \".aze\" as the file extension.</string>
     <string name="cannot_overwrite">Cannot overwrite file.</string>
+    <string name="create_hidden_file_warn">The created file will be hidden in the File List.</string>
 </resources>
 


### PR DESCRIPTION
Fixes #1231 and fixes #1235.

Trigger WarnableTextInputValidator.afterTextChanged() if prefill is not empty so warning message can be displayed too.