### PR TITLE
Fix possibility of archive entry extracted outside specified destination for 3.2.1

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/services/asynctasks/RarHelperTask.java
+++ b/app/src/main/java/com/amaze/filemanager/services/asynctasks/RarHelperTask.java
@@ -61,7 +61,7 @@ public class RarHelperTask extends AsyncTask<File, Void, ArrayList<FileHeader>> 
                     String name = header.getFileNameString();
 
                     if (!name.contains("\\")) {
-                        if(name.startsWith("..\\") || name.equals("..")) {
+                        if(name.startsWith("..\\") || name.startsWith("../") || name.equals("..")) {
                             continue;
                         }
 
@@ -71,7 +71,7 @@ public class RarHelperTask extends AsyncTask<File, Void, ArrayList<FileHeader>> 
             } else {
                 for (FileHeader header : zipViewer.wholelistRar) {
                     String name = header.getFileNameString();
-                    if(name.startsWith("..\\") || name.equals("..")) {
+                    if(name.startsWith("..\\") || name.startsWith("../") || name.equals("..")) {
                         continue;
                     }
                     if (name.substring(0, name.lastIndexOf("\\")).equals(dir)) {

--- a/app/src/main/java/com/amaze/filemanager/services/asynctasks/ZipHelperTask.java
+++ b/app/src/main/java/com/amaze/filemanager/services/asynctasks/ZipHelperTask.java
@@ -68,11 +68,9 @@ public class ZipHelperTask extends AsyncTask<String, Void, ArrayList<ZipObj>> {
 
             for (ZipObj entry : zipViewer.wholelist) {
 
-                String s = entry.getName();
-                //  System.out.println(s);
                 File file = new File(entry.getName());
 
-                if(entry.getName().startsWith("../") || entry.getName().equals("..")) {
+                if(entry.getName().startsWith("../") || entry.getName().startsWith("..\\") || entry.getName().equals("..")) {
                     continue;
                 }
 


### PR DESCRIPTION
Backported from #1258.

Copied from [comment](https://github.com/TeamAmaze/AmazeFileManager/pull/1258#issuecomment-393011994):

> Since 3.2.1 codebase doesn't in favour of writing unit tests, verification was done against Pixel 2 emulators running 5.1.1, 6.0, 7.1.1, 8.1, plus Oneplus One running Slim7 (7.1.2), Galaxy S2 running SlimLP (5.1.1) and GPD XD running LegacyROM (4.4.4).
