### PR TITLE
SSH/SFTP: Fix symlinks to files/directories treated as files using stat()

### DIFF
--- a/app/src/test/java/com/amaze/filemanager/filesystem/ssh/AbstractSftpServerTest.java
+++ b/app/src/test/java/com/amaze/filemanager/filesystem/ssh/AbstractSftpServerTest.java
@@ -1,0 +1,71 @@
+package com.amaze.filemanager.filesystem.ssh;
+
+import android.os.Environment;
+
+import com.amaze.filemanager.BuildConfig;
+import com.amaze.filemanager.filesystem.ssh.test.TestKeyProvider;
+
+import org.apache.sshd.common.config.keys.KeyUtils;
+import org.apache.sshd.common.file.FileSystemFactory;
+import org.apache.sshd.common.file.virtualfs.VirtualFileSystemFactory;
+import org.apache.sshd.server.SshServer;
+import org.apache.sshd.server.auth.pubkey.AcceptAllPublickeyAuthenticator;
+import org.apache.sshd.server.scp.ScpCommandFactory;
+import org.apache.sshd.server.subsystem.sftp.SftpSubsystemFactory;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+import org.robolectric.shadows.multidex.ShadowMultiDex;
+
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.Arrays;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(constants = BuildConfig.class, shadows = {ShadowMultiDex.class})
+public abstract class AbstractSftpServerTest {
+
+    protected SshServer server;
+
+    protected static TestKeyProvider hostKeyProvider;
+
+    @BeforeClass
+    public static void bootstrap() throws Exception {
+        hostKeyProvider = new TestKeyProvider();
+    }
+
+    @Before
+    public void setUp() throws IOException {
+        createSshServer(new VirtualFileSystemFactory(Paths.get(Environment.getExternalStorageDirectory().getAbsolutePath())));
+        prepareSshConnection();
+    }
+
+    @After
+    public void tearDown(){
+        SshConnectionPool.getInstance().expungeAllConnections();
+        if(server != null && server.isOpen())
+            server.close(true);
+    }
+
+    protected final void prepareSshConnection() {
+        String hostFingerprint = KeyUtils.getFingerPrint(hostKeyProvider.getKeyPair().getPublic());
+        SshConnectionPool.getInstance().getConnection("127.0.0.1", 22222, hostFingerprint, "testuser", "testpassword", null);
+    }
+
+    protected final void createSshServer(FileSystemFactory fileSystemFactory) throws IOException {
+        server = SshServer.setUpDefaultServer();
+
+        server.setFileSystemFactory(fileSystemFactory);
+        server.setPublickeyAuthenticator(AcceptAllPublickeyAuthenticator.INSTANCE);
+        server.setPort(22222);
+        server.setHost("127.0.0.1");
+        server.setKeyPairProvider(hostKeyProvider);
+        server.setCommandFactory(new ScpCommandFactory());
+        server.setSubsystemFactories(Arrays.asList(new SftpSubsystemFactory()));
+        server.setPasswordAuthenticator(((username, password, session) -> username.equals("testuser") && password.equals("testpassword")));
+        server.start();
+    }
+}

--- a/app/src/test/java/com/amaze/filemanager/filesystem/ssh/CreateFileOnSshdTest.java
+++ b/app/src/test/java/com/amaze/filemanager/filesystem/ssh/CreateFileOnSshdTest.java
@@ -3,6 +3,7 @@ package com.amaze.filemanager.filesystem.ssh;
 import android.os.Environment;
 
 import com.amaze.filemanager.BuildConfig;
+import com.amaze.filemanager.filesystem.HybridFile;
 import com.amaze.filemanager.filesystem.ssh.test.BlockFileCreationFileSystemProvider;
 import com.amaze.filemanager.filesystem.ssh.test.TestKeyProvider;
 
@@ -27,24 +28,8 @@ import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collections;
 
