### PR TITLE
PemToKeyPairTask refactor: popup passphrase dialog at onProgressUpdate instead

### DIFF
--- a/app/src/androidTest/java/com/amaze/filemanager/asynchronous/asynctasks/ssh/PemToKeyPairTaskTest.java
+++ b/app/src/androidTest/java/com/amaze/filemanager/asynchronous/asynctasks/ssh/PemToKeyPairTaskTest.java
@@ -1,0 +1,116 @@
+package com.amaze.filemanager.asynchronous.asynctasks.ssh;
+
+import android.support.test.runner.AndroidJUnit4;
+
+import net.schmizz.sshj.userauth.password.PasswordFinder;
+import net.schmizz.sshj.userauth.password.Resource;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.lang.reflect.Field;
+import java.util.concurrent.CountDownLatch;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+@RunWith(AndroidJUnit4.class)
+public class PemToKeyPairTaskTest {
+
+    private static final String unencryptedPuttyKey = "PuTTY-User-Key-File-2: ssh-rsa\n" +
+            "Encryption: none\n" +
+            "Comment: Key for test only\n" +
+            "Public-Lines: 6\n" +
+            "AAAAB3NzaC1yc2EAAAABJQAAAQEA6ZhWkS0Xpb1riC5r3dulviIwVFUP4uXnnapv\n" +
+            "eqVwB/7aklhu3SnOlBwRMoan+AohhHogy2cjNMqW6x/xLwH9Cbo4kMTeJTPR7ca2\n" +
+            "lxmCtGgdFRheR84if6T+i2fb1ADUmncJEkL2H1Q7RG7+opoerDpwdGjopsP7s7H4\n" +
+            "ZTvGGXcudhrOFOf/gW8hR8m9wJ05ON8qfKiRWIKDxFpectFOpJC/NGP4F53EHNAk\n" +
+            "HIhNPSW5voytGvj4VaS/xRAs2HLmj7jTor/Le/vJlndmnyJkGIwEJbVpp5HsZG7R\n" +
+            "VyhqZwCcI6ZiMXvYSH6oplffUGZz5HXkskBmreMauZC1beN31Q==\n" +
+            "Private-Lines: 14\n" +
+            "AAABAD8iQOj3bizLaSu5hO/af9KFx99w74lukaA75sczobz4xXOpMrhQfQVvXpgI\n" +
+            "t8Z/R1Q8rurdms//Zw8dY8eD/zMPvELNbHjB5bXireOmB6ZhU/fdEo/yhd1PMAoA\n" +
+            "ZO0wqCm/To9QXjH7Fu/mpa9n7J1AOhGf0C0SX7QGlikyv+s0c4ib+ipR6TEoLRHD\n" +
+            "Oa85soSZGjPvPckkfSNncemEWuo4Hp0jiJOU/Gd37YNY4Jc9FhRRuBlTUvhBdg5g\n" +
+            "FsvHZD2fZ+5J0Z2Gm9tJL6Uq6rvNWVC9sFlnornPXM9/UvXQ1Q59rIk0CQNEOVr7\n" +
+            "kdYpYeUhYrrwhCVQrjbV8CxyRi0AAACBAP1T4/nXa/+tA9f3orMBkxzQF0FnPI/+\n" +
+            "e8YXvdHtkHl3/uJEEy9FmliJecKNtNBDN6Tu3iAs5ne/btvyduMgRAxqOyXxdQCq\n" +
+            "uR2iNoHLCDqgOUbXCh+swVHPXsdbbhv/54aWjLBbbfZ6S1CwTmPV3eAVJRb78JwS\n" +
+            "uBi8Sq/5ZnhFAAAAgQDsDyjp1Bm6nonVwaGCHRsH5JFuiHbP8cyIQzdnC6PrMFvS\n" +
+            "EU1PfMKSeudywnEKyljct7Njw5FnMt1InWj1X80adK/gWTmppAPRr0u0ipT4J9ry\n" +
+            "1yCj4zeNS/cylZZoP/rOCq8Z2mbzqIO28jN5e7xDMrutNdXhqrOwmMgM0AliUQAA\n" +
+            "AIEAjMoM3mw2YXE7U1X2H/hfYymMWC+6XU4XHCI2Fk+CWGUPxvDT3uqUtoEXOXkY\n" +
+            "THdPSgA2f6EmqCOPR1VAA4jdQkK8VkN3/O3zWFdfRGqN5Kka7a7cmcyd93sq3LIU\n" +
+            "EYe4EYW7BQwe1W5ZCO+lRzjquGAB5rMhdAnzYfvkPc7sfJ8=\n" +
+            "Private-MAC: 2cd5ec740c5dd854e8a6bea3773f98697670bdc6";
+
+    //Passphrase = test
+    private static final String encryptedPuttyKey = "PuTTY-User-Key-File-2: ssh-rsa\n" +
+            "Encryption: aes256-cbc\n" +
+            "Comment: Key for test only\n" +
+            "Public-Lines: 6\n" +
+            "AAAAB3NzaC1yc2EAAAABJQAAAQEAoArpfCYeHImHcTELKVzVjyS6N6viAN4lzkWC\n" +
+            "EDCyBX6x4wwgVXRYQTbd6xNCpVb/TdBTN/aVF9EXtMW2TXyvntxGblE+ilK8b3GL\n" +
+            "zRfxjrjGsjqffwlHn3JaWpCOYtEqgGOLeKkofbKBXGn1aK6tvowPsY89Dl4aK857\n" +
+            "mwisAvCIxmd8b6f2aBy4MLQ7AdmZXxPq6YD9CDXPyQkNG4RH5RGAIAw7jD+O6tUo\n" +
+            "g69voQudjy3D51VQDGNxOJVojQiQvmRUR2qkSazPJqE/hFsdN6rKh+Pbe8h6z+rU\n" +
+            "bym37+sTK5JwWKHDQ7/ezLdNR38wAPHdz2VW5+0rqKm8LAtCGQ==\n" +
+            "Private-Lines: 14\n" +
+            "erS8mfUDEme+ujzF1k0GA7d2P4umHriMFQjBZIdvht6amZXoF1L+bkJp82/vG9lv\n" +
+            "YYNYQqk5tHezkV3sJncPwr3RI/0Y1L+WtKWSfE6OzSKdYJoX3WpAuMTeMlVrxu0t\n" +
+            "RXnjbfSz7Z1czryxO4NgAK3NsYQK6h290uq5/mpqP6fIhT3/tn+mH8kihAt8+uum\n" +
+            "1RW9ucNi3TZTG4I00Z3LWHw1VaqYFeCYh3yp8Canv3mKGn5ISqsd5ehNXW1TYvJF\n" +
+            "Bd742+JlxK8dhrAr2R+g+erSA0ac8Df3wH72syVPzdewnh+21zff3NGI9GWN799X\n" +
+            "CnVtf+psDPuebGQIHewNTGsaziNkAT5rGXdNMo3Xln/B1Wr9l8tIJAtDWSNqjDLp\n" +
+            "kAcLQ+Z1wTPZehZKBi0oTsLVm4tEcPQsbnuK9h+Y/d9EWcmBEiHTGM6otesNZNA8\n" +
+            "i247YZpyrG3azeRFBVMNSzKJ+vS2rKpgvm8nbYKy+nO5uNZDEm9oARr9QPCxdzXK\n" +
+            "dmI9F8IT3tLd4qCekD4DI9MKxJLjzFmyGOHc4zMxgUyL5BT5suVDIAWL/hiekwjt\n" +
+            "T1+V+TRScq4c+pIWxfVu4kY+HpLUpSR3RAVaRFar7jaB+YEEXw+gqEVTCyZeXGFf\n" +
+            "dWU+8BkhFBF24v3Qoi9SmuWYrSQGl9O8smIHW0H2JCNF+8oqpQG8dwx37L3VyMNq\n" +
+            "ApJh0LnRhoRwKo2YaAZKInaFTYS8Gnj7DvZ+l7lxPRfCV5yl9U2How2BI9YPRDDu\n" +
+            "Gs4agAG3InJnMiuIOzaNOIFLGM9STtYNyvG411rj6tR4EEQ6cJCxIlVe5a1mEt7M\n" +
+            "GVfbB5wUvow0o0a56OBmFMZOCxV2Vpxu6PuGTD8QQ0O0YzNDWFk3Fj2RRnnLCBLF\n" +
+            "Private-MAC: f742e2954fbb0c98984db0d9855a0f15507ecc0a";
+
+    @Test
+    public void testUnencryptedKeyToKeyPair() throws InterruptedException {
+        CountDownLatch waiter = new CountDownLatch(1);
+        PemToKeyPairTask task = new PemToKeyPairTask(unencryptedPuttyKey, result -> {
+            assertNotNull(result.result);
+            assertNull(result.exception);
+            assertNotNull(result.result.getPublic());
+            assertNotNull(result.result.getPrivate());
+            waiter.countDown();
+        });
+        task.execute();
+        waiter.await();
+    }
+
+    @Test
+    public void testEncryptedKeyToKeyPair() throws InterruptedException, NoSuchFieldException, IllegalAccessException {
+        CountDownLatch waiter = new CountDownLatch(1);
+        PemToKeyPairTask task = new PemToKeyPairTask(encryptedPuttyKey, result -> {
+            assertNotNull(result.result);
+            assertNull(result.exception);
+            assertNotNull(result.result.getPublic());
+            assertNotNull(result.result.getPrivate());
+            waiter.countDown();
+        });
+        Field field = PemToKeyPairTask.class.getDeclaredField("passwordFinder");
+        field.setAccessible(true);
+        field.set(task, new PasswordFinder() {
+            @Override
+            public char[] reqPassword(Resource<?> resource) {
+                return "test".toCharArray();
+            }
+
+            @Override
+            public boolean shouldRetry(Resource<?> resource) {
+                return false;
+            }
+        });
+        task.execute();
+        waiter.await();
+
+    }
+}

