### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Amaze File Manager [<img src="https://travis-ci.org/TeamAmaze/AmazeFileManager.svg?branch=master">](https://travis-ci.org/TeamAmaze/AmazeFileManager)    
+# Amaze File Manager [<img src="https://travis-ci.org/TeamAmaze/AmazeFileManager.svg?branch=master">](https://travis-ci.org/TeamAmaze/AmazeFileManager)    [<img src="https://app.bitrise.io/app/8384894428897c1c/status.svg?token=OACcUU0M-udD27xEpLLsag&branch=master">](https://app.bitrise.io/app/8384894428897c1c#/builds)
   
 [<img alt="Get it on Google Play" height="80" src="https://play.google.com/intl/en_us/badges/images/generic/en_badge_web_generic.png">](https://play.google.com/store/apps/details?id=com.amaze.filemanager)
 [<img alt="Get it on F-Droid" height="80" src="https://f-droid.org/badge/get-it-on.png">](https://f-droid.org/app/com.amaze.filemanager)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Amaze File Manager [<img src="https://travis-ci.org/TeamAmaze/AmazeFileManager.svg?branch=master">](https://travis-ci.org/TeamAmaze/AmazeFileManager)    [<img src="https://app.bitrise.io/app/8384894428897c1c/status.svg?token=OACcUU0M-udD27xEpLLsag&branch=master">](https://app.bitrise.io/app/8384894428897c1c#/builds)
+# Amaze File Manager [<img src="https://travis-ci.org/TeamAmaze/AmazeFileManager.svg?branch=master">](https://travis-ci.org/TeamAmaze/AmazeFileManager)    [<img src="https://app.bitrise.io/app/8384894428897c1c/status.svg?token=OACcUU0M-udD27xEpLLsag&branch=master">](https://app.bitrise.io/app/8384894428897c1c#/builds "Check out release branch builds logs and download compiled build apks")
   
 [<img alt="Get it on Google Play" height="80" src="https://play.google.com/intl/en_us/badges/images/generic/en_badge_web_generic.png">](https://play.google.com/store/apps/details?id=com.amaze.filemanager)
 [<img alt="Get it on F-Droid" height="80" src="https://f-droid.org/badge/get-it-on.png">](https://f-droid.org/app/com.amaze.filemanager)


### PR DESCRIPTION
Add Bitrise CI/CD workflow. Now you can also install apk file directly from the builds.
Will be deploying only release branches due to my account limit of Bitrise deploy to 200 builds per month.
Non bitrise users can find apk link in the build logs. Bitrise users will be able to see Apps&artifacts tab in build page.
This all sucks, so will try to find a way to directly link apk instead of browsing through logs. 