### PR TITLE
Add support for hash code of SFTP files in file lists

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/filesystem/HybridFile.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/HybridFile.java
@@ -743,6 +743,7 @@ public class HybridFile {
                                     f.setDate(info.getAttributes().getMtime() * 1000);
                                     f.setSize(f.isDirectory() ? 0 : info.getAttributes().getSize());
                                     f.setPermission(Integer.toString(FilePermission.toMask(info.getAttributes().getPermissions()), 8));
+                                    f.setHashCode(SshClientUtils.hashCode(info));
                                     onFileFound.onFileFound(f);
                                 }
                             } catch (IOException e) {

--- a/app/src/main/java/com/amaze/filemanager/filesystem/ssh/SshClientUtils.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/ssh/SshClientUtils.java
@@ -41,6 +41,7 @@ import com.amaze.filemanager.utils.cloud.CloudStreamer;
 
 import net.schmizz.sshj.SSHClient;
 import net.schmizz.sshj.connection.channel.direct.Session;
+import net.schmizz.sshj.sftp.RemoteResourceInfo;
 import net.schmizz.sshj.sftp.SFTPClient;
 
 import java.io.File;
@@ -262,5 +263,19 @@ public abstract class SshClientUtils
                 e.printStackTrace();
             }
         }).start();
+    }
+
+    /**
+     * Calculates {@link RemoteResourceInfo} hash code.
+     *
+     * @param remoteResourceInfo {@link RemoteResourceInfo} instance
+     * @return hash code calculated from path, name, is directory or not, and its size
+     */
+    public static int hashCode(@NonNull RemoteResourceInfo remoteResourceInfo){
+        int result = remoteResourceInfo.getPath().hashCode();
+        result = 37 * result + remoteResourceInfo.getName().hashCode();
+        result = 37 * result + (remoteResourceInfo.isDirectory() ? 1 : 0);
+        result = 37 * result + (int)(remoteResourceInfo.getAttributes().getSize() ^ (remoteResourceInfo.getAttributes().getSize() >>> 32));
+        return result;
     }
 }

--- a/app/src/test/java/com/amaze/filemanager/filesystem/ssh/SshClientUtilsTest.java
+++ b/app/src/test/java/com/amaze/filemanager/filesystem/ssh/SshClientUtilsTest.java
@@ -1,0 +1,67 @@
+package com.amaze.filemanager.filesystem.ssh;
+
+import net.schmizz.sshj.sftp.FileAttributes;
+import net.schmizz.sshj.sftp.FileMode;
+import net.schmizz.sshj.sftp.PathComponents;
+import net.schmizz.sshj.sftp.RemoteResourceInfo;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.util.Collections;
+
+import static org.junit.Assert.*;
+
+@RunWith(JUnit4.class)
+public class SshClientUtilsTest {
+
+    // 040755 is special mask for directories. See sshj's unit test for details
+    @Test
+    public void testDifferentHashCodeByName(){
+        PathComponents p1 = new PathComponents(null, "/bin", "/");
+        PathComponents p2 = new PathComponents(null, "/lib", "/");
+        FileAttributes f1 = new FileAttributes(700, 4096, 1000, 1000, new FileMode(040755), -1, -1, Collections.emptyMap());
+        FileAttributes f2 = new FileAttributes(700, 4096, 1000, 1000, new FileMode(040755), -1, -1, Collections.emptyMap());
+        RemoteResourceInfo r1 = new RemoteResourceInfo(p1, f1);
+        RemoteResourceInfo r2 = new RemoteResourceInfo(p2, f2);
+
+        assertNotEquals(SshClientUtils.hashCode(r1), SshClientUtils.hashCode(r2));
+    }
+
+    @Test
+    public void testDifferentHashCodeBySize(){
+        PathComponents p1 = new PathComponents(null, "/foo/bar/android/test1.txt", "/");
+        PathComponents p2 = new PathComponents(null, "/foo/bar/android/test1.txt", "/");
+        FileAttributes f1 = new FileAttributes(700, 8132, 1000, 1000, new FileMode(700), -1, -1, Collections.emptyMap());
+        FileAttributes f2 = new FileAttributes(700, 8192, 1000, 1000, new FileMode(700), -1, -1, Collections.emptyMap());
+        RemoteResourceInfo r1 = new RemoteResourceInfo(p1, f1);
+        RemoteResourceInfo r2 = new RemoteResourceInfo(p2, f2);
+
+        assertNotEquals(SshClientUtils.hashCode(r1), SshClientUtils.hashCode(r2));
+    }
+
+    @Test
+    public void testDifferentHashCodeByType(){
+        PathComponents p1 = new PathComponents(null, "/foo/bar/android/test1", "/");
+        PathComponents p2 = new PathComponents(null, "/foo/bar/android/test1", "/");
+        FileAttributes f1 = new FileAttributes(700, 4096, 1000, 1000, new FileMode(700), -1, -1, Collections.emptyMap());
+        FileAttributes f2 = new FileAttributes(700, 4096, 1000, 1000, new FileMode(040755), -1, -1, Collections.emptyMap());
+        RemoteResourceInfo r1 = new RemoteResourceInfo(p1, f1);
+        RemoteResourceInfo r2 = new RemoteResourceInfo(p2, f2);
+
+        assertNotEquals(SshClientUtils.hashCode(r1), SshClientUtils.hashCode(r2));
+    }
+
+    @Test
+    public void testIdenticalHashCode(){
+        PathComponents p1 = new PathComponents(null, "/foo/bar/android/test1.txt", "/");
+        PathComponents p2 = new PathComponents(null, "/foo/bar/android/test1.txt", "/");
+        FileAttributes f1 = new FileAttributes(700, 856, 1000, 1000, new FileMode(700), -1, -1, Collections.emptyMap());
+        FileAttributes f2 = new FileAttributes(700, 856, 1000, 1000, new FileMode(700), -1, -1, Collections.emptyMap());
+        RemoteResourceInfo r1 = new RemoteResourceInfo(p1, f1);
+        RemoteResourceInfo r2 = new RemoteResourceInfo(p2, f2);
+
+        assertEquals(SshClientUtils.hashCode(r1), SshClientUtils.hashCode(r2));
+    }
+}


### PR DESCRIPTION
Addendum to #1228, add support of calculating hash code for `RemoteResourceInfo` the representation of files stored on SSH server which [sshj](https://github.com/hierynomus/sshj) uses.

Hash code calculation method is derived from [here](https://stackoverflow.com/a/113600/768633).

Unit test included.