### PR TITLE
FTPService URL display fixes

### DIFF
--- a/app/src/androidTest/java/com/amaze/filemanager/asynchronous/services/ftp/FTPServiceStaticMethodsTest.java
+++ b/app/src/androidTest/java/com/amaze/filemanager/asynchronous/services/ftp/FTPServiceStaticMethodsTest.java
@@ -1,0 +1,47 @@
+package com.amaze.filemanager.asynchronous.services.ftp;
+
+import android.content.Context;
+import android.support.test.InstrumentationRegistry;
+import android.support.test.filters.SmallTest;
+import android.support.test.runner.AndroidJUnit4;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.*;
+
+/**
+ * This test is separated from FTPServiceEspressoTest since it does not actually requires the FTP
+ * service itself.
+ *
+ * It is expected that you are not running all the cases in one go. <b>You have been warned</b>.
+ */
+
+@SmallTest
+@RunWith(AndroidJUnit4.class)
+public class FTPServiceStaticMethodsTest {
+
+    /**
+     * To test {@link FTPService#getLocalInetAddress(Context)} must not return an empty string.
+     */
+    @Test
+    public void testGetLocalInetAddressMustNotBeEmpty(){
+        if(!FTPService.isConnectedToLocalNetwork(InstrumentationRegistry.getTargetContext()))
+            fail("Please connect your device to network to run this test!");
+        assertNotNull(FTPService.getLocalInetAddress(InstrumentationRegistry.getTargetContext()));
+        assertNotNull(FTPService.getLocalInetAddress(InstrumentationRegistry.getTargetContext()).getHostAddress());
+    }
+
+    /**
+     * To test IP address returned by {@link FTPService#getLocalInetAddress(Context)} must be 192.168.43.1.
+     *
+     * <b>Remember to turn on wifi AP when running this test on <u>real</u> devices.</b>
+     */
+    @Test
+    public void testGetLocalInetAddressMustBeAPAddress(){
+        if(!FTPService.isEnabledWifiHotspot(InstrumentationRegistry.getTargetContext()))
+            fail("Please enable wifi hotspot on your device to run this test!");
+
+        assertEquals("192.168.43.1", FTPService.getLocalInetAddress(InstrumentationRegistry.getTargetContext()).getHostAddress());
+    }
+}

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/services/ftp/FTPService.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/services/ftp/FTPService.java
@@ -88,7 +88,7 @@ public class FTPService extends Service implements Runnable {
     public static final String KEY_PREFERENCE_SECURE = "ftp_secure";
     public static final String DEFAULT_PATH = Environment.getExternalStorageDirectory().getAbsolutePath();
     public static final String INITIALS_HOST_FTP = "ftp://";
-    public static final String INITIALS_HOST_SFTP = "sftp://";
+    public static final String INITIALS_HOST_SFTP = "ftps://";
 
     private static final String TAG = FTPService.class.getSimpleName();
 
@@ -320,9 +320,10 @@ public class FTPService extends Service implements Runnable {
         WifiManager wm = (WifiManager) context.getSystemService(Context.WIFI_SERVICE);
         try {
             Method method = wm.getClass().getDeclaredMethod("isWifiApEnabled");
-            enabled = (Boolean) method.invoke(wm);
+            enabled = (method != null) ? (Boolean) method.invoke(wm) : false;
         } catch (Exception e) {
             e.printStackTrace();
+            enabled = false;
         }
         return enabled;
     }
@@ -343,21 +344,18 @@ public class FTPService extends Service implements Runnable {
         }
 
         try {
-            Enumeration<NetworkInterface> netinterfaces = NetworkInterface
-                    .getNetworkInterfaces();
+            Enumeration<NetworkInterface> netinterfaces = NetworkInterface.getNetworkInterfaces();
             while (netinterfaces.hasMoreElements()) {
                 NetworkInterface netinterface = netinterfaces.nextElement();
                 Enumeration<InetAddress> addresses = netinterface.getInetAddresses();
                 while (addresses.hasMoreElements()) {
                     InetAddress address = addresses.nextElement();
 
-                    if(isEnabledWifiHotspot(context)
-                            && WIFI_AP_ADDRESS.equals(address.getHostAddress()))
+                    if(WIFI_AP_ADDRESS.equals(address.getHostAddress()) && isEnabledWifiHotspot(context))
                         return address;
 
                     // this is the condition that sometimes gives problems
-                    if (!address.isLoopbackAddress()
-                            && !address.isLinkLocalAddress())
+                    if (!address.isLoopbackAddress() && !address.isLinkLocalAddress() && !isEnabledWifiHotspot(context))
                         return address;
                 }
             }


### PR DESCRIPTION
 * `getLocalInetAddress()` should always return 192.168.43.1 (AP's hard-coded IP address) when wifi AP is on (related to #1301)
 * URL prefix for FTP server running at implicit SSL mode changed to `ftps://`. Fixes #1300 
 * Null safety in `isEnabledWifiHotspot()`, for prevent crashing FTPService in Robolectric tests