### PR TITLE
Little help on enabling testing on MainActivity

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -80,8 +80,9 @@ dependencies {
 
     //For tests
     androidTestImplementation 'junit:junit:4.12'//tests the app logic
-    testImplementation "org.robolectric:robolectric:3.6.1"//tests android interaction
-    testImplementation "org.robolectric:shadows-multidex:3.6.1"//tests android interaction
+    testImplementation "org.robolectric:robolectric:3.7"//tests android interaction
+    testImplementation "org.robolectric:shadows-multidex:3.7"//tests android interaction
+    testImplementation "org.robolectric:shadows-httpclient:3.7"//tests android interaction
 
     //Detect memory leaks
     debugImplementation 'com.squareup.leakcanary:leakcanary-android:1.5.3'

--- a/app/src/main/java/com/amaze/filemanager/activities/MainActivity.java
+++ b/app/src/main/java/com/amaze/filemanager/activities/MainActivity.java
@@ -576,10 +576,12 @@ public class MainActivity extends ThemedActivity implements OnRequestPermissions
             if (TextUtils.isEmpty(rawExternalStorage)) {
                 // EXTERNAL_STORAGE undefined; falling back to default.
                 // Check for actual existence of the directory before adding to list
-                if(new File(DEFAULT_FALLBACK_STORAGE_PATH).exists())
+                if(new File(DEFAULT_FALLBACK_STORAGE_PATH).exists()) {
                     rv.add(DEFAULT_FALLBACK_STORAGE_PATH);
-                else
+                } else {
+                    //We know nothing else, use Environment's fallback
                     rv.add(Environment.getExternalStorageDirectory().getAbsolutePath());
+                }
             } else {
                 rv.add(rawExternalStorage);
             }

--- a/app/src/main/java/com/amaze/filemanager/activities/MainActivity.java
+++ b/app/src/main/java/com/amaze/filemanager/activities/MainActivity.java
@@ -259,6 +259,8 @@ public class MainActivity extends ThemedActivity implements OnRequestPermissions
 
     private PasteHelper pasteHelper;
 
+    private static final String DEFAULT_FALLBACK_STORAGE_PATH = "/storage/sdcard0";
+
     /**
      * Called when the activity is first created.
      */
@@ -573,7 +575,11 @@ public class MainActivity extends ThemedActivity implements OnRequestPermissions
             // Device has physical external storage; use plain paths.
             if (TextUtils.isEmpty(rawExternalStorage)) {
                 // EXTERNAL_STORAGE undefined; falling back to default.
-                rv.add("/storage/sdcard0");
+                // Check for actual existence of the directory before adding to list
+                if(new File(DEFAULT_FALLBACK_STORAGE_PATH).exists())
+                    rv.add(DEFAULT_FALLBACK_STORAGE_PATH);
+                else
+                    rv.add(Environment.getExternalStorageDirectory().getAbsolutePath());
             } else {
                 rv.add(rawExternalStorage);
             }


### PR DESCRIPTION
Tweaks to enable writing test cases against MainActivity (or classes that calls it).

* Added shadows-httpclient to prevent ClassNotFound error
* MainActivity.getStorageDirectories(): Check for existence of `/storage/sdcard0` before actually add to list of storage directories, to prevent test crash because of MainActivity failing to create tabs