### PR TITLE
Prevent RootHelper.getFiles() returns duplicated entries

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/filesystem/HybridFileParcelable.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/HybridFileParcelable.java
@@ -128,4 +128,31 @@ public class HybridFileParcelable extends HybridFile implements Parcelable {
         dest.writeByte((byte) (isDirectory ? 1 : 0));
 
     }
+
+    @Override
+    public String toString() {
+        return new StringBuilder("HybridFileParcelable, path=[").append(path).append(']')
+                .append(", name=[").append(name).append(']')
+                .append(", size=[").append(size).append(']')
+                .append(", date=[").append(date).append(']')
+                .append(", permission=[").append(permission).append(']')
+                .toString();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if(obj == null || (!(obj instanceof HybridFileParcelable)))
+            return false;
+        return path.equals(((HybridFileParcelable)obj).path);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = path.hashCode();
+        result = 37 * result + name.hashCode();
+        result = 37 * result + (isDirectory ? 1 : 0);
+        result = 37 * result + (int)(size ^ size >>> 32);
+        result = 37 * result + (int)(date ^ date >>> 32);
+        return result;
+    }
 }

--- a/app/src/main/java/com/amaze/filemanager/filesystem/RootHelper.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/RootHelper.java
@@ -29,8 +29,6 @@ import com.amaze.filemanager.utils.files.FileUtils;
 
 import java.io.File;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.List;
 
 import eu.chainfire.libsuperuser.Shell;
