### PR TITLE
Update compile SDK version + depending libs to version 27

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ android:
     - platform-tools
     - tools
     - build-tools-27.0.3
-    - android-26
+    - android-27
     - extra-google-m2repository
 
 script: "./gradlew assembledebug"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 26
+    compileSdkVersion 27
     buildToolsVersion '27.0.3'
 
     dexOptions {
@@ -71,12 +71,12 @@ dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
     implementation 'com.readystatesoftware.systembartint:systembartint:1.0.3'
 
-    implementation 'com.android.support:animated-vector-drawable:26.1.0'
-    implementation 'com.android.support:support-v13:26.1.0'
-    implementation 'com.android.support:design:26.1.0'
-    implementation 'com.android.support:appcompat-v7:26.1.0'
-    implementation 'com.android.support:palette-v7:26.1.0'
-    implementation 'com.android.support:cardview-v7:26.1.0'
+    implementation 'com.android.support:animated-vector-drawable:27.1.1'
+    implementation 'com.android.support:support-v13:27.1.1'
+    implementation 'com.android.support:design:27.1.1'
+    implementation 'com.android.support:appcompat-v7:27.1.1'
+    implementation 'com.android.support:palette-v7:27.1.1'
+    implementation 'com.android.support:cardview-v7:27.1.1'
 
     //For tests
     androidTestImplementation 'junit:junit:4.12'//tests the app logic


### PR DESCRIPTION
Fixes problem of proguard failed to run on making release builds, when this message was seen in console output

`Warning: com.bumptech.glide.load.resource.bitmap.VideoDecoder: can't find referenced method 'android.graphics.Bitmap getScaledFrameAtTime(long,int,int,int)' in library class android.media.MediaMetadataRetriever`

Does not affect 3.2.x branches, but >= 3.3.0 since proguard is enabled for their release builds.