### PR TITLE
Fix compressname

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/adapters/CompressedExplorerAdapter.java
+++ b/app/src/main/java/com/amaze/filemanager/adapters/CompressedExplorerAdapter.java
@@ -255,10 +255,8 @@ public class CompressedExplorerAdapter extends RecyclerView.Adapter<CompressedIt
                     toggleChecked(position, holder.checkImageView);
                 } else {
                     if (rowItem.directory) {
-                        final StringBuilder stringBuilder = new StringBuilder(rowItem.path);
-                        stringBuilder.deleteCharAt(rowItem.path.length() - 1);
-
-                        compressedExplorerFragment.changePath(stringBuilder.toString());
+                        String newPath = rowItem.path.substring(0, rowItem.path.length() - 1);
+                        compressedExplorerFragment.changePath(newPath);
                     } else {
                         String fileName = compressedExplorerFragment.compressedFile.getName().substring(0,
                                 compressedExplorerFragment.compressedFile.getName().lastIndexOf("."));

--- a/app/src/main/java/com/amaze/filemanager/adapters/CompressedExplorerAdapter.java
+++ b/app/src/main/java/com/amaze/filemanager/adapters/CompressedExplorerAdapter.java
@@ -207,17 +207,18 @@ public class CompressedExplorerAdapter extends RecyclerView.Adapter<CompressedIt
         } else {
             GlideApp.with(compressedExplorerFragment).load(rowItem.iconData.image).into(holder.genericIcon);
 
-            final StringBuilder stringBuilder = new StringBuilder(rowItem.name);
             if (compressedExplorerFragment.showLastModified)
                 holder.date.setText(Utils.getDate(rowItem.date, compressedExplorerFragment.year));
             if (rowItem.directory) {
                 holder.genericIcon.setImageDrawable(folder);
                 gradientDrawable.setColor(compressedExplorerFragment.iconskin);
-                if (stringBuilder.toString().length() > 0) {
+                if (!rowItem.name.isEmpty()) {
+                    final StringBuilder stringBuilder = new StringBuilder(rowItem.name);
                     stringBuilder.deleteCharAt(rowItem.name.length() - 1);
+
                     try {
-                        holder.txtTitle.setText(stringBuilder.toString().substring(stringBuilder.toString().lastIndexOf("/") + 1));
-                    } catch (Exception e) {
+                        holder.txtTitle.setText(stringBuilder.substring(stringBuilder.lastIndexOf("/") + 1));
+                    } catch (StringIndexOutOfBoundsException e) {
                         holder.txtTitle.setText(rowItem.name.substring(0, rowItem.name.lastIndexOf("/")));
                     }
                 }
@@ -265,11 +266,10 @@ public class CompressedExplorerAdapter extends RecyclerView.Adapter<CompressedIt
                 if (compressedExplorerFragment.selection) {
                     toggleChecked(position, holder.checkImageView);
                 } else {
-                    final StringBuilder stringBuilder = new StringBuilder(rowItem.name);
-                    if (rowItem.directory)
+                    if (rowItem.directory) {
+                        final StringBuilder stringBuilder = new StringBuilder(rowItem.name);
                         stringBuilder.deleteCharAt(rowItem.name.length() - 1);
 
-                    if (rowItem.directory) {
                         compressedExplorerFragment.changePath(stringBuilder.toString());
                     } else {
                         String fileName = compressedExplorerFragment.compressedFile.getName().substring(0,

--- a/app/src/main/java/com/amaze/filemanager/adapters/CompressedExplorerAdapter.java
+++ b/app/src/main/java/com/amaze/filemanager/adapters/CompressedExplorerAdapter.java
@@ -209,16 +209,7 @@ public class CompressedExplorerAdapter extends RecyclerView.Adapter<CompressedIt
             if (rowItem.directory) {
                 holder.genericIcon.setImageDrawable(folder);
                 gradientDrawable.setColor(compressedExplorerFragment.iconskin);
-                if (!rowItem.path.isEmpty()) {
-                    final StringBuilder stringBuilder = new StringBuilder(rowItem.path);
-                    stringBuilder.deleteCharAt(rowItem.path.length() - 1);
-
-                    try {
-                        holder.txtTitle.setText(stringBuilder.substring(stringBuilder.lastIndexOf("/") + 1));
-                    } catch (StringIndexOutOfBoundsException e) {
-                        holder.txtTitle.setText(rowItem.path.substring(0, rowItem.path.lastIndexOf("/")));
-                    }
-                }
+                holder.txtTitle.setText(rowItem.name);
             } else {
                 if (compressedExplorerFragment.showSize)
                     holder.txtDesc.setText(Formatter.formatFileSize(context, rowItem.size));

--- a/app/src/main/java/com/amaze/filemanager/adapters/CompressedExplorerAdapter.java
+++ b/app/src/main/java/com/amaze/filemanager/adapters/CompressedExplorerAdapter.java
@@ -2,7 +2,6 @@ package com.amaze.filemanager.adapters;
 
 import android.app.Activity;
 import android.content.Context;
-import android.graphics.Color;
 import android.graphics.drawable.Drawable;
 import android.graphics.drawable.GradientDrawable;
 import android.os.Build;
@@ -21,12 +20,10 @@ import com.amaze.filemanager.GlideApp;
 import com.amaze.filemanager.R;
 import com.amaze.filemanager.adapters.data.CompressedObjectParcelable;
 import com.amaze.filemanager.adapters.holders.CompressedItemViewHolder;
-import com.amaze.filemanager.adapters.holders.ItemViewHolder;
 import com.amaze.filemanager.filesystem.HybridFileParcelable;
 import com.amaze.filemanager.filesystem.compressed.CompressedHelper;
 import com.amaze.filemanager.filesystem.compressed.showcontents.Decompressor;
 import com.amaze.filemanager.fragments.CompressedExplorerFragment;
-import com.amaze.filemanager.ui.icons.Icons;
 import com.amaze.filemanager.ui.views.CircleGradientDrawable;
 import com.amaze.filemanager.utils.AnimUtils;
 import com.amaze.filemanager.utils.OpenMode;
@@ -212,20 +209,20 @@ public class CompressedExplorerAdapter extends RecyclerView.Adapter<CompressedIt
             if (rowItem.directory) {
                 holder.genericIcon.setImageDrawable(folder);
                 gradientDrawable.setColor(compressedExplorerFragment.iconskin);
-                if (!rowItem.name.isEmpty()) {
-                    final StringBuilder stringBuilder = new StringBuilder(rowItem.name);
-                    stringBuilder.deleteCharAt(rowItem.name.length() - 1);
+                if (!rowItem.path.isEmpty()) {
+                    final StringBuilder stringBuilder = new StringBuilder(rowItem.path);
+                    stringBuilder.deleteCharAt(rowItem.path.length() - 1);
 
                     try {
                         holder.txtTitle.setText(stringBuilder.substring(stringBuilder.lastIndexOf("/") + 1));
                     } catch (StringIndexOutOfBoundsException e) {
-                        holder.txtTitle.setText(rowItem.name.substring(0, rowItem.name.lastIndexOf("/")));
+                        holder.txtTitle.setText(rowItem.path.substring(0, rowItem.path.lastIndexOf("/")));
                     }
                 }
             } else {
                 if (compressedExplorerFragment.showSize)
                     holder.txtDesc.setText(Formatter.formatFileSize(context, rowItem.size));
-                holder.txtTitle.setText(rowItem.name.substring(rowItem.name.lastIndexOf("/") + 1));
+                holder.txtTitle.setText(rowItem.path.substring(rowItem.path.lastIndexOf("/") + 1));
                 if (compressedExplorerFragment.coloriseIcons) {
                     ColorUtils.colorizeIcons(context, rowItem.filetype, gradientDrawable,
                             compressedExplorerFragment.iconskin);
@@ -267,8 +264,8 @@ public class CompressedExplorerAdapter extends RecyclerView.Adapter<CompressedIt
                     toggleChecked(position, holder.checkImageView);
                 } else {
                     if (rowItem.directory) {
-                        final StringBuilder stringBuilder = new StringBuilder(rowItem.name);
-                        stringBuilder.deleteCharAt(rowItem.name.length() - 1);
+                        final StringBuilder stringBuilder = new StringBuilder(rowItem.path);
+                        stringBuilder.deleteCharAt(rowItem.path.length() - 1);
 
                         compressedExplorerFragment.changePath(stringBuilder.toString());
                     } else {
@@ -279,7 +276,7 @@ public class CompressedExplorerAdapter extends RecyclerView.Adapter<CompressedIt
 
                         HybridFileParcelable file = new HybridFileParcelable(archiveCacheDirPath
                                 + CompressedHelper.SEPARATOR
-                                + rowItem.name.replaceAll("\\\\", CompressedHelper.SEPARATOR));
+                                + rowItem.path.replaceAll("\\\\", CompressedHelper.SEPARATOR));
                         file.setMode(OpenMode.FILE);
                         // this file will be opened once service finishes up it's extraction
                         compressedExplorerFragment.files.add(file);
@@ -290,7 +287,7 @@ public class CompressedExplorerAdapter extends RecyclerView.Adapter<CompressedIt
                                 compressedExplorerFragment.getContext().getString(R.string.please_wait),
                                 Toast.LENGTH_SHORT).show();
                         decompressor.decompress(compressedExplorerFragment.getActivity().getExternalCacheDir().getPath(),
-                                new String[]{rowItem.name});
+                                new String[]{rowItem.path});
                     }
                 }
             }

--- a/app/src/main/java/com/amaze/filemanager/adapters/data/CompressedObjectParcelable.java
+++ b/app/src/main/java/com/amaze/filemanager/adapters/data/CompressedObjectParcelable.java
@@ -16,20 +16,20 @@ public class CompressedObjectParcelable implements Parcelable {
 
     public final boolean directory;
     public final int type;
-    public final String name;
+    public final String path;
     public final long date, size;
     public final int filetype;
     public final IconDataParcelable iconData;
 
-    public CompressedObjectParcelable(String name, long date, long size, boolean directory) {
+    public CompressedObjectParcelable(String path, long date, long size, boolean directory) {
         this.directory = directory;
         this.type = TYPE_NORMAL;
-        this.name = name;
+        this.path = path;
         this.date = date;
         this.size = size;
-        this.filetype = Icons.getTypeOfFile(name, directory);
+        this.filetype = Icons.getTypeOfFile(path, directory);
         this.iconData = new IconDataParcelable(IconDataParcelable.IMAGE_RES,
-                Icons.loadMimeIcon(name, directory));
+                Icons.loadMimeIcon(path, directory));
     }
 
     /**
@@ -38,7 +38,7 @@ public class CompressedObjectParcelable implements Parcelable {
     public CompressedObjectParcelable() {
         this.directory = true;
         this.type = TYPE_GOBACK;
-        this.name = null;
+        this.path = null;
         this.date = 0;
         this.size = 0;
         this.filetype = -1;
@@ -54,7 +54,7 @@ public class CompressedObjectParcelable implements Parcelable {
         p1.writeInt(type);
         if(type != TYPE_GOBACK) {
             p1.writeInt(directory? 1:0);
-            p1.writeString(name);
+            p1.writeString(path);
             p1.writeLong(size);
             p1.writeLong(date);
             p1.writeInt(filetype);
@@ -77,14 +77,14 @@ public class CompressedObjectParcelable implements Parcelable {
         type = im.readInt();
         if(type == TYPE_GOBACK) {
             directory = true;
-            name = null;
+            path = null;
             date = 0;
             size = 0;
             filetype = -1;
             iconData = null;
         } else {
             directory = im.readInt() == 1;
-            name = im.readString();
+            path = im.readString();
             size = im.readLong();
             date = im.readLong();
             filetype = im.readInt();
@@ -101,7 +101,7 @@ public class CompressedObjectParcelable implements Parcelable {
                 return -1;
             } else if (file2.directory && !(file1).directory) {
                 return 1;
-            } else return file1.name.compareToIgnoreCase(file2.name);
+            } else return file1.path.compareToIgnoreCase(file2.path);
         }
 
     }

--- a/app/src/main/java/com/amaze/filemanager/adapters/data/CompressedObjectParcelable.java
+++ b/app/src/main/java/com/amaze/filemanager/adapters/data/CompressedObjectParcelable.java
@@ -17,6 +17,7 @@ public class CompressedObjectParcelable implements Parcelable {
     public final boolean directory;
     public final int type;
     public final String path;
+    public final String name;
     public final long date, size;
     public final int filetype;
     public final IconDataParcelable iconData;
@@ -25,6 +26,7 @@ public class CompressedObjectParcelable implements Parcelable {
         this.directory = directory;
         this.type = TYPE_NORMAL;
         this.path = path;
+        this.name = getNameForPath(path);
         this.date = date;
         this.size = size;
         this.filetype = Icons.getTypeOfFile(path, directory);
@@ -39,6 +41,7 @@ public class CompressedObjectParcelable implements Parcelable {
         this.directory = true;
         this.type = TYPE_GOBACK;
         this.path = null;
+        this.name = null;
         this.date = 0;
         this.size = 0;
         this.filetype = -1;
@@ -55,6 +58,7 @@ public class CompressedObjectParcelable implements Parcelable {
         if(type != TYPE_GOBACK) {
             p1.writeInt(directory? 1:0);
             p1.writeString(path);
+            p1.writeString(name);
             p1.writeLong(size);
             p1.writeLong(date);
             p1.writeInt(filetype);
@@ -78,6 +82,7 @@ public class CompressedObjectParcelable implements Parcelable {
         if(type == TYPE_GOBACK) {
             directory = true;
             path = null;
+            name = null;
             date = 0;
             size = 0;
             filetype = -1;
@@ -85,6 +90,7 @@ public class CompressedObjectParcelable implements Parcelable {
         } else {
             directory = im.readInt() == 1;
             path = im.readString();
+            name = im.readString();
             size = im.readLong();
             date = im.readLong();
             filetype = im.readInt();
@@ -104,6 +110,19 @@ public class CompressedObjectParcelable implements Parcelable {
             } else return file1.path.compareToIgnoreCase(file2.path);
         }
 
+    }
+
+    private String getNameForPath(String path) {
+        if (path.isEmpty()) return "";
+
+        final StringBuilder stringBuilder = new StringBuilder(path);
+        stringBuilder.deleteCharAt(path.length() - 1);
+
+        try {
+            return stringBuilder.substring(stringBuilder.lastIndexOf("/") + 1);
+        } catch (StringIndexOutOfBoundsException e) {
+            return path.substring(0, path.lastIndexOf("/"));
+        }
     }
 
 }

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/compress/ZipHelperTask.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/compress/ZipHelperTask.java
@@ -87,9 +87,9 @@ public class ZipHelperTask extends CompressedHelperTask {
             ArrayList<String> strings = new ArrayList<>();
 
             for (CompressedObjectParcelable entry : wholelist) {
-                File file = new File(entry.name);
+                File file = new File(entry.path);
                 if (relativeDirectory == null || relativeDirectory.trim().length() == 0) {
-                    String y = entry.name;
+                    String y = entry.path;
                     if (y.startsWith("/"))
                         y = y.substring(1, y.length());
                     if (file.getParent() == null || file.getParent().length() == 0 || file.getParent().equals("/")) {
@@ -106,8 +106,8 @@ public class ZipHelperTask extends CompressedHelperTask {
                         }
                     }
                 } else {
-                    String y = entry.name;
-                    if (entry.name.startsWith("/"))
+                    String y = entry.path;
+                    if (entry.path.startsWith("/"))
                         y = y.substring(1, y.length());
 
                     if (file.getParent() != null && (file.getParent().equals(relativeDirectory) || file.getParent().equals("/" + relativeDirectory))) {

--- a/app/src/main/java/com/amaze/filemanager/fragments/CompressedExplorerFragment.java
+++ b/app/src/main/java/com/amaze/filemanager/fragments/CompressedExplorerFragment.java
@@ -318,7 +318,7 @@ public class CompressedExplorerFragment extends Fragment implements BottomBarBut
 
                     String[] dirs = new String[compressedExplorerAdapter.getCheckedItemPositions().size()];
                     for (int i = 0; i < dirs.length; i++) {
-                        dirs[i] = elements.get(compressedExplorerAdapter.getCheckedItemPositions().get(i)).name;
+                        dirs[i] = elements.get(compressedExplorerAdapter.getCheckedItemPositions().get(i)).path;
                     }
 
                     decompressor.decompress(compressedFile.getPath(), dirs);

--- a/app/src/test/java/com/amaze/filemanager/filesystem/compressed/B0rkenZipTest.java
+++ b/app/src/test/java/com/amaze/filemanager/filesystem/compressed/B0rkenZipTest.java
@@ -82,7 +82,7 @@ public class B0rkenZipTest {
         ZipHelperTask task = new ZipHelperTask(RuntimeEnvironment.application, zipfile1.getAbsolutePath(), null, false, (data) -> {});
         List<CompressedObjectParcelable> result = task.execute().get();
         assertEquals(1, result.size());
-        assertEquals("good.txt", result.get(0).name);
+        assertEquals("good.txt", result.get(0).path);
         assertEquals(RuntimeEnvironment.application.getString(R.string.multiple_invalid_archive_entries), ShadowToast.getTextOfLatestToast());
     }
 
@@ -91,7 +91,7 @@ public class B0rkenZipTest {
         ZipHelperTask task = new ZipHelperTask(RuntimeEnvironment.application, zipfile2.getAbsolutePath(), null, false, (data) -> {});
         List<CompressedObjectParcelable> result = task.execute().get();
         assertEquals(1, result.size());
-        assertEquals("good.txt", result.get(0).name);
+        assertEquals("good.txt", result.get(0).path);
         assertEquals(RuntimeEnvironment.application.getString(R.string.multiple_invalid_archive_entries), ShadowToast.getTextOfLatestToast());
     }
 }


### PR DESCRIPTION
* Small fixes to StringBuilder in CompressedExplorerAdapter
* Renamed `CompressedObjectParcelable.name` to path
* File name is now precalculated in `CompressedObjectParcelable`
* Reduced StringBuilder creation in `CompressedExplorerAdapter.onBindViewHolder()`