### PR TITLE
Fix size calculation for cloud connections

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/utils/files/FileUtils.java
+++ b/app/src/main/java/com/amaze/filemanager/utils/files/FileUtils.java
@@ -117,10 +117,10 @@ public class FileUtils {
     }
 
     public static long folderSize(HybridFile directory, OnProgressUpdate<Long> updateState) {
-        if(directory.isSftp())
-            return directory.folderSize(AppConfig.getInstance());
-        else
+        if(directory.isSimpleFile())
             return folderSize(new File(directory.getPath()), updateState);
+        else
+            return directory.folderSize(AppConfig.getInstance());
     }
 
     public static long folderSize(SmbFile directory) {


### PR DESCRIPTION
Try viewing properties of any directory in cloud connection. It shows 0bytes
This PR fixes the problem.