### PR TITLE
Fix parsing SSH URLs with special characters included

### DIFF
--- a/app/src/androidTest/java/com/amaze/filemanager/database/UtilsHandlerTest.java
+++ b/app/src/androidTest/java/com/amaze/filemanager/database/UtilsHandlerTest.java
@@ -1,0 +1,58 @@
+package com.amaze.filemanager.database;
+
+import android.support.annotation.NonNull;
+import android.support.test.InstrumentationRegistry;
+import android.support.test.runner.AndroidJUnit4;
+
+import com.amaze.filemanager.filesystem.ssh.SshClientUtils;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(AndroidJUnit4.class)
+public class UtilsHandlerTest {
+
+    private UtilsHandler utilsHandler;
+
+    @Before
+    public void setUp(){
+        utilsHandler = new UtilsHandler(InstrumentationRegistry.getTargetContext());
+        utilsHandler.onCreate(utilsHandler.getWritableDatabase());
+        utilsHandler.getWritableDatabase().execSQL("DELETE FROM sftp;");
+    }
+
+    @Test
+    public void testEncodeEncryptUri1(){
+        performTest("ssh://test:testP@ssw0rd@127.0.0.1:5460");
+    }
+
+    @Test
+    public void testEncodeEncryptUri2(){
+        performTest("ssh://test:testP@##word@127.0.0.1:22");
+    }
+
+    @Test
+    public void testEncodeEncryptUri3(){
+        performTest("ssh://test@example.com:testP@ssw0rd@127.0.0.1:22");
+    }
+
+    @Test
+    public void testEncodeEncryptUri4(){
+        performTest("ssh://test@example.com:testP@ssw0##$@127.0.0.1:22");
+    }
+
+    private void performTest(@NonNull final String origPath){
+        String encryptedPath = SshClientUtils.encryptSshPathAsNecessary(origPath);
+        utilsHandler.addSsh("Test", encryptedPath, "ab:cd:ef:1a:1b:1c:1d:ea", null, null);
+
+        List<String[]> result = utilsHandler.getSftpList();
+        assertEquals(1, result.size());
+        assertEquals("Test", result.get(0)[0]);
+        assertEquals(origPath, result.get(0)[1]);
+    }
+}

--- a/app/src/androidTest/java/com/amaze/filemanager/database/UtilsHandlerTest.java
+++ b/app/src/androidTest/java/com/amaze/filemanager/database/UtilsHandlerTest.java
@@ -54,5 +54,6 @@ public class UtilsHandlerTest {
         assertEquals(1, result.size());
         assertEquals("Test", result.get(0)[0]);
         assertEquals(origPath, result.get(0)[1]);
+        assertEquals("ab:cd:ef:1a:1b:1c:1d:ea", utilsHandler.getSshHostKey(origPath));
     }
 }

--- a/app/src/androidTest/java/com/amaze/filemanager/database/UtilsHandlerTest.java
+++ b/app/src/androidTest/java/com/amaze/filemanager/database/UtilsHandlerTest.java
@@ -48,12 +48,12 @@ public class UtilsHandlerTest {
 
     private void performTest(@NonNull final String origPath){
         String encryptedPath = SshClientUtils.encryptSshPathAsNecessary(origPath);
-        utilsHandler.addSsh("Test", encryptedPath, "ab:cd:ef:1a:1b:1c:1d:ea", null, null);
+        utilsHandler.addSsh("Test", encryptedPath, "00:11:22:33:44:55:66:77:88:99:aa:bb:cc:dd:ee:ff", null, null);
 
         List<String[]> result = utilsHandler.getSftpList();
         assertEquals(1, result.size());
         assertEquals("Test", result.get(0)[0]);
         assertEquals(origPath, result.get(0)[1]);
-        assertEquals("ab:cd:ef:1a:1b:1c:1d:ea", utilsHandler.getSshHostKey(origPath));
+        assertEquals("00:11:22:33:44:55:66:77:88:99:aa:bb:cc:dd:ee:ff", utilsHandler.getSshHostKey(origPath));
     }
 }

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/ssh/PemToKeyPairTask.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/ssh/PemToKeyPairTask.java
@@ -65,7 +65,7 @@ import java.security.Security;
  * @see KeyProvider
  * @see OpenSSHKeyV1KeyFile
  * @see PuTTYKeyFile
