### PR TITLE
Null safety on EditText.getTypeFace() for API 15

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -88,7 +88,7 @@ dependencies {
     testImplementation "org.apache.sshd:sshd-core:1.7.0"
 
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.0'
-    androidTestImplementation 'com.android.support.test:runner:1.0.2'
+    debugImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test:rules:1.0.2'
     androidTestImplementation 'com.android.support:support-annotations:27.0.2'
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -29,6 +29,7 @@ android {
         multiDexEnabled true
 
         vectorDrawables.useSupportLibrary = true
+        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
 
     signingConfigs {
@@ -85,6 +86,11 @@ dependencies {
     testImplementation "org.robolectric:shadows-httpclient:3.7"//tests android interaction
 
     testImplementation "org.apache.sshd:sshd-core:1.7.0"
+
+    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.0'
+    androidTestImplementation 'com.android.support.test:runner:1.0.2'
+    androidTestImplementation 'com.android.support.test:rules:1.0.2'
+    androidTestImplementation 'com.android.support:support-annotations:27.0.2'
 
     //Detect memory leaks
     debugImplementation 'com.squareup.leakcanary:leakcanary-android:1.5.3'
@@ -164,6 +170,7 @@ configurations.all {
     resolutionStrategy {
         dependencySubstitution {
             substitute module("commons-logging:commons-logging-api:1.1") with module("commons-logging:commons-logging:1.1.1")
+            substitute module("com.android.support:support-annotations:27.1.1") with module("com.android.support:support-annotations:27.0.2")
         }
     }
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -87,10 +87,10 @@ dependencies {
 
     testImplementation "org.apache.sshd:sshd-core:1.7.0"
 
-    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.0'
+    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
     debugImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test:rules:1.0.2'
-    androidTestImplementation 'com.android.support:support-annotations:27.0.2'
+    androidTestImplementation 'com.android.support:support-annotations:27.1.1'
 
     //Detect memory leaks
     debugImplementation 'com.squareup.leakcanary:leakcanary-android:1.5.3'

--- a/app/src/androidTest/java/com/amaze/filemanager/activities/TextEditorActivityEspressoTest.java
+++ b/app/src/androidTest/java/com/amaze/filemanager/activities/TextEditorActivityEspressoTest.java
@@ -1,0 +1,58 @@
+package com.amaze.filemanager.activities;
+
+import android.content.Context;
+import android.content.Intent;
+import android.net.Uri;
+import android.support.test.InstrumentationRegistry;
+import android.support.test.filters.SmallTest;
+import android.support.test.rule.ActivityTestRule;
+import android.support.test.runner.AndroidJUnit4;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.File;
+import java.util.concurrent.CountDownLatch;
+
+import static org.junit.Assert.*;
+
+@SmallTest
+@RunWith(AndroidJUnit4.class)
+public class TextEditorActivityEspressoTest {
+
+    @Rule
+    public ActivityTestRule<TextEditorActivity> activityRule = new ActivityTestRule<>(TextEditorActivity.class, true, false);
+
+    private Context context;
+
+    private Uri uri;
+
+    @Before
+    public void setUp() {
+        context = InstrumentationRegistry.getTargetContext();
+
+        File file = new File("/default.prop");
+        uri = Uri.fromFile(file);
+    }
+
+    @Test
+    public void testOpenFile() throws Exception {
+        Intent intent = new Intent(context, TextEditorActivity.class)
+            .setAction(Intent.ACTION_VIEW)
+            .addCategory(Intent.CATEGORY_DEFAULT)
+            .setType("text/plain")
+            .setData(uri);
+        activityRule.launchActivity(intent);
+        CountDownLatch waiter = new CountDownLatch(1);
+        while("".equals(activityRule.getActivity().mInput.getText().toString())){
+            waiter.await();
+        }
+        waiter.countDown();
+        assertNotEquals("", activityRule.getActivity().mInput.getText());
+        assertNotEquals("foobar", activityRule.getActivity().mInput.getText());
+        //Add extra time for you to see the Activity did load, and text is actually there
+        //Thread.sleep(1000);
+    }
+}

--- a/app/src/androidTest/java/com/amaze/filemanager/utils/files/CryptUtilTest.java
+++ b/app/src/androidTest/java/com/amaze/filemanager/utils/files/CryptUtilTest.java
@@ -1,0 +1,27 @@
+package com.amaze.filemanager.utils.files;
+
+import android.content.Context;
+import android.support.test.InstrumentationRegistry;
+import android.support.test.runner.AndroidJUnit4;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.*;
+
+@RunWith(AndroidJUnit4.class)
+public class CryptUtilTest {
+
+    private Context context;
+
+    public void setUp(){
+        context = InstrumentationRegistry.getTargetContext();
+    }
+
+    @Test
+    public void testEncryptDecrypt() throws Exception {
+        String password = "hackme";
+        String encrypted = CryptUtil.encryptPassword(context, password);
+        assertEquals(password, CryptUtil.decryptPassword(context, encrypted));
+    }
+}

--- a/app/src/main/java/com/amaze/filemanager/activities/TextEditorActivity.java
+++ b/app/src/main/java/com/amaze/filemanager/activities/TextEditorActivity.java
@@ -204,6 +204,9 @@ public class TextEditorActivity extends ThemedActivity implements TextWatcher, V
         else if (getAppTheme().equals(AppTheme.BLACK))
             mInput.setBackgroundColor(Utils.getColor(this, android.R.color.black));
 
+        if(mInput.getTypeface() == null)
+            mInput.setTypeface(Typeface.DEFAULT);
+
         mInputTypefaceDefault = mInput.getTypeface();
         mInputTypefaceMono = Typeface.MONOSPACE;
 
@@ -224,7 +227,7 @@ public class TextEditorActivity extends ThemedActivity implements TextWatcher, V
         outState.putString(KEY_MODIFIED_TEXT, mInput.getText().toString());
         outState.putInt(KEY_INDEX, mInput.getScrollY());
         outState.putString(KEY_ORIGINAL_TEXT, mOriginal);
-        outState.putBoolean(KEY_MONOFONT, mInput.getTypeface().equals(mInputTypefaceMono));
+        outState.putBoolean(KEY_MONOFONT, mInputTypefaceMono.equals(mInput.getTypeface()));
     }
 
     private void checkUnsavedChanges() {
@@ -346,7 +349,7 @@ public class TextEditorActivity extends ThemedActivity implements TextWatcher, V
     @Override
     public boolean onPrepareOptionsMenu(Menu menu) {
         menu.findItem(R.id.save).setVisible(mModified);
-        menu.findItem(R.id.monofont).setChecked(mInput.getTypeface().equals(mInputTypefaceMono));
+        menu.findItem(R.id.monofont).setChecked(mInputTypefaceMono.equals(mInput.getTypeface()));
         return super.onPrepareOptionsMenu(menu);
     }
 


### PR DESCRIPTION
Fixes #1160. If `EditText.getTypeFace()` is null the default typeface (`TypeFace.DEFAULT`) will be inserted into the `EditText`. Also reversed equality checks (`mInputTypefaceMono.equals(mInput.getTypeface()`) for null safety.

This should be where the crash came from; however on testing with emulator running API 15, there had been frequent cases opening text file ended up crashes Android itself (black screen -> boot animation -> lock screen). Debugging app suggested the crash was inside `Looper.loop()`, which seems to be out of my knowledge...

The only message in the logcat I can see which makes sense:

`DexOpt: unable to opt direct call 0x00d0 at 0x8f in Lcom/amaze/filemanager/activities/TextEditorActivity;.onCreate`

But in debug session the whole `TextEditorActivity.onCreate()` ran smooth without any problem.