### PR TITLE
Add tests for CloudStreamSource, HybridFileParcelable and StreamSourceTest

### DIFF
--- a/app/src/androidTest/java/com/amaze/filemanager/filesystem/HybridFileParcelableTest.java
+++ b/app/src/androidTest/java/com/amaze/filemanager/filesystem/HybridFileParcelableTest.java
@@ -1,0 +1,267 @@
+package com.amaze.filemanager.filesystem;
+
+import android.os.Parcel;
+import android.support.test.runner.AndroidJUnit4;
+
+import com.amaze.filemanager.utils.OpenMode;
+
+import org.junit.*;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.*;
+
+/**
+ * Created by Rustam Khadipash on 29/3/2018.
+ */
+@RunWith(AndroidJUnit4.class)
+public class HybridFileParcelableTest {
+    private HybridFileParcelable filePath;
+    private HybridFileParcelable directory;
+    private HybridFileParcelable file;
+
+    @Before
+    public void setUp() {
+        // Initialization with a file's path only
+        filePath =
+                new HybridFileParcelable("/storage/sdcard0/Test1/Test1.txt");
+
+        // Initialization of a directory
+        directory =
+                new HybridFileParcelable("/storage/sdcard0/Test2",
+                        "rw", 123456, 654321, true);
+
+        // Initialization of a file with full list of parameters
+        file =
+                new HybridFileParcelable("/storage/sdcard0/Test3/Test3.txt",
+                        "rw", 123456, 654321, false);
+    }
+
+    /**
+     * Purpose: Get name of a file / directory
+     * Input: no
+     * Expected:
+     *          return file / directory's name
+     */
+    @Test
+    public void getName() {
+        assertEquals("Test1.txt", filePath.getName());
+        assertEquals("Test2", directory.getName());
+        assertEquals("Test3.txt", file.getName());
+    }
+
+    /**
+     * Purpose: Change name of a file / directory
+     * Input: setName newName
+     * Expected:
+     *          File / directory's name is changed
+     */
+    @Test
+    public void setName() {
+        filePath.setName("Tset1.txt");
+        assertEquals("Tset1.txt", filePath.getName());
+        directory.setName("Tset2");
+        assertEquals("Tset2", directory.getName());
+        file.setName("Tset3.txt");
+        assertEquals("Tset3.txt", file.getName());
+    }
+
+    /**
+     * Purpose: Get open mode of a file / directory
+     * Input: no
+     * Expected:
+     *          return OpenMode.FILE
+     *
+     * All files and directories in this class have
+     * open mode set as OpenMode.FILE
+     */
+    @Test
+    public void getMode() {
+        assertEquals(OpenMode.FILE, filePath.getMode());
+        assertEquals(OpenMode.FILE, directory.getMode());
+        assertEquals(OpenMode.FILE, file.getMode());
+    }
+
+    /**
+     * Purpose: Get link to a file / directory
+     * Input: no
+     * Expected:
+     *          return empty string
+     */
+    @Test
+    public void getLink() {
+        assertEquals("", filePath.getLink());
+        assertEquals("", directory.getLink());
+        assertEquals("", file.getLink());
+    }
+
+    /**
+     * Purpose: Set link to a file / directory
+     * Input: setLink newLink
+     * Expected:
+     *          File / directory's link is changed
+     */
+    @Test
+    public void setLink() {
+        filePath.setLink("abc");
+        assertEquals("abc", filePath.getLink());
+        directory.setLink("def");
+        assertEquals("def", directory.getLink());
+        file.setLink("ghi");
+        assertEquals("ghi", file.getLink());
+    }
+
+    /**
+     * Purpose: Get creation date of a file / directory
+     * Input: no
+     * Expected:
+     *          return date
+     */
+    @Test
+    public void getDate() {
+        assertEquals(0, filePath.getDate());
+        assertEquals(123456, directory.getDate());
+        assertEquals(123456, file.getDate());
+    }
+
+    /**
+     * Purpose: Change creation date of a file / directory
+     * Input: setDate newDate
+     * Expected:
+     *          File / directory's creation date is changed
+     */
+    @Test
+    public void setDate() {
+        filePath.setDate(746352);
+        assertEquals(746352, filePath.getDate());
+        directory.setDate(474587);
+        assertEquals(474587, directory.getDate());
+        file.setDate(3573335);
+        assertEquals(3573335, file.getDate());
+    }
+
+    /**
+     * Purpose: Get size of a file / directory
+     * Input: no
+     * Expected:
+     *          return size
+     */
+    @Test
+    public void getSize() {
+        assertEquals(0, filePath.getSize());
+        assertEquals(654321, directory.getSize());
+        assertEquals(654321, file.getSize());
+    }
+
+    /**
+     * Purpose: Change size of a file / directory
+     * Input: setSize newSize
+     * Expected:
+     *          File / directory's size is changed
+     */
+    @Test
+    public void setSize() {
+        filePath.setSize(3534546);
+        assertEquals(3534546, filePath.getSize());
+        directory.setSize(1745534);
+        assertEquals(1745534, directory.getSize());
+        file.setSize(7546543);
+        assertEquals(7546543, file.getSize());
+    }
+
+    /**
+     * Purpose: Check whether it is a file or directory
+     * Input: no
+     * Expected:
+     *          return directory
+     */
+    @Test
+    public void isDirectory() {
+        assertEquals(false, filePath.isDirectory());
+        assertEquals(true, directory.isDirectory());
+        assertEquals(false, file.isDirectory());
+    }
+
+    /**
+     * Purpose: Change type to file / directory
+     * Input: setDirectory isDirectory
+     * Expected:
+     *          File / directory's type is changed
+     */
+    @Test
+    public void setDirectory() {
+        filePath.setDirectory(true);
+        assertEquals(true, filePath.isDirectory());
+        directory.setDirectory(false);
+        assertEquals(false, directory.isDirectory());
+        file.setDirectory(true);
+        assertEquals(true, file.isDirectory());
+    }
+
+    /**
+     * Purpose: Get path to a file / directory
+     * Input: no
+     * Expected:
+     *          return path
+     */
+    @Test
+    public void getPath() {
+        assertEquals("/storage/sdcard0/Test1/Test1.txt", filePath.getPath());
+        assertEquals("/storage/sdcard0/Test2", directory.getPath());
+        assertEquals("/storage/sdcard0/Test3/Test3.txt", file.getPath());
+    }
+
+    /**
+     * Purpose: Get file / directory's permissions
+     * Input: no
+     * Expected:
+     *          return permissions
+     */
+    @Test
+    public void getPermission() {
+        assertEquals(null, filePath.getPermission());
+        assertEquals("rw", directory.getPermission());
+        assertEquals("rw", file.getPermission());
+    }
+
+    /**
+     * Purpose: Change permissions of a file / directory
+     * Input: setPermission newPermission
+     * Expected:
+     *          File / directory's permissions are changed
+     */
+    @Test
+    public void setPermission() {
+        filePath.setPermission("rwx");
+        assertEquals("rwx", filePath.getPermission());
+        directory.setPermission("rwx");
+        assertEquals("rwx", directory.getPermission());
+        file.setPermission("rwx");
+        assertEquals("rwx", file.getPermission());
+    }
+
+    /**
+     * Purpose: Write an object into a parcel, send it through an intent
+     * and read the object from the parcel
+     * Input: writeToParcel parcel object
+     * Expected:
+     *          The parcel can be sent and the object can be
+     *          extracted from the parcel
+     */
+    @Test
+    public void writeToParcel() {
+        Parcel parcel = Parcel.obtain();
+        file.writeToParcel(parcel, file.describeContents());
+        parcel.setDataPosition(0);
+
+        HybridFileParcelable createdFromParcel =
+                HybridFileParcelable.CREATOR.createFromParcel(parcel);
+        assertEquals(file.getDate(), createdFromParcel.getDate());
+        assertEquals(file.getLink(), createdFromParcel.getLink());
+        assertEquals(file.getMode(), createdFromParcel.getMode());
+        assertEquals(file.getName(), createdFromParcel.getName());
+        assertEquals(file.getPath(), createdFromParcel.getPath());
+        assertEquals(file.getPermission(), createdFromParcel.getPermission());
+        assertEquals(file.getSize(), createdFromParcel.getSize());
+        assertEquals(file.isDirectory(), createdFromParcel.isDirectory());
+    }
+}