- * @see com.amaze.filemanager.filesystem.ssh.SshConnectionPool#create(Uri)
+ * @see com.amaze.filemanager.filesystem.ssh.SshConnectionPool#create(String)
  * @see net.schmizz.sshj.SSHClient#authPublickey(String, KeyProvider...)
  */
 public class PemToKeyPairTask extends AsyncTask<Void, Void, AsyncTaskResult<KeyPair>>

--- a/app/src/main/java/com/amaze/filemanager/database/UtilsHandler.java
+++ b/app/src/main/java/com/amaze/filemanager/database/UtilsHandler.java
@@ -5,6 +5,7 @@ import android.content.Context;
 import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteOpenHelper;
+import android.net.Uri;
 import android.os.Environment;
 import android.util.Log;
 import android.widget.Toast;
@@ -195,7 +196,7 @@ public class UtilsHandler extends SQLiteOpenHelper {
         SQLiteDatabase database = getWritableDatabase();
         ContentValues values = new ContentValues();
         values.put(COLUMN_NAME, name);
-        values.put(COLUMN_PATH, path);
+        values.put(COLUMN_PATH, Uri.encode(path));
         values.put(COLUMN_HOST_PUBKEY, hostKey);
         if(sshKey != null && !"".equals(sshKey))
         {
@@ -354,7 +355,7 @@ public class UtilsHandler extends SQLiteOpenHelper {
             SQLiteDatabase sqLiteDatabase = getReadableDatabase();
 
             Cursor result = sqLiteDatabase.query(TABLE_SFTP, new String[]{COLUMN_HOST_PUBKEY},
-                    COLUMN_PATH + " = ?", new String[]{uri},
+                    COLUMN_PATH + " = ?", new String[]{Uri.encode(uri)},
                     null, null, null);
             if(result.moveToFirst())
             {

--- a/app/src/main/java/com/amaze/filemanager/database/UtilsHandler.java
+++ b/app/src/main/java/com/amaze/filemanager/database/UtilsHandler.java
@@ -196,7 +196,7 @@ public class UtilsHandler extends SQLiteOpenHelper {
         SQLiteDatabase database = getWritableDatabase();
         ContentValues values = new ContentValues();
         values.put(COLUMN_NAME, name);
-        values.put(COLUMN_PATH, Uri.encode(path));
+        values.put(COLUMN_PATH, path);
         values.put(COLUMN_HOST_PUBKEY, hostKey);
         if(sshKey != null && !"".equals(sshKey))
         {
@@ -355,7 +355,7 @@ public class UtilsHandler extends SQLiteOpenHelper {
             SQLiteDatabase sqLiteDatabase = getReadableDatabase();
 
             Cursor result = sqLiteDatabase.query(TABLE_SFTP, new String[]{COLUMN_HOST_PUBKEY},
-                    COLUMN_PATH + " = ?", new String[]{Uri.encode(uri)},
+                    COLUMN_PATH + " = ?", new String[]{uri},
                     null, null, null);
             if(result.moveToFirst())
             {

--- a/app/src/main/java/com/amaze/filemanager/filesystem/ssh/SshClientUtils.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/ssh/SshClientUtils.java
@@ -175,6 +175,7 @@ public abstract class SshClientUtils
      * @return SSH URL with the password (if exists) decrypted
      */
     public static final String decryptSshPathAsNecessary(@NonNull String fullUri) {
+        fullUri = Uri.decode(fullUri);
         String uriWithoutProtocol = fullUri.substring(SSH_URI_PREFIX.length(), fullUri.indexOf('@'));
         try {
             return (uriWithoutProtocol.indexOf(':') > 0) ?

--- a/app/src/main/java/com/amaze/filemanager/filesystem/ssh/SshClientUtils.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/ssh/SshClientUtils.java
@@ -175,7 +175,6 @@ public abstract class SshClientUtils
      * @return SSH URL with the password (if exists) decrypted
      */
     public static final String decryptSshPathAsNecessary(@NonNull String fullUri) {
-        fullUri = Uri.decode(fullUri);
         String uriWithoutProtocol = fullUri.substring(SSH_URI_PREFIX.length(), fullUri.indexOf('@'));
         try {
             return (uriWithoutProtocol.indexOf(':') > 0) ?

--- a/app/src/main/java/com/amaze/filemanager/filesystem/ssh/SshConnectionPool.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/ssh/SshConnectionPool.java
@@ -202,7 +202,11 @@ public class SshConnectionPool
             }
         }
 
-        return create(host, port, utilsHandler.getSshHostKey(url), username, password,
+        String hostKey = utilsHandler.getSshHostKey(url);
+        if(hostKey == null)
+            return null;
+
+        return create(host, port, hostKey, username, password,
                 keyPair.get());
     }
 

--- a/app/src/main/java/com/amaze/filemanager/filesystem/ssh/SshConnectionPool.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/ssh/SshConnectionPool.java
@@ -189,7 +189,7 @@ public class SshConnectionPool
         UtilsHandler utilsHandler = AppConfig.getInstance().getUtilsHandler();
         String pem = utilsHandler.getSshAuthPrivateKey(uri.toString());
 
-        AtomicReference<KeyPair> keyPair = new AtomicReference<>(null);;
+        AtomicReference<KeyPair> keyPair = new AtomicReference<>(null);
         if(pem != null && !pem.isEmpty()) {
             try {
                 CountDownLatch latch = new CountDownLatch(1);

--- a/app/src/main/java/com/amaze/filemanager/filesystem/ssh/SshConnectionPool.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/ssh/SshConnectionPool.java
@@ -172,16 +172,7 @@ public class SshConnectionPool
     // Logic for creating SSH connection. Depends on password existence in given Uri password or
     // key-based authentication
     private SSHClient create(@NonNull String url) {
-        String host = url.substring(url.lastIndexOf('@')+1, url.lastIndexOf(':'));
-        int port = Integer.parseInt(url.substring(url.lastIndexOf(':')+1));
-        //If the uri is fetched from the app's database storage, we assume it will never be empty
-        String authString = url.substring(SSH_URI_PREFIX.length(), url.lastIndexOf('@'));
-        String[] userInfo = authString.split(":");
-        String username = userInfo[0];
-        String password = userInfo.length > 1 ? userInfo[1] : null;
-
-        if(port < 0)
-            port = SSH_DEFAULT_PORT;
+        ConnectionInfo connInfo = new ConnectionInfo(url);
 
         UtilsHandler utilsHandler = AppConfig.getInstance().getUtilsHandler();
         String pem = utilsHandler.getSshAuthPrivateKey(url);
@@ -206,7 +197,7 @@ public class SshConnectionPool
         if(hostKey == null)
             return null;
 
-        return create(host, port, hostKey, username, password,
+        return create(connInfo.host, connInfo.port, hostKey, connInfo.username, connInfo.password,
                 keyPair.get());
     }
 
@@ -235,5 +226,41 @@ public class SshConnectionPool
 
     private void expire(@NonNull SSHClient client) {
         SshClientUtils.tryDisconnect(client);
+    }
+
+    /**
+     * Container object for SSH URI, encapsulating logic for splitting information from given URI.
+     *
+     * <code>Uri.parse()</code> only parse URI that is compliant to RFC2396, but we have to deal
+     * with URI that is not compliant, since usernames and/or strong passwords usually have special
+     * characters included, like <code>ssh://user@example.com:P@##w0rd@127.0.0.1:22</code>.
+     *
+     * A design decision to keep database schema slim, by the way... -TranceLove
+     */
+    static class ConnectionInfo {
+
+        final String host;
+        final int port;
+        final String username;
+        final String password;
+
+        //FIXME: Crude assumption
+        ConnectionInfo(@NonNull String url){
+            if(!url.startsWith(SSH_URI_PREFIX))
+                throw new IllegalArgumentException("Argument is not a SSH URI: " + url);
+
+            this.host = url.substring(url.lastIndexOf('@')+1, url.lastIndexOf(':'));
+            int port = Integer.parseInt(url.substring(url.lastIndexOf(':')+1));
+            //If the uri is fetched from the app's database storage, we assume it will never be empty
+            String authString = url.substring(SSH_URI_PREFIX.length(), url.lastIndexOf('@'));
+            String[] userInfo = authString.split(":");
+            this.username = userInfo[0];
+            this.password = userInfo.length > 1 ? userInfo[1] : null;
+
+            if(port < 0)
+                port = SSH_DEFAULT_PORT;
+
+            this.port = port;
+        }
     }
 }

--- a/app/src/main/java/com/amaze/filemanager/filesystem/ssh/SshConnectionPool.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/ssh/SshConnectionPool.java
@@ -237,7 +237,7 @@ public class SshConnectionPool
      *
      * A design decision to keep database schema slim, by the way... -TranceLove
      */
-    static class ConnectionInfo {
+    static final class ConnectionInfo {
 
         final String host;
         final int port;

--- a/app/src/main/java/com/amaze/filemanager/ui/dialogs/SftpConnectDialog.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/dialogs/SftpConnectDialog.java
@@ -43,20 +43,18 @@ import com.afollestad.materialdialogs.internal.MDButton;
 import com.amaze.filemanager.R;
 import com.amaze.filemanager.activities.MainActivity;
 import com.amaze.filemanager.activities.superclasses.ThemedActivity;
+import com.amaze.filemanager.asynchronous.asynctasks.ssh.GetSshHostFingerprintTask;
+import com.amaze.filemanager.asynchronous.asynctasks.ssh.PemToKeyPairTask;
 import com.amaze.filemanager.database.UtilsHandler;
 import com.amaze.filemanager.database.models.OperationData;
 import com.amaze.filemanager.filesystem.ssh.SshClientUtils;
 import com.amaze.filemanager.filesystem.ssh.SshConnectionPool;
 import com.amaze.filemanager.fragments.MainFragment;
-import com.amaze.filemanager.asynchronous.asynctasks.AsyncTaskResult;
-import com.amaze.filemanager.asynchronous.asynctasks.ssh.PemToKeyPairTask;
-import com.amaze.filemanager.asynchronous.asynctasks.ssh.SshAuthenticationTask;
-import com.amaze.filemanager.asynchronous.asynctasks.ssh.GetSshHostFingerprintTask;
 import com.amaze.filemanager.utils.BookSorter;
-import com.amaze.filemanager.utils.SimpleTextWatcher;
-import com.amaze.filemanager.utils.application.AppConfig;
 import com.amaze.filemanager.utils.DataUtils;
 import com.amaze.filemanager.utils.OpenMode;
+import com.amaze.filemanager.utils.SimpleTextWatcher;
+import com.amaze.filemanager.utils.application.AppConfig;
 import com.amaze.filemanager.utils.provider.UtilitiesProvider;
 
 import net.schmizz.sshj.SSHClient;
@@ -209,7 +207,6 @@ public class SftpConnectDialog extends DialogFragment {
 
         //If we are editing connection settings, give new actions for neutral and negative buttons
         if(edit) {
-            Log.d(TAG, "Edit? " + edit);
             dialogBuilder.negativeText(R.string.delete).onNegative((dialog, which) -> {
 
             final String connectionName = connectionET.getText().toString();
@@ -273,9 +270,7 @@ public class SftpConnectDialog extends DialogFragment {
         if(SELECT_PEM_INTENT == requestCode && Activity.RESULT_OK == resultCode)
         {
             selectedPem = data.getData();
-            Log.d(TAG, "Selected PEM: " + selectedPem.toString() + "/ "
-                    + selectedPem.getLastPathSegment());
-            
+
             try {
                 InputStream selectedKeyContent = context.getContentResolver()
                         .openInputStream(selectedPem);

--- a/app/src/main/java/com/amaze/filemanager/utils/MainActivityHelper.java
+++ b/app/src/main/java/com/amaze/filemanager/utils/MainActivityHelper.java
@@ -553,7 +553,7 @@ public class MainActivityHelper {
 
     public String parseSftpPath(String a) {
         if (a.contains("@"))
-            return "ssh://" + a.substring(a.indexOf("@") + 1, a.length());
+            return "ssh://" + a.substring(a.lastIndexOf("@") + 1, a.length());
         else return a;
     }
 

--- a/app/src/main/java/com/amaze/filemanager/utils/files/CryptUtil.java
+++ b/app/src/main/java/com/amaze/filemanager/utils/files/CryptUtil.java
@@ -475,11 +475,10 @@ public class CryptUtil {
      */
     public static String encryptPassword(Context context, String plainText) throws GeneralSecurityException, IOException {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-
-            return CryptUtil.aesEncryptPassword(plainText);
+            return aesEncryptPassword(plainText);
         } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
 
-            return CryptUtil.rsaEncryptPassword(context, plainText);
+            return rsaEncryptPassword(context, plainText);
         } else return plainText;
     }
 
@@ -488,9 +487,9 @@ public class CryptUtil {
      */
     public static String decryptPassword(Context context, String cipherText) throws GeneralSecurityException, IOException {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            return CryptUtil.aesDecryptPassword(cipherText);
+            return aesDecryptPassword(cipherText);
         } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
-            return CryptUtil.rsaDecryptPassword(context, cipherText);
+            return rsaDecryptPassword(context, cipherText);
         } else return cipherText;
     }
 

--- a/app/src/test/java/com/amaze/filemanager/filesystem/ssh/SshConnectionPoolTest.java
+++ b/app/src/test/java/com/amaze/filemanager/filesystem/ssh/SshConnectionPoolTest.java
@@ -1,27 +1,40 @@
 package com.amaze.filemanager.filesystem.ssh;
 
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.util.Base64;
+
 import com.amaze.filemanager.BuildConfig;
+import com.amaze.filemanager.database.UtilsHandler;
 import com.amaze.filemanager.filesystem.ssh.test.TestKeyProvider;
+import com.amaze.filemanager.test.ShadowCryptUtil;
 
 import net.schmizz.sshj.common.SecurityUtils;
 
 import org.apache.sshd.server.SshServer;
 import org.apache.sshd.server.auth.pubkey.AcceptAllPublickeyAuthenticator;
-import org.junit.AfterClass;
+import org.junit.After;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
 import org.robolectric.shadows.multidex.ShadowMultiDex;
 
-import static org.junit.Assert.*;
+import java.io.IOException;
+import java.security.PrivateKey;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(constants = BuildConfig.class, shadows = {ShadowMultiDex.class})
+@Config(constants = BuildConfig.class, shadows = {ShadowMultiDex.class, ShadowCryptUtil.class})
 public class SshConnectionPoolTest {
 
-    private static SshServer server;
+    private SshServer server;
+
+    private UtilsHandler utilsHandler;
 
     private static TestKeyProvider hostKeyProvider, userKeyProvider;
 
@@ -29,17 +42,17 @@ public class SshConnectionPoolTest {
     public static void bootstrap() throws Exception {
         hostKeyProvider = new TestKeyProvider();
         userKeyProvider = new TestKeyProvider();
-        createSshServer();
     }
 
-    @AfterClass
-    public static void shutdownServer(){
+    @After
+    public void tearDown(){
         if(server != null && server.isOpen())
             server.close(true);
     }
 
     @Test
-    public void testGetConnectionWithUsernameAndPassword(){
+    public void testGetConnectionWithUsernameAndPassword() throws IOException {
+        createSshServer("testuser", "testpassword");
         assertNotNull(SshConnectionPool.getInstance().getConnection("127.0.0.1", 22222,
                 SecurityUtils.getFingerprint(hostKeyProvider.getKeyPair().getPublic()),
                 "testuser", "testpassword", null));
@@ -50,7 +63,8 @@ public class SshConnectionPoolTest {
     }
 
     @Test
-    public void testGetConnectionWithUsernameAndKey(){
+    public void testGetConnectionWithUsernameAndKey() throws IOException {
+        createSshServer("testuser", null);
         assertNotNull(SshConnectionPool.getInstance().getConnection("127.0.0.1", 22222,
                 SecurityUtils.getFingerprint(hostKeyProvider.getKeyPair().getPublic()),
                 "testuser", null, userKeyProvider.getKeyPair()));
@@ -60,14 +74,116 @@ public class SshConnectionPoolTest {
                 "invaliduser", null, userKeyProvider.getKeyPair()));
     }
 
-    private static void createSshServer() throws Exception {
+    @Test
+    public void testGetConnectionWithUrl() throws IOException {
+        String validPassword = "testpassword";
+        createSshServer("testuser", validPassword);
+        saveSshConnectionSettings("testuser", validPassword, null);
+        assertNotNull(SshConnectionPool.getInstance().getConnection("ssh://testuser:testpassword@127.0.0.1:22222"));
+        assertNull(SshConnectionPool.getInstance().getConnection("ssh://invaliduser:invalidpassword@127.0.0.1:22222"));
+    }
+
+    //Sorry but this is not getting through yet...
+//    @Test @Ignore
+//    public void testGetConnectionWithUrlAndKeyAuth() throws IOException {
+//        createSshServer("testuser", null);
+//        saveSshConnectionSettings("testuser", null, userKeyProvider.getKeyPair().getPrivate());
+//        assertNotNull(SshConnectionPool.getInstance().getConnection("ssh://testuser@127.0.0.1:22222"));
+//        assertNull(SshConnectionPool.getInstance().getConnection("ssh://invaliduser@127.0.0.1:22222"));
+//    }
+
+    @Test
+    public void testGetConnectionWithUrlHavingComplexPassword1() throws IOException {
+        String validPassword = "testP@ssw0rd";
+        createSshServer("testuser", validPassword);
+        saveSshConnectionSettings("testuser", validPassword, null);
+        assertNotNull(SshConnectionPool.getInstance().getConnection("ssh://testuser:testP@ssw0rd@127.0.0.1:22222"));
+        assertNull(SshConnectionPool.getInstance().getConnection("ssh://invaliduser:invalidpassword@127.0.0.1:22222"));
+    }
+
+    @Test
+    public void testGetConnectionWithUrlHavingComplexPassword2() throws IOException {
+        String validPassword = "testP@##word";
+        createSshServer("testuser", validPassword);
+        saveSshConnectionSettings("testuser", validPassword, null);
+        assertNotNull(SshConnectionPool.getInstance().getConnection("ssh://testuser:testP@##word@127.0.0.1:22222"));
+        assertNull(SshConnectionPool.getInstance().getConnection("ssh://invaliduser:invalidpassword@127.0.0.1:22222"));
+    }
+
+    @Test
+    public void testGetConnectionWithUrlHavingComplexCredential1() throws IOException {
+        String validPassword = "testP@##word";
+        createSshServer("testuser", validPassword);
+        saveSshConnectionSettings("testuser", validPassword, null);
+        assertNotNull(SshConnectionPool.getInstance().getConnection("ssh://testuser:testP@##word@127.0.0.1:22222"));
+        assertNull(SshConnectionPool.getInstance().getConnection("ssh://invaliduser:invalidpassword@127.0.0.1:22222"));
+    }
+
+    @Test
+    public void testGetConnectionWithUrlHavingComplexCredential2() throws IOException {
+        String validPassword = "testP@##word";
+        createSshServer("testuser", validPassword);
+        saveSshConnectionSettings("testuser", validPassword, null);
+        assertNotNull(SshConnectionPool.getInstance().getConnection("ssh://testuser:testP@##word@127.0.0.1:22222"));
+        assertNull(SshConnectionPool.getInstance().getConnection("ssh://invaliduser:invalidpassword@127.0.0.1:22222"));
+    }
+
+    @Test
+    public void testGetConnectionWithUrlHavingComplexCredential3() throws IOException {
+        String validUsername = "test@example.com";
+        String validPassword = "testP@ssw0rd";
+        createSshServer(validUsername, validPassword);
+        saveSshConnectionSettings(validUsername, validPassword, null);
+        assertNotNull(SshConnectionPool.getInstance().getConnection("ssh://test@example.com:testP@ssw0rd@127.0.0.1:22222"));
+        assertNull(SshConnectionPool.getInstance().getConnection("ssh://invaliduser:invalidpassword@127.0.0.1:22222"));
+    }
+
+    @Test
+    public void testGetConnectionWithUrlHavingComplexCredential4() throws IOException {
+        String validUsername = "test@example.com";
+        String validPassword = "testP@ssw0##$";
+        createSshServer(validUsername, validPassword);
+        saveSshConnectionSettings(validUsername, validPassword, null);
+        assertNotNull(SshConnectionPool.getInstance().getConnection("ssh://test@example.com:testP@ssw0##$@127.0.0.1:22222"));
+        assertNull(SshConnectionPool.getInstance().getConnection("ssh://invaliduser:invalidpassword@127.0.0.1:22222"));
+    }
+
+    private void createSshServer(@NonNull String validUsername, @Nullable String validPassword) throws IOException {
         server = SshServer.setUpDefaultServer();
         server.setPublickeyAuthenticator(AcceptAllPublickeyAuthenticator.INSTANCE);
         server.setPort(22222);
         server.setHost("127.0.0.1");
         server.setKeyPairProvider(hostKeyProvider);
-        server.setPasswordAuthenticator(((username, password, session) -> username.equals("testuser") && password.equals("testpassword")));
-        server.setPublickeyAuthenticator((username, key, session) -> username.equals("testuser") && key.equals(userKeyProvider.getKeyPair().getPublic()));
+        if(validPassword != null)
+            server.setPasswordAuthenticator(((username, password, session) -> username.equals(validUsername) && password.equals(validPassword)));
+        server.setPublickeyAuthenticator((username, key, session) -> username.equals(validUsername) && key.equals(userKeyProvider.getKeyPair().getPublic()));
         server.start();
+    }
+
+    private void saveSshConnectionSettings(@NonNull String validUsername, @Nullable String validPassword, @Nullable PrivateKey privateKey) {
+        utilsHandler = new UtilsHandler(RuntimeEnvironment.application);
+        utilsHandler.onCreate(utilsHandler.getWritableDatabase());
+
+        String privateKeyContents = null;
+        if(privateKey != null){
+            privateKeyContents = new StringBuilder()
+                .append("-----BEGIN RSA PRIVATE KEY-----\n")
+                .append(Base64.encodeToString(privateKey.getEncoded(), 16))
+                .append("-----END RSA PRIVATE KEY-----")
+                .toString();
+        }
+
+        StringBuilder fullUri = new StringBuilder()
+            .append("ssh://").append(validUsername);
+
+        if(validPassword != null)
+            fullUri.append(':').append(validPassword);
+
+        fullUri.append("@127.0.0.1:22222");
+
+        if(validPassword != null)
+            utilsHandler.addSsh("test", SshClientUtils.encryptSshPathAsNecessary(fullUri.toString()), SecurityUtils.getFingerprint(hostKeyProvider.getKeyPair().getPublic()), null, null);
+        else
+            utilsHandler.addSsh("test", fullUri.toString(), SecurityUtils.getFingerprint(hostKeyProvider.getKeyPair().getPublic()), "id_rsa", privateKeyContents);
     }
 }

--- a/app/src/test/java/com/amaze/filemanager/filesystem/ssh/SshConnectionPoolTest.java
+++ b/app/src/test/java/com/amaze/filemanager/filesystem/ssh/SshConnectionPoolTest.java
@@ -13,7 +13,6 @@ import net.schmizz.sshj.common.SecurityUtils;
 
 import org.apache.sshd.server.SshServer;
 import org.apache.sshd.server.auth.pubkey.AcceptAllPublickeyAuthenticator;
-import org.bouncycastle.asn1.pkcs.PrivateKeyInfo;
 import org.bouncycastle.openssl.jcajce.JcaPEMWriter;
 import org.junit.After;
 import org.junit.BeforeClass;

--- a/app/src/test/java/com/amaze/filemanager/filesystem/ssh/SshConnectionPoolTest.java
+++ b/app/src/test/java/com/amaze/filemanager/filesystem/ssh/SshConnectionPoolTest.java
@@ -83,15 +83,6 @@ public class SshConnectionPoolTest {
         assertNull(SshConnectionPool.getInstance().getConnection("ssh://invaliduser:invalidpassword@127.0.0.1:22222"));
     }
 
-    //Sorry but this is not getting through yet...
-//    @Test @Ignore
-//    public void testGetConnectionWithUrlAndKeyAuth() throws IOException {
-//        createSshServer("testuser", null);
-//        saveSshConnectionSettings("testuser", null, userKeyProvider.getKeyPair().getPrivate());
-//        assertNotNull(SshConnectionPool.getInstance().getConnection("ssh://testuser@127.0.0.1:22222"));
-//        assertNull(SshConnectionPool.getInstance().getConnection("ssh://invaliduser@127.0.0.1:22222"));
-//    }
-
     @Test
     public void testGetConnectionWithUrlHavingComplexPassword1() throws IOException {
         String validPassword = "testP@ssw0rd";
@@ -164,6 +155,7 @@ public class SshConnectionPoolTest {
         utilsHandler = new UtilsHandler(RuntimeEnvironment.application);
         utilsHandler.onCreate(utilsHandler.getWritableDatabase());
 
+        //FIXME: privateKeyContents created this way cannot be parsed back in PemToKeyPairTask
         String privateKeyContents = null;
         if(privateKey != null){
             privateKeyContents = new StringBuilder()

--- a/app/src/test/java/com/amaze/filemanager/test/ShadowCryptUtil.java
+++ b/app/src/test/java/com/amaze/filemanager/test/ShadowCryptUtil.java
@@ -1,0 +1,79 @@
+package com.amaze.filemanager.test;
+
+import android.content.Context;
+import android.util.Base64;
+
+import com.amaze.filemanager.utils.files.CryptUtil;
+
+import org.robolectric.annotation.Implementation;
+import org.robolectric.annotation.Implements;
+
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+
+import javax.crypto.Cipher;
+import javax.crypto.KeyGenerator;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.GCMParameterSpec;
+
+@Implements(CryptUtil.class)
+public class ShadowCryptUtil {
+
+    private static final String ALGO_AES = "AES/GCM/NoPadding";
+    private static final String IV = "LxbHiJhhUXcj";    // 12 byte long IV supported by android for GCM
+
+    private static SecretKey secretKey = null;
+
+    static {
+        try {
+            KeyGenerator keyGen = KeyGenerator.getInstance("AES", "BC");
+            keyGen.init(128);
+            secretKey = keyGen.generateKey();
+        } catch (GeneralSecurityException e) {
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * Method handles encryption of plain text on various APIs
+     */
+    @Implementation
+    public static String encryptPassword(Context context, String plainText) throws GeneralSecurityException, IOException {
+        return aesEncryptPassword(plainText);
+    }
+
+    /**
+     * Method handles decryption of cipher text on various APIs
+     */
+    @Implementation
+    public static String decryptPassword(Context context, String cipherText) throws GeneralSecurityException, IOException {
+        return aesDecryptPassword(cipherText);
+    }
+
+    /**
+     * Helper method to encrypt plain text password
+     */
+    private static String aesEncryptPassword(String plainTextPassword)
+            throws GeneralSecurityException {
+
+        Cipher cipher = Cipher.getInstance(ALGO_AES, "BC");
+        GCMParameterSpec gcmParameterSpec = new GCMParameterSpec(128, IV.getBytes());
+        cipher.init(Cipher.ENCRYPT_MODE, secretKey, gcmParameterSpec);
+        byte[] encodedBytes = cipher.doFinal(plainTextPassword.getBytes());
+
+        return Base64.encodeToString(encodedBytes, Base64.DEFAULT);
+    }
+
+    /**
+     * Helper method to decrypt cipher text password
+     */
+    private static String aesDecryptPassword(String cipherPassword) throws GeneralSecurityException {
+
+        Cipher cipher = Cipher.getInstance(ALGO_AES, "BC");
+        GCMParameterSpec gcmParameterSpec = new GCMParameterSpec(128, IV.getBytes());
+        cipher.init(Cipher.DECRYPT_MODE, secretKey, gcmParameterSpec);
+        byte[] decryptedBytes = cipher.doFinal(Base64.decode(cipherPassword, Base64.DEFAULT));
+
+        return new String(decryptedBytes);
+    }
+}

--- a/app/src/test/java/com/amaze/filemanager/test/ShadowCryptUtilTest.java
+++ b/app/src/test/java/com/amaze/filemanager/test/ShadowCryptUtilTest.java
@@ -1,0 +1,42 @@
+package com.amaze.filemanager.test;
+
+import com.amaze.filemanager.BuildConfig;
+import com.amaze.filemanager.database.UtilsHandler;
+import com.amaze.filemanager.filesystem.ssh.SshClientUtils;
+import com.amaze.filemanager.utils.files.CryptUtil;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.annotation.Config;
+import org.robolectric.shadows.multidex.ShadowMultiDex;
+
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(constants = BuildConfig.class, shadows = {ShadowMultiDex.class, ShadowCryptUtil.class})
+public class ShadowCryptUtilTest {
+
+    @Test
+    public void testEncryptDecrypt() throws GeneralSecurityException, IOException {
+        String text = "test";
+        String encrypted = CryptUtil.encryptPassword(RuntimeEnvironment.application, text);
+        assertEquals(text, CryptUtil.decryptPassword(RuntimeEnvironment.application, encrypted));
+    }
+
+    @Test
+    public void testWithUtilsHandler() throws GeneralSecurityException, IOException {
+        UtilsHandler utilsHandler = new UtilsHandler(RuntimeEnvironment.application);
+        utilsHandler.onCreate(utilsHandler.getWritableDatabase());
+
+        String fingerprint = "00:11:22:33:44:55:66:77:88:99:aa:bb:cc:dd:ee:ff";
+        String url = "ssh://test:test@127.0.0.1:22";
+
+        utilsHandler.addSsh("Test", SshClientUtils.encryptSshPathAsNecessary(url), fingerprint, null, null);
+        assertEquals(fingerprint, utilsHandler.getSshHostKey(url));
+    }
+}


### PR DESCRIPTION
Fixes #1333 (hopefully) and fixes #1290. At places where `Uri.parse()` cannot properly split the SSH server URI for authentication credentials, it is done by hand instead.

~~Writing~~Robolectric test case ~~was not possible due to #1290, and~~ included since Apache Sshd cannot be run on Android devices (physical/emulator) ~~so Espresso tests aren't possible either~~. ~~I had to test with the hard way - t~~Tested with Oneplus One running Slim7 (7.1.2) and Galaxy S2 running SlimLP (5.1.1), connecting to OpenSSH server running on Fedora Atomic Host.

Espresso test for `UtilsHandler` to make sure data saved to database is not truncated is included however.

Note: I suspect SMB implementation would be affected by such problem too, but since nobody is complaining so far, I'm following the rule of "if it ain't broken, don't fix it" - or in separate PR for next milestone.