-@RunWith(RobolectricTestRunner.class)
-@Config(constants = BuildConfig.class, shadows = {ShadowMultiDex.class})
-public class CreateFileOnSshdTest {
 
-    private SshServer server;
-
-    private static TestKeyProvider hostKeyProvider;
-
-    @BeforeClass
-    public static void bootstrap() throws Exception {
-        hostKeyProvider = new TestKeyProvider();
-    }
-
-    @After
-    public void tearDown(){
-        if(server != null && server.isOpen())
-            server.close(true);
-    }
+public class CreateFileOnSshdTest extends AbstractSftpServerTest {
 
     @Test
     public void testCreateFileNormal() throws Exception {
@@ -56,22 +41,8 @@ public class CreateFileOnSshdTest {
         createSshServer(new VirtualFileSystemFactory(){
             @Override
             public FileSystem createFileSystem(Session session) throws IOException {
-                return new BlockFileCreationFileSystemProvider().newFileSystem(Paths.get(Environment.getExternalStorageDirectory().getAbsolutePath()), Collections.emptyMap());
+            return new BlockFileCreationFileSystemProvider().newFileSystem(Paths.get(Environment.getExternalStorageDirectory().getAbsolutePath()), Collections.emptyMap());
             }
         });
-    }
-
-    private void createSshServer(FileSystemFactory fileSystemFactory) throws Exception {
-        server = SshServer.setUpDefaultServer();
-
-        server.setFileSystemFactory(fileSystemFactory);
-        server.setPublickeyAuthenticator(AcceptAllPublickeyAuthenticator.INSTANCE);
-        server.setPort(22222);
-        server.setHost("127.0.0.1");
-        server.setKeyPairProvider(hostKeyProvider);
-        server.setCommandFactory(new ScpCommandFactory());
-        server.setSubsystemFactories(Arrays.asList(new SftpSubsystemFactory()));
-        server.setPasswordAuthenticator(((username, password, session) -> username.equals("testuser") && password.equals("testpassword")));
-        server.start();
     }
 }

--- a/app/src/test/java/com/amaze/filemanager/filesystem/ssh/ListFilesOnSshdTest.java
+++ b/app/src/test/java/com/amaze/filemanager/filesystem/ssh/ListFilesOnSshdTest.java
@@ -1,0 +1,101 @@
+package com.amaze.filemanager.filesystem.ssh;
+
+import android.os.Environment;
+
+import com.amaze.filemanager.filesystem.HybridFile;
+import com.amaze.filemanager.utils.OpenMode;
+
+import org.junit.Test;
+import org.robolectric.RuntimeEnvironment;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+
+import static org.hamcrest.Matchers.hasItems;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+public class ListFilesOnSshdTest extends AbstractSftpServerTest {
+
+    @Test
+    public void testNormalListDirs() throws InterruptedException {
+        for(String s: new String[]{"sysroot","srv","var","tmp","bin","lib","usr"}){
+            new File(Environment.getExternalStorageDirectory(), s).mkdir();
+        }
+        performVerify();
+    }
+
+    @Test
+    public void testListDirsAndSymlinks() throws Exception {
+        File sysroot = new File(Environment.getExternalStorageDirectory(), "sysroot");
+        sysroot.mkdir();
+        for(String s: new String[]{"srv","var","tmp"}){
+            File subdir = new File(sysroot, s);
+            subdir.mkdir();
+            Files.createSymbolicLink(Paths.get(new File(Environment.getExternalStorageDirectory(), s).getAbsolutePath()), Paths.get(subdir.getAbsolutePath()));
+        }
+        for(String s: new String[]{"bin","lib","usr"}){
+            new File(Environment.getExternalStorageDirectory(), s).mkdir();
+        }
+        performVerify();
+    }
+
+    private void performVerify() throws InterruptedException{
+        List<String> result = new ArrayList<>();
+        HybridFile file = new HybridFile(OpenMode.SFTP, "ssh://testuser:testpassword@127.0.0.1:22222");
+        CountDownLatch waiter = new CountDownLatch(7);
+        file.forEachChildrenFile(RuntimeEnvironment.application, false, (fileFound)->{
+            assertTrue(fileFound.getPath() + " not seen as directory", fileFound.isDirectory());
+            result.add(fileFound.getName());
+            waiter.countDown();
+        });
+        waiter.await();
+        assertEquals(7, result.size());
+        assertThat(result, hasItems("sysroot","srv","var","tmp","bin","lib","usr"));
+    }
+
+    @Test
+    public void testListDirsAndFilesAndSymlinks() throws Exception {
+        File sysroot = new File(Environment.getExternalStorageDirectory(), "sysroot");
+        sysroot.mkdir();
+        for(String s: new String[]{"srv","var","tmp"}){
+            File subdir = new File(sysroot, s);
+            subdir.mkdir();
+            Files.createSymbolicLink(Paths.get(new File(Environment.getExternalStorageDirectory(), s).getAbsolutePath()), Paths.get(subdir.getAbsolutePath()));
+        }
+        for(String s: new String[]{"bin","lib","usr"}){
+            new File(Environment.getExternalStorageDirectory(), s).mkdir();
+        }
+        for(int i=1;i<=4;i++){
+            File f = new File(Environment.getExternalStorageDirectory(), i+".txt");
+            FileOutputStream out = new FileOutputStream(f);
+            out.write(i);
+            out.close();
+            Files.createSymbolicLink(Paths.get(new File(Environment.getExternalStorageDirectory(), "symlink"+i+".txt").getAbsolutePath()), Paths.get(f.getAbsolutePath()));
+        }
+        List<String> dirs = new ArrayList<>(), files = new ArrayList<>();
+        HybridFile file = new HybridFile(OpenMode.SFTP, "ssh://testuser:testpassword@127.0.0.1:22222");
+        CountDownLatch waiter = new CountDownLatch(15);
+        file.forEachChildrenFile(RuntimeEnvironment.application, false, (fileFound)->{
+            if(!fileFound.getName().endsWith(".txt")) {
+                assertTrue(fileFound.getPath() + " not seen as directory", fileFound.isDirectory());
+                dirs.add(fileFound.getName());
+            } else {
+                assertFalse(fileFound.getPath() + " not seen as file", fileFound.isDirectory());
+                files.add(fileFound.getName());
+            }
+            waiter.countDown();
+        });
+        waiter.await();
+        assertEquals(7, dirs.size());
+        assertThat(dirs, hasItems("sysroot","srv","var","tmp","bin","lib","usr"));
+        assertThat(files, hasItems("1.txt", "2.txt", "3.txt", "4.txt", "symlink1.txt", "symlink2.txt", "symlink3.txt", "symlink4.txt"));
+    }
+}


### PR DESCRIPTION
Fixes #1330. Extra `stat()` will be called if the file/directory is actually a symbolic link.

Test case included, but be reminded that it may not run on non-POSIX OSes.

(And the way I coded the tests were actually a convenience but disregarded the fact that Android's user space storage never understands symlinks ;) )