@@ -46,10 +44,10 @@ public class RootHelper {
      * @return a list of results. Null only if the command passed is a blocking call or no output is
      * there for the command passed
      */
-    public static Collection<String> runShellCommand(String cmd) throws ShellNotRunningException {
+    public static List<String> runShellCommand(String cmd) throws ShellNotRunningException {
         if (MainActivity.shellInteractive == null || !MainActivity.shellInteractive.isRunning())
             throw new ShellNotRunningException();
-        final ArrayList<String> result = new ArrayList<>();
+        final List<String> result = new ArrayList<>();
 
         // callback being called on a background handler thread
         MainActivity.shellInteractive.addCommand(cmd, 0, (commandCode, exitCode, output) -> result.addAll(output));
@@ -219,7 +217,7 @@ public class RootHelper {
         String name = f.getName();
         String p = f.getParent();
         if (p != null && p.length() > 0) {
-            Collection<String> ls = runShellCommand("ls -l " + p);
+            List<String> ls = runShellCommand("ls -l " + p);
             for (String s : ls) {
                 if (contains(s.split(" "), name)) {
                     try {
@@ -284,7 +282,7 @@ public class RootHelper {
             try {
                 // we're rooted and we're trying to load file with superuser
                 // we're at the root directories, superuser is required!
-                Collection<String> ls;
+                List<String> ls;
                 String cpath = getCommandLineString(path);
                 //ls = Shell.SU.run("ls -l " + cpath);
                 ls = runShellCommand("ls -l " + (showHidden ? "-a " : "") + "\"" + cpath + "\"");

--- a/app/src/main/java/com/amaze/filemanager/filesystem/RootHelper.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/RootHelper.java
@@ -280,7 +280,6 @@ public class RootHelper {
     public static void getFiles(String path, boolean root, boolean showHidden,
                                 GetModeCallBack getModeCallBack, OnFileFound fileCallback) {
         OpenMode mode = OpenMode.FILE;
-        ArrayList<HybridFileParcelable> files = new ArrayList<>();
         if (root && !path.startsWith("/storage") && !path.startsWith("/sdcard")) {
             try {
                 // we're rooted and we're trying to load file with superuser
@@ -301,7 +300,6 @@ public class RootHelper {
                                     boolean isdirectory = isDirectory(array.getLink(), root, 0);
                                     array.setDirectory(isdirectory);
                                 } else array.setDirectory(isDirectory(array));
-                                files.add(array);
                                 fileCallback.onFileFound(array);
                             }
                         }
@@ -315,7 +313,7 @@ public class RootHelper {
             }
         }
 
-        if (FileUtils.canListFiles(new File(path))) {
+        else if (FileUtils.canListFiles(new File(path))) {
             // we're taking a chance to load files using basic java filesystem
             getFilesList(path, showHidden, fileCallback);
             mode = OpenMode.FILE;

--- a/app/src/main/java/com/amaze/filemanager/utils/RootUtils.java
+++ b/app/src/main/java/com/amaze/filemanager/utils/RootUtils.java
@@ -8,6 +8,7 @@ import com.amaze.filemanager.exceptions.ShellNotRunningException;
 import com.amaze.filemanager.filesystem.RootHelper;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.regex.Pattern;
 
 public class RootUtils {
@@ -37,7 +38,7 @@ public class RootUtils {
      */
     private static String mountFileSystemRW(String path) throws ShellNotRunningException {
         String command = "mount";
-        ArrayList<String> output = RootHelper.runShellCommand(command);
+        Collection<String> output = RootHelper.runShellCommand(command);
         String mountPoint = "", types = null;
         for (String line : output) {
             String[] words = line.split(" ");
@@ -61,7 +62,7 @@ public class RootUtils {
             } else if (types.contains("ro")) {
                 // read-only file system, remount as rw
                 String mountCommand = "mount -o rw,remount " + mountPoint;
-                ArrayList<String> mountOutput = RootHelper.runShellCommand(mountCommand);
+                Collection<String> mountOutput = RootHelper.runShellCommand(mountCommand);
 
                 if (mountOutput.size() != 0) {
                     // command failed, and we got a reason echo'ed
@@ -134,7 +135,7 @@ public class RootUtils {
      * Method requires busybox
      */
     private static int getFilePermissions(String path) throws ShellNotRunningException {
-        String line = RootHelper.runShellCommand("stat -c  %a \"" + path + "\"").get(0);
+        String line = RootHelper.runShellCommand("stat -c  %a \"" + path + "\"").iterator().next();
 
         return Integer.valueOf(line);
     }
@@ -146,7 +147,7 @@ public class RootUtils {
      */
     public static boolean delete(String path) throws ShellNotRunningException {
         String mountPoint = mountFileSystemRW(path);
-        ArrayList<String> result = RootHelper.runShellCommand("rm -rf \"" + path + "\"");
+        Collection<String> result = RootHelper.runShellCommand("rm -rf \"" + path + "\"");
 
         if (mountPoint != null) {
             // we mounted the filesystem as rw, let's mount it back to ro
@@ -181,7 +182,7 @@ public class RootUtils {
      */
     public static boolean rename(String oldPath, String newPath) throws ShellNotRunningException {
         String mountPoint = mountFileSystemRW(oldPath);
-        ArrayList<String> output = RootHelper.runShellCommand("mv \"" + oldPath + "\" \"" + newPath + "\"");
+        Collection<String> output = RootHelper.runShellCommand("mv \"" + oldPath + "\" \"" + newPath + "\"");
 
         if (mountPoint != null) {
             // we mounted the filesystem as rw, let's mount it back to ro

--- a/app/src/main/java/com/amaze/filemanager/utils/RootUtils.java
+++ b/app/src/main/java/com/amaze/filemanager/utils/RootUtils.java
@@ -7,8 +7,7 @@ package com.amaze.filemanager.utils;
 import com.amaze.filemanager.exceptions.ShellNotRunningException;
 import com.amaze.filemanager.filesystem.RootHelper;
 
-import java.util.ArrayList;
-import java.util.Collection;
+import java.util.List;
 import java.util.regex.Pattern;
 
 public class RootUtils {
@@ -38,7 +37,7 @@ public class RootUtils {
      */
     private static String mountFileSystemRW(String path) throws ShellNotRunningException {
         String command = "mount";
-        Collection<String> output = RootHelper.runShellCommand(command);
+        List<String> output = RootHelper.runShellCommand(command);
         String mountPoint = "", types = null;
         for (String line : output) {
             String[] words = line.split(" ");
@@ -62,7 +61,7 @@ public class RootUtils {
             } else if (types.contains("ro")) {
                 // read-only file system, remount as rw
                 String mountCommand = "mount -o rw,remount " + mountPoint;
-                Collection<String> mountOutput = RootHelper.runShellCommand(mountCommand);
+                List<String> mountOutput = RootHelper.runShellCommand(mountCommand);
 
                 if (mountOutput.size() != 0) {
                     // command failed, and we got a reason echo'ed
@@ -147,7 +146,7 @@ public class RootUtils {
      */
     public static boolean delete(String path) throws ShellNotRunningException {
         String mountPoint = mountFileSystemRW(path);
-        Collection<String> result = RootHelper.runShellCommand("rm -rf \"" + path + "\"");
+        List<String> result = RootHelper.runShellCommand("rm -rf \"" + path + "\"");
 
         if (mountPoint != null) {
             // we mounted the filesystem as rw, let's mount it back to ro
@@ -182,7 +181,7 @@ public class RootUtils {
      */
     public static boolean rename(String oldPath, String newPath) throws ShellNotRunningException {
         String mountPoint = mountFileSystemRW(oldPath);
-        Collection<String> output = RootHelper.runShellCommand("mv \"" + oldPath + "\" \"" + newPath + "\"");
+        List<String> output = RootHelper.runShellCommand("mv \"" + oldPath + "\" \"" + newPath + "\"");
 
         if (mountPoint != null) {
             // we mounted the filesystem as rw, let's mount it back to ro
@@ -206,7 +205,7 @@ public class RootUtils {
 
     /**
      * This converts from a set of booleans to OCTAL permissions notations.
-     * For use with {@link RootUtils.CHMOD_COMMAND}
+     * For use with {@link RootUtils#CHMOD_COMMAND}
      * (true, false, false,  true, true, false,  false, false, true) => 0461
      */
     public static int permissionsToOctalString(boolean ur, boolean uw, boolean ux,

--- a/app/src/test/java/com/amaze/filemanager/filesystem/RootHelperTest.java
+++ b/app/src/test/java/com/amaze/filemanager/filesystem/RootHelperTest.java
@@ -1,0 +1,80 @@
+package com.amaze.filemanager.filesystem;
+
+import android.os.Environment;
+
+import com.amaze.filemanager.BuildConfig;
+import com.amaze.filemanager.activities.MainActivity;
+import com.amaze.filemanager.test.ShadowShellInteractive;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+import org.robolectric.shadows.multidex.ShadowMultiDex;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+
+import eu.chainfire.libsuperuser.Shell;
+
+import static org.junit.Assert.fail;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(constants = BuildConfig.class, shadows = {ShadowMultiDex.class, ShadowShellInteractive.class})
+public class RootHelperTest {
+
+    private static final File sysroot = new File(Environment.getExternalStorageDirectory(), "sysroot");
+
+    private static final List<String> expected = Arrays.asList("srv", "var", "tmp", "bin", "lib", "usr", "1.txt", "2.txt", "3.txt", "4.txt", "symlink1.txt", "symlink2.txt", "symlink3.txt", "symlink4.txt");
+
+    @Before
+    public void setUp() throws IOException {
+        sysroot.mkdir();
+        for(String s: new String[]{"srv","var","tmp"}){
+            File subdir = new File(sysroot, s);
+            subdir.mkdir();
+            Files.createSymbolicLink(Paths.get(new File(Environment.getExternalStorageDirectory(), s).getAbsolutePath()), Paths.get(subdir.getAbsolutePath()));
+        }
+        for(String s: new String[]{"bin","lib","usr"}){
+            new File(Environment.getExternalStorageDirectory(), s).mkdir();
+        }
+        for(int i=1;i<=4;i++){
+            File f = new File(Environment.getExternalStorageDirectory(), i+".txt");
+            FileOutputStream out = new FileOutputStream(f);
+            out.write(i);
+            out.close();
+            Files.createSymbolicLink(Paths.get(new File(Environment.getExternalStorageDirectory(), "symlink"+i+".txt").getAbsolutePath()), Paths.get(f.getAbsolutePath()));
+        }
+    }
+
+    @Test
+    public void testNonRoot() throws InterruptedException {
+        runVerify(false);
+    }
+
+    @Test
+    public void testRoot() throws InterruptedException, SecurityException, IllegalArgumentException {
+        MainActivity.shellInteractive = new Shell.Builder().setShell("/bin/false").open();
+        runVerify(true);
+    }
+
+    private void runVerify(boolean root) throws InterruptedException {
+        List<String> result = new ArrayList<>();
+        CountDownLatch waiter = new CountDownLatch(expected.size());
+        RootHelper.getFiles(Environment.getExternalStorageDirectory().getAbsolutePath(), root, true, mode -> {}, file -> {
+            if(result.contains(file.getName()))
+                fail(file.getName() + " already listed");
+            result.add(file.getName());
+            waiter.countDown();
+        });
+        waiter.await();
+    }
+}

--- a/app/src/test/java/com/amaze/filemanager/test/ShadowShellInteractive.java
+++ b/app/src/test/java/com/amaze/filemanager/test/ShadowShellInteractive.java
@@ -1,0 +1,54 @@
+package com.amaze.filemanager.test;
+
+import com.amaze.filemanager.filesystem.RootHelper;
+import com.amaze.filemanager.utils.OnFileFound;
+
+import org.robolectric.annotation.Implementation;
+import org.robolectric.annotation.Implements;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
+
+import eu.chainfire.libsuperuser.Shell;
+
+/**
+ * Shadow of {@link Shell.Interactive}, for {@link com.amaze.filemanager.filesystem.RootHelperTest}.
+ *
+ * Only tested for {@link com.amaze.filemanager.filesystem.RootHelper#getFiles(String, boolean, boolean, RootHelper.GetModeCallBack, OnFileFound)},
+ * so only guarantees work for that.
+ *
+ * <strong>DO NOT RUN THIS ON NON-UNIX OS. YOU SHOULD KNOW THIS ALREADY.</strong>
+ */
+@Implements(Shell.Interactive.class)
+public class ShadowShellInteractive {
+
+    @Implementation
+    public boolean isRunning(){
+        return true;
+    }
+
+    @Implementation
+    public boolean waitForIdle(){
+        return true;
+    }
+
+    @Implementation
+    public void addCommand(String command, int code, Shell.OnCommandResultListener onCommandResultListener) throws IOException, InterruptedException {
+        ProcessBuilder pb = new ProcessBuilder("/bin/sh", "-c", command);
+        pb.environment().put("LC_ALL", "en_US.utf8");
+        pb.environment().put("LANG", "en_US.utf8");
+        pb.environment().put("TIME_STYLE", "long-iso");
+        Process process = pb.start();
+        int exitValue = process.waitFor();
+        BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream(), "utf-8"));
+        List<String> result = new ArrayList<>();
+        String line;
+        while((line = reader.readLine()) != null){
+            result.add(line);
+        }
+        onCommandResultListener.onCommandResult(exitValue, code, result);
+    }
+}


### PR DESCRIPTION
Fixes #1097.

The fix was actually at the last 2 commits(7b53f05 and 2d33d99), while the first 2 were done while investigating the problem; I think they'd be useful anyway, so I kept them in the PR.

Robolectric test included, with Shadow emulating SuperSU's `Shell.Interactive`. I coded on an Ubuntu, so YMMV if you're running on a Mac.