--- a/app/src/androidTest/java/com/amaze/filemanager/asynchronous/asynctasks/ssh/PemToKeyPairTaskTest.java
+++ b/app/src/androidTest/java/com/amaze/filemanager/asynchronous/asynctasks/ssh/PemToKeyPairTaskTest.java
@@ -76,10 +76,9 @@ public class PemToKeyPairTaskTest {
     public void testUnencryptedKeyToKeyPair() throws InterruptedException {
         CountDownLatch waiter = new CountDownLatch(1);
         PemToKeyPairTask task = new PemToKeyPairTask(unencryptedPuttyKey, result -> {
-            assertNotNull(result.result);
-            assertNull(result.exception);
-            assertNotNull(result.result.getPublic());
-            assertNotNull(result.result.getPrivate());
+            assertNotNull(result);
+            assertNotNull(result.getPublic());
+            assertNotNull(result.getPrivate());
             waiter.countDown();
         });
         task.execute();
@@ -90,10 +89,9 @@ public class PemToKeyPairTaskTest {
     public void testEncryptedKeyToKeyPair() throws InterruptedException, NoSuchFieldException, IllegalAccessException {
         CountDownLatch waiter = new CountDownLatch(1);
         PemToKeyPairTask task = new PemToKeyPairTask(encryptedPuttyKey, result -> {
-            assertNotNull(result.result);
-            assertNull(result.exception);
-            assertNotNull(result.result.getPublic());
-            assertNotNull(result.result.getPrivate());
+            assertNotNull(result);
+            assertNotNull(result.getPublic());
+            assertNotNull(result.getPrivate());
             waiter.countDown();
         });
         Field field = PemToKeyPairTask.class.getDeclaredField("passwordFinder");

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/ssh/PemToKeyPairTask.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/ssh/PemToKeyPairTask.java
@@ -102,6 +102,8 @@ public class PemToKeyPairTask extends AsyncTask<Void, IOException, KeyPair>
         while(true){
             if(paused) {
                 continue;
+            } else if (isCancelled()) {
+                return null;
             } else {
                 for (PemToKeyPairConverter converter : converters) {
                     KeyPair keyPair = converter.convert(new String(pemFile));
@@ -154,6 +156,7 @@ public class PemToKeyPairTask extends AsyncTask<Void, IOException, KeyPair>
                     .onNegative(((dialog, which) -> {
                         dialog.dismiss();
                         toastOnParseError(result);
+                        cancel(true);
                     }));
 
             MaterialDialog dialog = builder.show();

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/ssh/PemToKeyPairTask.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/ssh/PemToKeyPairTask.java
@@ -100,22 +100,24 @@ public class PemToKeyPairTask extends AsyncTask<Void, IOException, KeyPair>
     @Override
     protected KeyPair doInBackground(Void... voids) {
         while(true){
-            if(paused) {
-                continue;
-            } else if (isCancelled()) {
+            if(isCancelled()) {
                 return null;
             } else {
-                for (PemToKeyPairConverter converter : converters) {
-                    KeyPair keyPair = converter.convert(new String(pemFile));
-                    if (keyPair != null) {
-                        paused = false;
-                        return keyPair;
+                if(paused) {
+                    continue;
+                } else {
+                    for (PemToKeyPairConverter converter : converters) {
+                        KeyPair keyPair = converter.convert(new String(pemFile));
+                        if (keyPair != null) {
+                            paused = false;
+                            return keyPair;
+                        }
                     }
+                    if(this.passwordFinder != null)
+                        this.errorMessage = AppConfig.getInstance().getString(R.string.ssh_key_invalid_passphrase);
+                    paused = true;
+                    publishProgress(new IOException("No converter available to parse selected PEM"));
                 }
-                if(this.passwordFinder != null)
-                    this.errorMessage = AppConfig.getInstance().getString(R.string.ssh_key_invalid_passphrase);
-                paused = true;
-                publishProgress(new IOException("No converter available to parse selected PEM"));
             }
         }
     }

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/ssh/SshAuthenticationTask.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/ssh/SshAuthenticationTask.java
@@ -122,7 +122,7 @@ public class SshAuthenticationTask extends AsyncTask<Void, Void, AsyncTaskResult
                     }
 
                     @Override
-                    public KeyType getType() throws IOException {
+                    public KeyType getType() {
                         return KeyType.fromKey(getPublic());
                     }
                 });

--- a/app/src/main/java/com/amaze/filemanager/filesystem/ssh/SshConnectionPool.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/ssh/SshConnectionPool.java
@@ -194,10 +194,8 @@ public class SshConnectionPool
             try {
                 CountDownLatch latch = new CountDownLatch(1);
                 new PemToKeyPairTask(pem, result -> {
-                    if (result.result != null) {
-                        keyPair.set(result.result);
-                        latch.countDown();
-                    }
+                    keyPair.set(result);
+                    latch.countDown();
                 }).execute();
                 latch.await();
             } catch(InterruptedException e) {

--- a/app/src/main/java/com/amaze/filemanager/ui/dialogs/SftpConnectDialog.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/dialogs/SftpConnectDialog.java
@@ -280,18 +280,15 @@ public class SftpConnectDialog extends DialogFragment {
                 InputStream selectedKeyContent = context.getContentResolver()
                         .openInputStream(selectedPem);
                 new PemToKeyPairTask(selectedKeyContent, result -> {
-                    if(result.result != null)
-                    {
-                        selectedParsedKeyPair = result.result;
-                        selectedParsedKeyPairName = selectedPem.getLastPathSegment()
-                                .substring(selectedPem.getLastPathSegment().indexOf('/')+1);
-                        MDButton okBTN = ((MaterialDialog)getDialog())
-                                .getActionButton(DialogAction.POSITIVE);
-                        okBTN.setEnabled(okBTN.isEnabled() || true);
+                    selectedParsedKeyPair = result;
+                    selectedParsedKeyPairName = selectedPem.getLastPathSegment()
+                            .substring(selectedPem.getLastPathSegment().indexOf('/')+1);
+                    MDButton okBTN = ((MaterialDialog)getDialog())
+                            .getActionButton(DialogAction.POSITIVE);
+                    okBTN.setEnabled(okBTN.isEnabled() || true);
 
-                        Button selectPemBTN = getDialog().findViewById(R.id.selectPemBTN);
-                        selectPemBTN.setText(selectedParsedKeyPairName);
-                    }
+                    Button selectPemBTN = getDialog().findViewById(R.id.selectPemBTN);
+                    selectPemBTN.setText(selectedParsedKeyPairName);
                 }).execute();
 
             } catch(FileNotFoundException e) {


### PR DESCRIPTION
Fixes #1354. This prevents PemToKeyPairTask from never getting the decrypted key at postExecute loop.

Because of `AsyncTask`'s nature of `doInBackground()` is performed only once, inevitably I need to use a while loop to keep the task wait for a correct passphrase (if there is one), hence making the passphrase popup at `onProgressUpdate()`.

So sorry that I couldn't make an Espresso or Robolectric test that is working, either on device or in Android Studio, so please use the following way to verify (if you need to):

1. Generate a new key in puttygen, with passphrase (don't worry, puttygen works nice with wine too)
2. Add the key to authroized_keys on SSH server
3. Copy the key to device
4. Launch Amaze FM
5. Setup connection with the key
6. Passphrase dialog will popup, prompt for passphrase
7. Try enter incorrect passphrase, dialog will indicate incorrect passphrase and still block the connection setup dialog
8. Enter the correct passphrase to connect to the SSH server, as well as saving the connection settings
9. The next time we launch Amaze again, when we tap on the connection saved at 8), dialog will popup prompt for key passphrase. Enter the correct passphrase to connect to the SSH server