### PR TITLE
Change order of jcenter/google repo order

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,8 +2,8 @@
 
 buildscript {
     repositories {
-        jcenter()
         google()
+        jcenter()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.1.2'
@@ -15,8 +15,8 @@ buildscript {
 
 allprojects {
     repositories {
-        jcenter()
         google()
+        jcenter()
         maven { url "https://jitpack.io" }
         mavenCentral()
     }


### PR DESCRIPTION
This fixes problem of failing to resolve android.arch.core:common:1.1.0 on build, which causes recent Travis CI builds failed on PRs.

[Reference](https://stackoverflow.com/a/50563942/768633)