### PR TITLE
Bypass space check when API supports moving through renaming paths

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/MoveFiles.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/MoveFiles.java
@@ -22,12 +22,15 @@ package com.amaze.filemanager.asynchronous.asynctasks;
 import android.content.Context;
 import android.content.Intent;
 import android.os.AsyncTask;
+import android.widget.Toast;
 
+import com.amaze.filemanager.R;
 import com.amaze.filemanager.activities.MainActivity;
 import com.amaze.filemanager.activities.superclasses.ThemedActivity;
 import com.amaze.filemanager.database.CryptHandler;
 import com.amaze.filemanager.database.models.EncryptedEntry;
 import com.amaze.filemanager.exceptions.ShellNotRunningException;
+import com.amaze.filemanager.filesystem.HybridFile;
 import com.amaze.filemanager.filesystem.HybridFileParcelable;
 import com.amaze.filemanager.fragments.MainFragment;
 import com.amaze.filemanager.utils.application.AppConfig;
@@ -40,10 +43,12 @@ import com.amaze.filemanager.utils.OpenMode;
 import com.amaze.filemanager.utils.RootUtils;
 import com.amaze.filemanager.utils.ServiceWatcherUtil;
 import com.cloudrail.si.interfaces.CloudStorage;
+import com.cloudrail.si.interfaces.SMS;
 
 import java.io.File;
 import java.net.MalformedURLException;
 import java.util.ArrayList;
+import java.util.List;
 
 import jcifs.smb.SmbException;
 import jcifs.smb.SmbFile;
@@ -53,13 +58,15 @@ import jcifs.smb.SmbFile;
  * if they're in the same filesystem, else starting the copy service.
  * Be advised - do not start this AsyncTask directly but use {@link PrepareCopyTask} instead
  */
