### PR TITLE
Add Espresso test framework to source tree

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -88,7 +88,7 @@ dependencies {
     testImplementation "org.apache.sshd:sshd-core:1.7.0"
 
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.0'
-    androidTestImplementation 'com.android.support.test:runner:1.0.2'
+    debugImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test:rules:1.0.2'
     androidTestImplementation 'com.android.support:support-annotations:27.0.2'
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -29,6 +29,7 @@ android {
         multiDexEnabled true
 
         vectorDrawables.useSupportLibrary = true
+        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
 
     signingConfigs {
@@ -85,6 +86,11 @@ dependencies {
     testImplementation "org.robolectric:shadows-httpclient:3.7"//tests android interaction
 
     testImplementation "org.apache.sshd:sshd-core:1.7.0"
+
+    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.0'
+    androidTestImplementation 'com.android.support.test:runner:1.0.2'
+    androidTestImplementation 'com.android.support.test:rules:1.0.2'
+    androidTestImplementation 'com.android.support:support-annotations:27.0.2'
 
     //Detect memory leaks
     debugImplementation 'com.squareup.leakcanary:leakcanary-android:1.5.3'
@@ -164,6 +170,7 @@ configurations.all {
     resolutionStrategy {
         dependencySubstitution {
             substitute module("commons-logging:commons-logging-api:1.1") with module("commons-logging:commons-logging:1.1.1")
+            substitute module("com.android.support:support-annotations:27.1.1") with module("com.android.support:support-annotations:27.0.2")
         }
     }
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -87,10 +87,10 @@ dependencies {
 
     testImplementation "org.apache.sshd:sshd-core:1.7.0"
 
-    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.0'
+    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
     debugImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test:rules:1.0.2'
-    androidTestImplementation 'com.android.support:support-annotations:27.0.2'
+    androidTestImplementation 'com.android.support:support-annotations:27.1.1'
 
     //Detect memory leaks
     debugImplementation 'com.squareup.leakcanary:leakcanary-android:1.5.3'

--- a/app/src/androidTest/java/com/amaze/filemanager/utils/files/CryptUtilTest.java
+++ b/app/src/androidTest/java/com/amaze/filemanager/utils/files/CryptUtilTest.java
@@ -1,0 +1,27 @@
+package com.amaze.filemanager.utils.files;
+
+import android.content.Context;
+import android.support.test.InstrumentationRegistry;
+import android.support.test.runner.AndroidJUnit4;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.*;
+
+@RunWith(AndroidJUnit4.class)
+public class CryptUtilTest {
+
+    private Context context;
+
+    public void setUp(){
+        context = InstrumentationRegistry.getTargetContext();
+    }
+
+    @Test
+    public void testEncryptDecrypt() throws Exception {
+        String password = "hackme";
+        String encrypted = CryptUtil.encryptPassword(context, password);
+        assertEquals(password, CryptUtil.decryptPassword(context, encrypted));
+    }
+}


### PR DESCRIPTION
Facilitate writing test cases that requires Android device (physical/emulator) to run, as in #1244. The test case written for #1244 was included for reference.

A note about this line in app/build.gradle:
> `testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"`

It didn't affect Robolectric-based tests, and we only run tests from Android Studio, it should be fine.