### PR TITLE
Fix intent-filter for cloudrail to identify entrypoint for google drive

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -89,13 +89,13 @@
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
                 <data android:scheme="com.amaze.filemanager" />
-                <data android:mimeType="resource/folder" />
             </intent-filter>
 
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
                 <data android:mimeType="resource/folder" />
                 <category android:name="android.intent.category.DEFAULT" />
+                <data android:scheme="com.amaze.filemanager" />
             </intent-filter>
 
             <intent-filter android:label="@string/intent_save_as">

--- a/app/src/main/java/com/amaze/filemanager/activities/MainActivity.java
+++ b/app/src/main/java/com/amaze/filemanager/activities/MainActivity.java
@@ -244,7 +244,7 @@ public class MainActivity extends PermissionsActivity implements SmbConnectionLi
     public static final String ARGS_INTENT_ACTION_VIEW_MIME_FOLDER = "resource/folder";
 
     private static final String CLOUD_AUTHENTICATOR_GDRIVE = "android.intent.category.BROWSABLE";
-    private static final String CLOUD_AUTHENTICATOR_REDIRECT_URI = "com.amaze.filemanager:/oauth2redirect";
+    private static final String CLOUD_AUTHENTICATOR_REDIRECT_URI = "com.amaze.filemanager:/auth";
 
     // the current visible tab, either 0 or 1
     public static int currentTab;


### PR DESCRIPTION
There was no issue created for this. But it fixes the redirect problem on current master with google drive connection. We currently get no redirect back to amaze so the connection is never created.
I don't think I've added SHA-1 fingerprint for your android studio debug key so you shouldn't even be able to add a drive connection but rest assured, I tested this and it's safe to merge.