-public class MoveFiles extends AsyncTask<ArrayList<String>, Void, Boolean> {
+public class MoveFiles extends AsyncTask<ArrayList<String>, String, Boolean> {
 
     private ArrayList<ArrayList<HybridFileParcelable>> files;
     private MainFragment mainFrag;
     private ArrayList<String> paths;
     private Context context;
     private OpenMode mode;
+    private long totalBytes = 0l;
+    private long destinationSize = 0l;
 
     public MoveFiles(ArrayList<ArrayList<HybridFileParcelable>> files, MainFragment ma, Context context, OpenMode mode) {
         mainFrag = ma;
@@ -69,10 +76,21 @@ public class MoveFiles extends AsyncTask<ArrayList<String>, Void, Boolean> {
     }
 
     @Override
+    public void onProgressUpdate(String... message) {
+        Toast.makeText(context, message[0], Toast.LENGTH_LONG).show();
+    }
+
+    @Override
     protected Boolean doInBackground(ArrayList<String>... strings) {
         paths = strings[0];
 
         if (files.size() == 0) return true;
+
+        for (ArrayList<HybridFileParcelable> filesCurrent : files) {
+            totalBytes += FileUtils.getTotalBytes(filesCurrent, context);
+        }
+        HybridFile destination = new HybridFile(mode, paths.get(0));
+        destinationSize = destination.getUsableSpace();
 
         switch (mode) {
             case SMB:
@@ -188,6 +206,13 @@ public class MoveFiles extends AsyncTask<ArrayList<String>, Void, Boolean> {
             });
 
         } else {
+
+            if (destinationSize < totalBytes) {
+                // destination don't have enough space; return
+                publishProgress(context.getResources().getString(R.string.in_safe));
+                return;
+            }
+
             for (int i = 0; i < paths.size(); i++) {
                 Intent intent = new Intent(context, CopyService.class);
                 intent.putExtra(CopyService.TAG_COPY_SOURCES, files.get(i));
@@ -198,5 +223,21 @@ public class MoveFiles extends AsyncTask<ArrayList<String>, Void, Boolean> {
                 ServiceWatcherUtil.runService(context, intent);
             }
         }
+    }
+
+    /**
+     * Maintains a list of filesystems supporting the move/rename implementation.
+     * Please update to return your {@link OpenMode} type if it is supported here
+     * @return
+     */
+    public static List<OpenMode> getOperationSupportedFileSystem() {
+        ArrayList<OpenMode> arrayList = new ArrayList<>();
+        arrayList.add(OpenMode.SMB);
+        arrayList.add(OpenMode.FILE);
+        arrayList.add(OpenMode.DROPBOX);
+        arrayList.add(OpenMode.BOX);
+        arrayList.add(OpenMode.GDRIVE);
+        arrayList.add(OpenMode.ONEDRIVE);
+        return arrayList;
     }
 }

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/MoveFiles.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/MoveFiles.java
@@ -48,6 +48,7 @@ import com.cloudrail.si.interfaces.SMS;
 import java.io.File;
 import java.net.MalformedURLException;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 
 import jcifs.smb.SmbException;
@@ -73,11 +74,6 @@ public class MoveFiles extends AsyncTask<ArrayList<String>, String, Boolean> {
         this.context = context;
         this.files = files;
         this.mode = mode;
-    }
-
-    @Override
-    public void onProgressUpdate(String... message) {
-        Toast.makeText(context, message[0], Toast.LENGTH_LONG).show();
     }
 
     @Override
@@ -209,7 +205,7 @@ public class MoveFiles extends AsyncTask<ArrayList<String>, String, Boolean> {
 
             if (destinationSize < totalBytes) {
                 // destination don't have enough space; return
-                publishProgress(context.getResources().getString(R.string.in_safe));
+                Toast.makeText(context, context.getResources().getString(R.string.in_safe), Toast.LENGTH_LONG).show();
                 return;
             }
 
@@ -230,14 +226,14 @@ public class MoveFiles extends AsyncTask<ArrayList<String>, String, Boolean> {
      * Please update to return your {@link OpenMode} type if it is supported here
      * @return
      */
-    public static List<OpenMode> getOperationSupportedFileSystem() {
-        ArrayList<OpenMode> arrayList = new ArrayList<>();
-        arrayList.add(OpenMode.SMB);
-        arrayList.add(OpenMode.FILE);
-        arrayList.add(OpenMode.DROPBOX);
-        arrayList.add(OpenMode.BOX);
-        arrayList.add(OpenMode.GDRIVE);
-        arrayList.add(OpenMode.ONEDRIVE);
-        return arrayList;
+    public static HashSet<OpenMode> getOperationSupportedFileSystem() {
+        HashSet<OpenMode> hashSet = new HashSet<>();
+        hashSet.add(OpenMode.SMB);
+        hashSet.add(OpenMode.FILE);
+        hashSet.add(OpenMode.DROPBOX);
+        hashSet.add(OpenMode.BOX);
+        hashSet.add(OpenMode.GDRIVE);
+        hashSet.add(OpenMode.ONEDRIVE);
+        return hashSet;
     }
 }

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/PrepareCopyTask.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/PrepareCopyTask.java
@@ -59,6 +59,7 @@ public class PrepareCopyTask extends AsyncTask<ArrayList<HybridFileParcelable>, 
     private boolean rootMode = false;
     private OpenMode openMode = OpenMode.FILE;
     private DO_FOR_ALL_ELEMENTS dialogState = null;
+    private boolean isRenameMoveSupport = false;
 
     //causes folder containing filesToCopy to be deleted
     private ArrayList<File> deleteCopiedFolder = null;
@@ -104,10 +105,18 @@ public class PrepareCopyTask extends AsyncTask<ArrayList<HybridFileParcelable>, 
             return null;
         }
 
+        HybridFile destination = new HybridFile(openMode, path);
+        destination.generateMode(context);
+
+        if (move && destination.getMode() == openMode
+                && MoveFiles.getOperationSupportedFileSystem().contains(openMode)) {
+            // move/rename supported filesystems, skip checking for space
+            isRenameMoveSupport = true;
+        }
+
         totalBytes = FileUtils.getTotalBytes(filesToCopy, context);
 
-        HybridFile destination = new HybridFile(openMode, path);
-        if (destination.getUsableSpace() < totalBytes) {
+        if (destination.getUsableSpace() < totalBytes && !isRenameMoveSupport) {
             publishProgress(context.getResources().getString(R.string.in_safe));
             return null;
         }


### PR DESCRIPTION
Fixes #1345 and fixes #895 and fixes #513 (?)
Had plans for long to fix this problem. Finally it's done.