### PR TITLE
Fix parameter order to UtilsHandler.removeFromDatabase() for SSH targets

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/ui/dialogs/SftpConnectDialog.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/dialogs/SftpConnectDialog.java
@@ -226,7 +226,7 @@ public class SftpConnectDialog extends DialogFragment {
 
                 AppConfig.runInBackground(() -> {
                     utilsHandler.removeFromDatabase(new OperationData(UtilsHandler.Operation.SFTP,
-                            connectionName, path, null, null, null));
+                            path, connectionName, null, null, null));
                 });
                 ((MainActivity) getActivity()).getDrawer().refreshDrawer();
             }


### PR DESCRIPTION
Symptom:
1. Setup a new SSH connection
2. Open drawer
3. Tap on the pen beside the connection
4. Tap delete
5. App crashed

This PR fixes this.