### PR TITLE
Chinese and Japanese translation of "Internal storage"

### DIFF
--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -574,5 +574,6 @@ Wi-Fiに接続する必要があります。</li><li>\\n
   <string name="cannot_overwrite">ファイルを上書きすることはできません。</string>
   <string name="filename">ファイル名</string>
   <string name="ssh_key_invalid_passphrase">無効な秘密鍵のパスフレーズ。</string>
-  <!-- end of plurals -->
+    <string name="storage">内部ストレージ</string>
+    <!-- end of plurals -->
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -593,4 +593,5 @@
   <string name="transfer_rate">传输速率</string>
   <string name="unknown">未知</string>
   <string name="multiple_invalid_archive_entries">无法解压一些文件，压缩文件已损坏或为恶意文件</string>
+    <string name="storage">内部储存空间</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -602,4 +602,5 @@
   <string name="transfer_rate">傳輸速率</string>
   <string name="time_remaining">剩餘時間</string>
   <string name="grant_apkinstall_permission">程式需要安裝程式的權限以繼續。</string>
+    <string name="storage">內部儲存空間</string>
 </resources>


### PR DESCRIPTION
For #1398.

For Japanese it's easy - that I just translated as-is; but for Chinese (both traditional and simplified) I'm translating the phrase so it means "internal storage space" instead of "internal storage device". See if this meaning fits.