### PR TITLE
Tweaks to encrypt/decryptSshPathAsNecessary() (related to #1370)

### DIFF
--- a/app/src/androidTest/java/com/amaze/filemanager/ssh/SshClientUtilTest.java
+++ b/app/src/androidTest/java/com/amaze/filemanager/ssh/SshClientUtilTest.java
@@ -1,0 +1,62 @@
+package com.amaze.filemanager.ssh;
+
+import android.support.test.runner.AndroidJUnit4;
+
+import com.amaze.filemanager.filesystem.ssh.SshClientUtils;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(AndroidJUnit4.class)
+public class SshClientUtilTest {
+
+    @Test
+    public void testEncryptDecryptUriWithNoPassword(){
+        String uri = "ssh://testuser@127.0.0.1:22";
+        assertEquals(uri, SshClientUtils.encryptSshPathAsNecessary(uri));
+        assertEquals(uri, SshClientUtils.decryptSshPathAsNecessary(uri));
+    }
+
+    @Test
+    public void testEncryptDecryptPasswordWithMinusSign1(){
+        String uri = "ssh://testuser:abcd-efgh@127.0.0.1:22";
+        String result = SshClientUtils.encryptSshPathAsNecessary(uri);
+        assertTrue(result.contains("ssh://testuser:"));
+        assertTrue(result.contains("@127.0.0.1:22"));
+        String verify = SshClientUtils.decryptSshPathAsNecessary(result);
+        assertEquals(uri, verify);
+    }
+
+    @Test
+    public void testEncryptDecryptPasswordWithMinusSign2(){
+        String uri = "ssh://testuser:---------------@127.0.0.1:22";
+        String result = SshClientUtils.encryptSshPathAsNecessary(uri);
+        assertTrue(result.contains("ssh://testuser:"));
+        assertTrue(result.contains("@127.0.0.1:22"));
+        String verify = SshClientUtils.decryptSshPathAsNecessary(result);
+        assertEquals(uri, verify);
+    }
+
+    @Test
+    public void testEncryptDecryptPasswordWithMinusSign3(){
+        String uri = "ssh://testuser:--agdiuhdpost15@127.0.0.1:22";
+        String result = SshClientUtils.encryptSshPathAsNecessary(uri);
+        assertTrue(result.contains("ssh://testuser:"));
+        assertTrue(result.contains("@127.0.0.1:22"));
+        String verify = SshClientUtils.decryptSshPathAsNecessary(result);
+        assertEquals(uri, verify);
+    }
+
+    @Test
+    public void testEncryptDecryptPasswordWithMinusSign4(){
+        String uri = "ssh://testuser:t-h-i-s-i-s-p-a-s-s-w-o-r-d-@127.0.0.1:22";
+        String result = SshClientUtils.encryptSshPathAsNecessary(uri);
+        assertTrue(result.contains("ssh://testuser:"));
+        assertTrue(result.contains("@127.0.0.1:22"));
+        String verify = SshClientUtils.decryptSshPathAsNecessary(result);
+        assertEquals(uri, verify);
+    }
+}

--- a/app/src/main/java/com/amaze/filemanager/filesystem/ssh/SshClientUtils.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/ssh/SshClientUtils.java
@@ -156,9 +156,9 @@ public abstract class SshClientUtils
      * @return SSH URL with the password (if exists) encrypted
      */
     public static final String encryptSshPathAsNecessary(@NonNull String fullUri) {
-        String uriWithoutProtocol = fullUri.substring(SSH_URI_PREFIX.length(), fullUri.indexOf('@'));
+        String uriWithoutProtocol = fullUri.substring(SSH_URI_PREFIX.length(), fullUri.lastIndexOf('@'));
         try {
-            return (uriWithoutProtocol.indexOf(':') > 0) ?
+            return (uriWithoutProtocol.lastIndexOf(':') > 0) ?
                     SmbUtil.getSmbEncryptedPath(AppConfig.getInstance(), fullUri) :
                     fullUri;
         } catch(IOException | GeneralSecurityException e){
@@ -175,9 +175,9 @@ public abstract class SshClientUtils
      * @return SSH URL with the password (if exists) decrypted
      */
     public static final String decryptSshPathAsNecessary(@NonNull String fullUri) {
-        String uriWithoutProtocol = fullUri.substring(SSH_URI_PREFIX.length(), fullUri.indexOf('@'));
+        String uriWithoutProtocol = fullUri.substring(SSH_URI_PREFIX.length(), fullUri.lastIndexOf('@'));
         try {
-            return (uriWithoutProtocol.indexOf(':') > 0) ?
+            return (uriWithoutProtocol.lastIndexOf(':') > 0) ?
                     SmbUtil.getSmbDecryptedPath(AppConfig.getInstance(), fullUri) :
                     fullUri;
         } catch(IOException | GeneralSecurityException e){

--- a/app/src/test/java/com/amaze/filemanager/filesystem/ssh/SshConnectionPoolTest.java
+++ b/app/src/test/java/com/amaze/filemanager/filesystem/ssh/SshConnectionPoolTest.java
@@ -149,6 +149,46 @@ public class SshConnectionPoolTest {
         assertNull(SshConnectionPool.getInstance().getConnection("ssh://invaliduser:invalidpassword@127.0.0.1:22222"));
     }
 
+    @Test
+    public void testGetConnectionWithUrlHavingMinusSignInPassword1() throws IOException {
+        String validUsername = "test@example.com";
+        String validPassword = "abcd-efgh";
+        createSshServer(validUsername, validPassword);
+        saveSshConnectionSettings(validUsername, validPassword, null);
+        assertNotNull(SshConnectionPool.getInstance().getConnection("ssh://test@example.com:abcd-efgh@127.0.0.1:22222"));
+        assertNull(SshConnectionPool.getInstance().getConnection("ssh://invaliduser:invalidpassword@127.0.0.1:22222"));
+    }
+
+    @Test
+    public void testGetConnectionWithUrlHavingMinusSignInPassword2() throws IOException {
+        String validUsername = "test@example.com";
+        String validPassword = "---------------";
+        createSshServer(validUsername, validPassword);
+        saveSshConnectionSettings(validUsername, validPassword, null);
+        assertNotNull(SshConnectionPool.getInstance().getConnection("ssh://test@example.com:---------------@127.0.0.1:22222"));
+        assertNull(SshConnectionPool.getInstance().getConnection("ssh://invaliduser:invalidpassword@127.0.0.1:22222"));
+    }
+
+    @Test
+    public void testGetConnectionWithUrlHavingMinusSignInPassword3() throws IOException {
+        String validUsername = "test@example.com";
+        String validPassword = "--agdiuhdpost15";
+        createSshServer(validUsername, validPassword);
+        saveSshConnectionSettings(validUsername, validPassword, null);
+        assertNotNull(SshConnectionPool.getInstance().getConnection("ssh://test@example.com:--agdiuhdpost15@127.0.0.1:22222"));
+        assertNull(SshConnectionPool.getInstance().getConnection("ssh://invaliduser:invalidpassword@127.0.0.1:22222"));
+    }
+
+    @Test
+    public void testGetConnectionWithUrlHavingMinusSignInPassword4() throws IOException {
+        String validUsername = "test@example.com";
+        String validPassword = "t-h-i-s-i-s-p-a-s-s-w-o-r-d-";
+        createSshServer(validUsername, validPassword);
+        saveSshConnectionSettings(validUsername, validPassword, null);
+        assertNotNull(SshConnectionPool.getInstance().getConnection("ssh://test@example.com:t-h-i-s-i-s-p-a-s-s-w-o-r-d-@127.0.0.1:22222"));
+        assertNull(SshConnectionPool.getInstance().getConnection("ssh://invaliduser:invalidpassword@127.0.0.1:22222"));
+    }
+
     private void createSshServer(@NonNull String validUsername, @Nullable String validPassword) throws IOException {
         server = SshServer.setUpDefaultServer();
         server.setPublickeyAuthenticator(AcceptAllPublickeyAuthenticator.INSTANCE);
@@ -165,7 +205,6 @@ public class SshConnectionPoolTest {
         utilsHandler = new UtilsHandler(RuntimeEnvironment.application);
         utilsHandler.onCreate(utilsHandler.getWritableDatabase());
 
-        //FIXME: privateKeyContents created this way cannot be parsed back in PemToKeyPairTask
         String privateKeyContents = null;
         if(privateKey != null){
             StringWriter writer = new StringWriter();


### PR DESCRIPTION
To ensure SSH URI extract correctly by using `String.lastIndexOf()` for `:` and `@` tokens.

Test cases updated with passwords having minus (-) signs. Also added Espresso tests for `SshClientUtils.encryptSshPathAsNecessary()` and `SshClientUtils.decryptSshPathAsNecessary()`.

Actually test cases also passed without change to SshClientUtils, but just to be sure.

@VishalNehra you may run the Espresso `SshClientUtilTest` with your device to see if it's working correctly.