--- a/app/src/androidTest/java/com/amaze/filemanager/filesystem/HybridFileParcelableTest.java
+++ b/app/src/androidTest/java/com/amaze/filemanager/filesystem/HybridFileParcelableTest.java
@@ -21,18 +21,12 @@ public class HybridFileParcelableTest {
 
     @Before
     public void setUp() {
-        // Initialization with a file's path only
-        filePath =
-                new HybridFileParcelable("/storage/sdcard0/Test1/Test1.txt");
+        filePath = new HybridFileParcelable("/storage/sdcard0/Test1/Test1.txt");
 
-        // Initialization of a directory
-        directory =
-                new HybridFileParcelable("/storage/sdcard0/Test2",
+        directory = new HybridFileParcelable("/storage/sdcard0/Test2",
                         "rw", 123456, 654321, true);
 
-        // Initialization of a file with full list of parameters
-        file =
-                new HybridFileParcelable("/storage/sdcard0/Test3/Test3.txt",
+        file = new HybridFileParcelable("/storage/sdcard0/Test3/Test3.txt",
                         "rw", 123456, 654321, false);
     }
 

--- a/app/src/androidTest/java/com/amaze/filemanager/filesystem/HybridFileParcelableTest.java
+++ b/app/src/androidTest/java/com/amaze/filemanager/filesystem/HybridFileParcelableTest.java
@@ -13,7 +13,6 @@ import static org.junit.Assert.*;
 /**
  * Created by Rustam Khadipash on 29/3/2018.
  */
-@RunWith(AndroidJUnit4.class)
 public class HybridFileParcelableTest {
     private HybridFileParcelable filePath;
     private HybridFileParcelable directory;

--- a/app/src/test/java/com/amaze/filemanager/shadows/jcifs/smb/ShadowSmbFile.java
+++ b/app/src/test/java/com/amaze/filemanager/shadows/jcifs/smb/ShadowSmbFile.java
@@ -1,0 +1,40 @@
+package com.amaze.filemanager.shadows.jcifs.smb;
+
+import org.robolectric.annotation.Implementation;
+import org.robolectric.annotation.Implements;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+
+import jcifs.smb.NtlmPasswordAuthentication;
+import jcifs.smb.SmbException;
+import jcifs.smb.SmbFile;
+import jcifs.smb.SmbFileInputStream;
+
+@Implements(SmbFile.class)
+public class ShadowSmbFile {
+
+    private File file = null;
+
+    @Implementation
+    public void __constructor__(URL url, NtlmPasswordAuthentication auth) {
+        //intentionally empty
+    }
+
+    public void setFile(File file) {
+        this.file = file;
+    }
+
+    @Implementation
+    public InputStream getInputStream() throws IOException {
+        return new FileInputStream(file);
+    }
+
+    @Implementation
+    public long length() throws SmbException {
+        return file.length();
+    }
+}

--- a/app/src/test/java/com/amaze/filemanager/utils/SmbStreamer/StreamSourceTest.java
+++ b/app/src/test/java/com/amaze/filemanager/utils/SmbStreamer/StreamSourceTest.java
@@ -1,0 +1,315 @@
+package com.amaze.filemanager.utils.SmbStreamer;
+
+import org.junit.*;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+
+import jcifs.smb.NtlmPasswordAuthentication;
+import jcifs.smb.SmbFile;
+import jcifs.smb.SmbFileInputStream;
+
+import static org.junit.Assert.*;
+
+/**
+ * Created by Rustam Khadipash on 30/3/2018.
+ */
+public class StreamSourceTest {
+    private SmbFile file;
+    private StreamSource ssEmpty;
+    private StreamSource ss;
+    private byte[] text;
+
+    // File Test.txt is 20 characters length
+    // And contains "This is a test file." phrase
+    @Before
+    public void setUp() throws Exception {
+        file = new SmbFile("smb://192.168.0.101/Test/Test.txt",
+                new NtlmPasswordAuthentication(null, "usertest", "12345"));
+
+        text = ((new BufferedReader(new InputStreamReader(new SmbFileInputStream(file))))
+                .readLine()).getBytes();
+        ssEmpty = new StreamSource();
+        ss = new StreamSource(file, file.length());
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        file = null;
+        text = null;
+        ss = null;
+    }
+
+    /**
+     * Purpose: Open an empty stream
+     * Input: no
+     * Expected:
+     *          IOException is thrown
+     */
+    @Test (expected = IOException.class)
+    public void openEmpty() throws IOException {
+        ssEmpty.open();
+    }
+
+
+    /*
+      From now on ssEmpty will not be used since StreamSource()
+      constructor does not initialize any internal variables
+     */
+
+
+    /**
+     * Purpose: Open an existing file
+     * Input: no
+     * Expected:
+     *          cs.read() = 1
+     *          buff[0] = text[0]
+     */
+    @Test
+    public void openExisting() throws IOException {
+        ss.open();
+        byte[] buff = new byte[1];
+
+        assertEquals(buff.length, ss.read(buff));
+        assertEquals(text[0], buff[0]);
+    }
+
+    /**
+     * Purpose: Read content of length equal to the buffer size from the file
+     * Input: read(buffer)
+     * Expected:
+     *          buffer = text
+     *          n = len(buffer)
+     */
+    @Test
+    public void read() throws IOException {
+        byte[] buff = new byte[10];
+        int n = ss.read(buff);
+        byte[] temp = Arrays.copyOfRange(text, 0, buff.length);
+
+        assertArrayEquals(temp, buff);
+        assertEquals(buff.length, n);
+    }
+
+    /**
+     * Purpose: Read content from the file with the buffer size bigger than length
+     * of the text in the file
+     * Input: read(buffer)
+     * Expected:
+     *          buffer = text
+     *          n = len
+     */
+    @Test
+    public void readExceed() throws IOException {
+        byte[] buff = new byte[100];
+        int n = ss.read(buff);
+        // erase dummy values in the end of buffer
+        byte[] buffer = Arrays.copyOfRange(buff, 0, n);
+
+        assertArrayEquals(text, buffer);
+        assertEquals(text.length, n);
+    }
+
+    /**
+     * Purpose: Throw an exception when reading happen on a closed file
+     * Input: read(buffer)
+     * Expected:
+     *          IOException is thrown
+     */
+    @Test (expected = IOException.class)
+    public void readClosedException() throws IOException {
+        ss.close();
+        byte[] buff = new byte[text.length];
+        int n = ss.read(buff);
+    }
+
+    /**
+     * Purpose: Read content in certain positions of the buffer from the file
+     * Input: read(buffer, startPosition, endPosition)
+     * Expected:
+     *          buffer = text
+     *          n = endPosition
+     */
+    @Test
+    public void readStartEnd() throws IOException {
+        byte[] buff = new byte[100];
+        int start = 5;
+        int end = 10;
+
+        int n = ss.read(buff, start, end);
+        byte[] file = Arrays.copyOfRange(text, 0, end - start);
+        byte[] buffer = Arrays.copyOfRange(buff, start, end);
+
+        assertArrayEquals(file, buffer);
+        assertEquals(end, n);
+    }
+
+    /**
+     * Purpose: Throw an exception when start and/or end positions for writing in
+     * the buffer exceed size of the buffer
+     * Input: read(buffer, startPosition, endPosition)
+     * Expected:
+     *          IOException is thrown
+     */
+    @Ignore ("Expected IOException, but IndexOutOfBoundsException is thrown")
+    @Test (expected = IOException.class)
+    public void readStartEndExceedException() throws IOException {
+        byte[] buff = new byte[100];
+        int start = 95;
+        int end = 110;
+
+        int n = ss.read(buff, start, end);
+    }
+
+    /**
+     * Purpose: Throw an exception when reading happen on a closed file
+     * Input: read(buffer, startPosition, endPosition)
+     * Expected:
+     *          IOException is thrown
+     */
+    @Test (expected = IOException.class)
+    public void readStartEndClosedException() throws IOException {
+        ss.close();
+        byte[] buff = new byte[100];
+        int start = 5;
+        int end = 10;
+
+        int n = ss.read(buff, start, end);
+    }
+
+    /**
+     * Purpose: Read content of the file from a certain position
+     * Input: moveTo(readPosition), read(buff)
+     * Expected:
+     *          buff = text[readPosition]
+     *          n = buff.length
+     */
+    @Test
+    public void moveTo() throws IOException {
+        int readPosition = text.length - 10;
+        byte[] buff = new byte[1];
+
+        ss.moveTo(readPosition);
+        ss.open();
+
+        int n = ss.read(buff);
+        assertEquals(text[readPosition], buff[0]);
+        assertEquals(buff.length, n);
+    }
+
+    /**
+     * Purpose: Throw an exception when a reading position in the file is incorrect
+     * Input: moveTo(wrongPosition)
+     * Expected:
+     *          IOException is thrown
+     */
+    @Ignore ("No exception is thrown")
+    @Test (expected = IOException.class)
+    public void moveToException() throws IOException {
+        ss.moveTo(-1);
+    }
+
+    /**
+     * Purpose: Close file after successful reading
+     * Input: no
+     * Expected:
+     *          Stream is closed and reading from the file is unavailable
+     */
+    @Test
+    public void close() {
+        ss.close();
+
+        int n = -1;
+        try{
+            byte[] buff = new byte[1];
+            n = ss.read(buff);
+        } catch (IOException ignored) {
+        }
+
+        assertEquals(-1, n);
+    }
+
+    /**
+     * Purpose: Get MIME type
+     * Input: no
+     * Expected:
+     *          return "txt"
+     */
+    @Test
+    public void getMimeType() {
+        assertEquals("txt", ss.getMimeType());
+    }
+
+    /**
+     * Purpose: Get length of the text from a file
+     * Input: no
+     * Expected:
+     *          return len
+     */
+    @Test
+    public void length() {
+        assertEquals(text.length, ss.length());
+    }
+
+    /**
+     * Purpose: Get name of a file
+     * Input: no
+     * Expected:
+     *          return "Test.txt"
+     */
+    @Test
+    public void getName() {
+        assertEquals(file.getName(), ss.getName());
+    }
+
+    /**
+     * Purpose: Get available to read remain amount of text from a file
+     * Input: no
+     * Expected:
+     *          return amount
+     */
+    @Test
+    public void available() throws IOException {
+        int amount = 12;
+        ss.moveTo(text.length - amount);
+        assertEquals(amount, ss.available());
+    }
+
+    /**
+     * Purpose: Move reading position to the beginning of a file
+     * Input: no
+     * Expected:
+     *          return len
+     */
+    @Test
+    public void reset() throws IOException {
+        ss.moveTo(10);
+        assertEquals(text.length - 10, ss.available());
+        ss.reset();
+        assertEquals(text.length, ss.available());
+    }
+
+    /**
+     * Purpose: Get a file object
+     * Input: no
+     * Expected:
+     *          return SmbFile
+     */
+    @Test
+    public void getFile() {
+        assertEquals(file, ss.getFile());
+    }
+
+    /**
+     * Purpose: Get size of a buffer. The buffer size is predefined in StreamSource class
+     * Input: no
+     * Expected:
+     *          return 1024*60
+     */
+    @Test
+    public void getBufferSize() {
+        assertEquals(1024*60, ss.getBufferSize());
+    }
+}

--- a/app/src/test/java/com/amaze/filemanager/utils/SmbStreamer/StreamSourceTest.java
+++ b/app/src/test/java/com/amaze/filemanager/utils/SmbStreamer/StreamSourceTest.java
@@ -5,9 +5,12 @@ import org.junit.*;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.net.MalformedURLException;
+import java.net.UnknownHostException;
 import java.util.Arrays;
 
 import jcifs.smb.NtlmPasswordAuthentication;
+import jcifs.smb.SmbException;
 import jcifs.smb.SmbFile;
 import jcifs.smb.SmbFileInputStream;
 
@@ -25,7 +28,7 @@ public class StreamSourceTest {
     // File Test.txt is 20 characters length
     // And contains "This is a test file." phrase
     @Before
-    public void setUp() throws Exception {
+    public void setUp() throws IOException {
         file = new SmbFile("smb://192.168.0.101/Test/Test.txt",
                 new NtlmPasswordAuthentication(null, "usertest", "12345"));
 
@@ -33,13 +36,6 @@ public class StreamSourceTest {
                 .readLine()).getBytes();
         ssEmpty = new StreamSource();
         ss = new StreamSource(file, file.length());
-    }
-
-    @After
-    public void tearDown() throws Exception {
-        file = null;
-        text = null;
-        ss = null;
     }
 
     /**

--- a/app/src/test/java/com/amaze/filemanager/utils/SmbStreamer/StreamSourceTest.java
+++ b/app/src/test/java/com/amaze/filemanager/utils/SmbStreamer/StreamSourceTest.java
@@ -237,10 +237,10 @@ public class StreamSourceTest {
      * Purpose: Throw an exception when a reading position in the file is incorrect
      * Input: moveTo(wrongPosition)
      * Expected:
-     *          IOException is thrown
+     *          IllegalArgumentException is thrown
      */
-    @Test (expected = IOException.class)
-    public void moveToException() throws IOException {
+    @Test (expected = IllegalArgumentException.class)
+    public void moveToException() throws IllegalArgumentException, IOException {
         ss.open();
         ss.moveTo(-1);
     }

--- a/app/src/test/java/com/amaze/filemanager/utils/SmbStreamer/StreamSourceTest.java
+++ b/app/src/test/java/com/amaze/filemanager/utils/SmbStreamer/StreamSourceTest.java
@@ -183,16 +183,17 @@ public class StreamSourceTest {
      * the buffer exceed size of the buffer
      * Input: read(buffer, startPosition, endPosition)
      * Expected:
-     *          IOException is thrown
+     *          IndexOutOfBoundsException is thrown
      */
-    @Ignore ("Expected IOException, but IndexOutOfBoundsException is thrown")
-    @Test (expected = IOException.class)
+    @Test (expected = IndexOutOfBoundsException.class)
     public void readStartEndExceedException() throws IOException {
+        ss.open();
+
         byte[] buff = new byte[100];
         int start = 95;
         int end = 110;
 
-        int n = ss.read(buff, start, end);
+        ss.read(buff, start, end);
     }
 
     /**
@@ -238,7 +239,6 @@ public class StreamSourceTest {
      * Expected:
      *          IOException is thrown
      */
-    @Ignore ("No exception is thrown")
     @Test (expected = IOException.class)
     public void moveToException() throws IOException {
         ss.open();

--- a/app/src/test/java/com/amaze/filemanager/utils/SmbStreamer/StreamSourceTest.java
+++ b/app/src/test/java/com/amaze/filemanager/utils/SmbStreamer/StreamSourceTest.java
@@ -113,6 +113,7 @@ public class StreamSourceTest {
      */
     @Test
     public void read() throws IOException {
+        ss.open();
         byte[] buff = new byte[10];
         int n = ss.read(buff);
         byte[] temp = Arrays.copyOfRange(text, 0, buff.length);
@@ -131,6 +132,7 @@ public class StreamSourceTest {
      */
     @Test
     public void readExceed() throws IOException {
+        ss.open();
         byte[] buff = new byte[100];
         int n = ss.read(buff);
         // erase dummy values in the end of buffer
@@ -148,6 +150,7 @@ public class StreamSourceTest {
      */
     @Test (expected = IOException.class)
     public void readClosedException() throws IOException {
+        ss.open();
         ss.close();
         byte[] buff = new byte[text.length];
         int n = ss.read(buff);
@@ -162,6 +165,7 @@ public class StreamSourceTest {
      */
     @Test
     public void readStartEnd() throws IOException {
+        ss.open();
         byte[] buff = new byte[100];
         int start = 5;
         int end = 10;
@@ -199,6 +203,7 @@ public class StreamSourceTest {
      */
     @Test (expected = IOException.class)
     public void readStartEndClosedException() throws IOException {
+        ss.open();
         ss.close();
         byte[] buff = new byte[100];
         int start = 5;
@@ -236,6 +241,7 @@ public class StreamSourceTest {
     @Ignore ("No exception is thrown")
     @Test (expected = IOException.class)
     public void moveToException() throws IOException {
+        ss.open();
         ss.moveTo(-1);
     }
 
@@ -246,7 +252,8 @@ public class StreamSourceTest {
      *          Stream is closed and reading from the file is unavailable
      */
     @Test
-    public void close() {
+    public void close() throws IOException {
+        ss.open();
         ss.close();
 
         int n = -1;

--- a/app/src/test/java/com/amaze/filemanager/utils/SmbStreamer/StreamSourceTest.java
+++ b/app/src/test/java/com/amaze/filemanager/utils/SmbStreamer/StreamSourceTest.java
@@ -337,14 +337,4 @@ public class StreamSourceTest {
         assertEquals(file, ss.getFile());
     }
 
-    /**
-     * Purpose: Get size of a buffer. The buffer size is predefined in StreamSource class
-     * Input: no
-     * Expected:
-     *          return 1024*60
-     */
-    @Test
-    public void getBufferSize() {
-        assertEquals(1024*60, ss.getBufferSize());
-    }
 }

--- a/app/src/test/java/com/amaze/filemanager/utils/cloud/CloudStreamSourceTest.java
+++ b/app/src/test/java/com/amaze/filemanager/utils/cloud/CloudStreamSourceTest.java
@@ -1,0 +1,297 @@
+package com.amaze.filemanager.utils.cloud;
+
+import org.junit.*;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Arrays;
+
+import static org.junit.Assert.*;
+
+/**
+ * Created by Rustam Khadipash on 31/3/2018.
+ */
+public class CloudStreamSourceTest {
+    private CloudStreamSource cs;
+    private byte[] text;
+    private long len;
+    private String fn;
+
+    // File Test.txt is 20 characters length
+    // And contains "This is a test file." phrase
+    @Before
+    public void setUp() throws Exception {
+        InputStream is = new FileInputStream("D://Test.txt");
+        fn = "Test.txt";
+        len = Files.size(Paths.get("D://Test.txt"));
+        text = Files.readAllBytes(Paths.get("D://Test.txt"));
+
+        cs = new CloudStreamSource(fn, len, is);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        fn = null;
+        len = 0;
+        text = null;
+        cs = null;
+    }
+
+    /**
+     * Purpose: Open an existing file
+     * Input: no
+     * Expected:
+     *          cs.read() = 1
+     *          buff[0] = text[0]
+     */
+    @Test
+    public void open() throws IOException {
+        cs.open();
+        byte[] buff = new byte[1];
+
+        assertEquals(buff.length, cs.read(buff));
+        assertEquals(text[0], buff[0]);
+    }
+
+    /**
+     * Purpose: Throw an exception when a file does not exist
+     * Input: CloudStreamSource (FileName, FileLength, Null pointer)
+     * Expected:
+     *          IOException is thrown
+     */
+    @Test (expected = IOException.class)
+    public void openNoFileException() throws IOException {
+        cs = new CloudStreamSource(fn, len, null);
+        cs.moveTo(10);  // move pointer to non-existing position
+        cs.open();
+    }
+
+    /**
+     * Purpose: Read content of length equal to the buffer size from the file
+     * Input: read(buffer)
+     * Expected:
+     *          buffer = text
+     *          n = len(buffer)
+     */
+    @Test
+    public void read() throws IOException {
+        byte[] buff = new byte[10];
+        int n = cs.read(buff);
+        byte[] temp = Arrays.copyOfRange(text, 0, buff.length);
+
+        assertArrayEquals(temp, buff);
+        assertEquals(buff.length, n);
+    }
+
+    /**
+     * Purpose: Read content from the file with the buffer size bigger than length
+     * of the text in the file
+     * Input: read(buffer)
+     * Expected:
+     *          buffer = text
+     *          n = len
+     */
+    @Test
+    public void readExceed() throws IOException {
+        byte[] buff = new byte[100];
+        int n = cs.read(buff);
+        // erase dummy values in the end of buffer
+        byte[] buffer = Arrays.copyOfRange(buff, 0, n);
+
+        assertArrayEquals(text, buffer);
+        assertEquals(len, n);
+    }
+
+    /**
+     * Purpose: Throw an exception when reading happen on a closed file
+     * Input: read(buffer)
+     * Expected:
+     *          IOException is thrown
+     */
+    @Test (expected = IOException.class)
+    public void readClosedException() throws IOException {
+        cs.close();
+        byte[] buff = new byte[(int)len];
+        int n = cs.read(buff);
+    }
+
+    /**
+     * Purpose: Read content in certain positions of the buffer from the file
+     * Input: read(buffer, startPosition, endPosition)
+     * Expected:
+     *          buffer = text
+     *          n = endPosition
+     */
+    @Test
+    public void readStartEnd() throws IOException {
+        byte[] buff = new byte[100];
+        int start = 5;
+        int end = 10;
+
+        int n = cs.read(buff, start, end);
+        byte[] file = Arrays.copyOfRange(text, 0, end - start);
+        byte[] buffer = Arrays.copyOfRange(buff, start, end);
+
+        assertArrayEquals(file, buffer);
+        assertEquals(end, n);
+    }
+
+    /**
+     * Purpose: Throw an exception when start and/or end positions for writing in
+     * the buffer exceed size of the buffer
+     * Input: read(buffer, startPosition, endPosition)
+     * Expected:
+     *          IOException is thrown
+     */
+    @Ignore ("Expected IOException, but IndexOutOfBoundsException is thrown")
+    @Test (expected = IOException.class)
+    public void readStartEndExceedException() throws IOException {
+        byte[] buff = new byte[100];
+        int start = 95;
+        int end = 110;
+
+        int n = cs.read(buff, start, end);
+    }
+
+    /**
+     * Purpose: Throw an exception when reading happen on a closed file
+     * Input: read(buffer, startPosition, endPosition)
+     * Expected:
+     *          IOException is thrown
+     */
+    @Test (expected = IOException.class)
+    public void readStartEndClosedException() throws IOException {
+        cs.close();
+        byte[] buff = new byte[100];
+        int start = 5;
+        int end = 10;
+
+        int n = cs.read(buff, start, end);
+    }
+
+    /**
+     * Purpose: Read content of the file from a certain position
+     * Input: moveTo(readPosition), read(buff)
+     * Expected:
+     *          buff = text[readPosition]
+     *          n = buff.length
+     */
+    @Test
+    public void moveTo() throws IOException {
+        int readPosition = (int)len - 10;
+        byte[] buff = new byte[1];
+
+        cs.moveTo(readPosition);
+        cs.open();
+
+        int n = cs.read(buff);
+        assertEquals(text[readPosition], buff[0]);
+        assertEquals(buff.length, n);
+    }
+
+    /**
+     * Purpose: Throw an exception when a reading position in the file is incorrect
+     * Input: moveTo(wrongPosition)
+     * Expected:
+     *          IOException is thrown
+     */
+    @Ignore ("No exception is thrown")
+    @Test (expected = IOException.class)
+    public void moveToException() throws IOException {
+        cs.moveTo(-1);
+    }
+
+    /**
+     * Purpose: Close file after successful reading
+     * Input: no
+     * Expected:
+     *          Stream is closed and reading from the file is unavailable
+     */
+    @Test
+    public void close() {
+        cs.close();
+
+        int n = -1;
+        try{
+            byte[] buff = new byte[1];
+            n = cs.read(buff);
+        } catch (IOException ignored) {
+        }
+
+        assertEquals(-1, n);
+    }
+
+    /**
+     * Purpose: Get MIME type
+     * Input: no
+     * Expected:
+     *          return NULL
+     */
+    @Test
+    public void getMimeType() {
+        assertEquals(null, cs.getMimeType());
+    }
+
+    /**
+     * Purpose: Get length of the text from a file
+     * Input: no
+     * Expected:
+     *          return len
+     */
+    @Test
+    public void length() {
+        assertEquals(len, cs.length());
+    }
+
+    /**
+     * Purpose: Get name of a file
+     * Input: no
+     * Expected:
+     *          return fn
+     */
+    @Test
+    public void getName() {
+        assertEquals(fn, cs.getName());
+    }
+
+    /**
+     * Purpose: Get available to read remain amount of text from a file
+     * Input: no
+     * Expected:
+     *          return amount
+     */
+    @Test
+    public void available() throws IOException {
+        int amount = 12;
+        cs.moveTo((int)len - amount);
+        assertEquals(amount, cs.available());
+    }
+
+    /**
+     * Purpose: Move reading position to the beginning of a file
+     * Input: no
+     * Expected:
+     *          return len
+     */
+    @Test
+    public void reset() throws IOException {
+        cs.moveTo(10);
+        assertEquals(len - 10, cs.available());
+        cs.reset();
+        assertEquals(len, cs.available());
+    }
+
+    /**
+     * Purpose: Get size of a buffer. The buffer size is predefined in CloudStreamSource class
+     * Input: no
+     * Expected:
+     *          return 1024*60
+     */
+    @Test
+    public void getBufferSize() {
+        assertEquals(1024*60, cs.getBufferSize());
+    }
+}

--- a/app/src/test/java/com/amaze/filemanager/utils/cloud/CloudStreamSourceTest.java
+++ b/app/src/test/java/com/amaze/filemanager/utils/cloud/CloudStreamSourceTest.java
@@ -15,6 +15,8 @@ import static org.junit.Assert.*;
  * Created by Rustam Khadipash on 31/3/2018.
  */
 public class CloudStreamSourceTest {
+
+
     private CloudStreamSource cs;
     private byte[] text;
     private long len;
@@ -33,7 +35,7 @@ public class CloudStreamSourceTest {
     }
 
     @After
-    public void tearDown() throws Exception {
+    public void tearDown() {
         fn = null;
         len = 0;
         text = null;
@@ -200,7 +202,7 @@ public class CloudStreamSourceTest {
      */
     @Ignore ("No exception is thrown")
     @Test (expected = IOException.class)
-    public void moveToException() throws IOException {
+    public void moveToException() {
         cs.moveTo(-1);
     }
 
@@ -264,7 +266,7 @@ public class CloudStreamSourceTest {
      *          return amount
      */
     @Test
-    public void available() throws IOException {
+    public void available() {
         int amount = 12;
         cs.moveTo((int)len - amount);
         assertEquals(amount, cs.available());
@@ -277,7 +279,7 @@ public class CloudStreamSourceTest {
      *          return len
      */
     @Test
-    public void reset() throws IOException {
+    public void reset() {
         cs.moveTo(10);
         assertEquals(len - 10, cs.available());
         cs.reset();

--- a/app/src/test/java/com/amaze/filemanager/utils/cloud/CloudStreamSourceTest.java
+++ b/app/src/test/java/com/amaze/filemanager/utils/cloud/CloudStreamSourceTest.java
@@ -302,14 +302,4 @@ public class CloudStreamSourceTest {
         assertEquals(len, cs.available());
     }
 
-    /**
-     * Purpose: Get size of a buffer. The buffer size is predefined in CloudStreamSource class
-     * Input: no
-     * Expected:
-     *          return 1024*60
-     */
-    @Test
-    public void getBufferSize() {
-        assertEquals(1024*60, cs.getBufferSize());
-    }
 }

--- a/app/src/test/java/com/amaze/filemanager/utils/cloud/CloudStreamSourceTest.java
+++ b/app/src/test/java/com/amaze/filemanager/utils/cloud/CloudStreamSourceTest.java
@@ -1,10 +1,22 @@
 package com.amaze.filemanager.utils.cloud;
 
-import org.junit.*;
+import android.os.Environment;
 
+import com.amaze.filemanager.BuildConfig;
+
+import org.junit.*;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+import org.robolectric.shadows.multidex.ShadowMultiDex;
+
+import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Arrays;
@@ -14,32 +26,37 @@ import static org.junit.Assert.*;
 /**
  * Created by Rustam Khadipash on 31/3/2018.
  */
+@RunWith(RobolectricTestRunner.class)
+@Config(constants = BuildConfig.class, shadows = {ShadowMultiDex.class})
 public class CloudStreamSourceTest {
-
-
     private CloudStreamSource cs;
+    private String testFilePath;
     private byte[] text;
     private long len;
-    private String fn;
+    private String fn =  "Test.txt";
 
     // File Test.txt is 20 characters length
     // And contains "This is a test file." phrase
     @Before
     public void setUp() throws Exception {
-        InputStream is = new FileInputStream("D://Test.txt");
-        fn = "Test.txt";
-        len = Files.size(Paths.get("D://Test.txt"));
-        text = Files.readAllBytes(Paths.get("D://Test.txt"));
+        File testFile = createFile();
 
-        cs = new CloudStreamSource(fn, len, is);
+        testFilePath = testFile.getAbsolutePath();
+        len = Files.size(Paths.get(testFilePath));
+        text = Files.readAllBytes(Paths.get(testFilePath));
+        cs = new CloudStreamSource(fn, len, new FileInputStream(testFile));
     }
 
-    @After
-    public void tearDown() {
-        fn = null;
-        len = 0;
-        text = null;
-        cs = null;
+    private File createFile() throws IOException {
+        File testFile = new File(Environment.getExternalStorageDirectory(), fn);
+        testFile.createNewFile();
+
+        OutputStream is = new FileOutputStream(testFile);
+        for (int i = 0; i < 20; i++) is.write("a".getBytes());
+        is.flush();
+        is.close();
+
+        return testFile;
     }
 
     /**

--- a/app/src/test/java/com/amaze/filemanager/utils/cloud/CloudStreamSourceTest.java
+++ b/app/src/test/java/com/amaze/filemanager/utils/cloud/CloudStreamSourceTest.java
@@ -214,10 +214,10 @@ public class CloudStreamSourceTest {
      * Purpose: Throw an exception when a reading position in the file is incorrect
      * Input: moveTo(wrongPosition)
      * Expected:
-     *          IOException is thrown
+     *          IllegalArgumentException is thrown
      */
-    @Test (expected = IOException.class)
-    public void moveToException() throws IOException {
+    @Test (expected = IllegalArgumentException.class)
+    public void moveToException() throws IllegalArgumentException, IOException {
         cs.open();
         cs.moveTo(-1);
     }

--- a/app/src/test/java/com/amaze/filemanager/utils/cloud/CloudStreamSourceTest.java
+++ b/app/src/test/java/com/amaze/filemanager/utils/cloud/CloudStreamSourceTest.java
@@ -163,16 +163,15 @@ public class CloudStreamSourceTest {
      * the buffer exceed size of the buffer
      * Input: read(buffer, startPosition, endPosition)
      * Expected:
-     *          IOException is thrown
+     *          IndexOutOfBoundsException is thrown
      */
-    @Ignore ("Expected IOException, but IndexOutOfBoundsException is thrown")
-    @Test (expected = IOException.class)
+    @Test (expected = IndexOutOfBoundsException.class)
     public void readStartEndExceedException() throws IOException {
         byte[] buff = new byte[100];
         int start = 95;
         int end = 110;
 
-        int n = cs.read(buff, start, end);
+        cs.read(buff, start, end);
     }
 
     /**
@@ -217,9 +216,9 @@ public class CloudStreamSourceTest {
      * Expected:
      *          IOException is thrown
      */
-    @Ignore ("No exception is thrown")
     @Test (expected = IOException.class)
-    public void moveToException() {
+    public void moveToException() throws IOException {
+        cs.open();
         cs.moveTo(-1);
     }
 


### PR DESCRIPTION
Grabbed first commit of #1249 and made corrections to it. 

Adds tests for CloudStreamSource, HybridFileParcelable and StreamSourceTest.
@TranceLove please check `ShadowSmbFile` and tell me how I should have done it (better), because I think it's very broken.
Known issues: some tests are not passed, those are 'genuine bugs' in the tested classes.