### PR TITLE
 Fixed missing padding constant for API < 22 in ColorPickerDialog's xml 

### DIFF
--- a/app/src/main/res/layout-v22/dialog_colorpicker.xml
+++ b/app/src/main/res/layout-v22/dialog_colorpicker.xml
@@ -3,8 +3,8 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
-    android:paddingLeft="@dimen/dialogPreferredPadding"
-    android:paddingRight="@dimen/dialogPreferredPadding">
+    android:paddingEnd="?android:dialogPreferredPadding"
+    android:paddingStart="?android:dialogPreferredPadding">
 
     <ScrollView
         android:layout_width="match_parent"

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -504,5 +504,7 @@
   <string name="items">Éléments</string>
   <string name="byte_singular">octet</string>
   <string name="bytes">Octets</string>
+    <string name="preselectedconfigs_title">Couleurs préconfigurées</string>
+  <string name="selectcolorconfig">Configurer les couleurs</string>
   <!-- end of plurals -->
 </resources>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -50,4 +50,6 @@
     <dimen name="md_content_textsize">16sp</dimen>
     <dimen name="md_content_padding_top">8dp</dimen>
 
+    <dimen name="dialogPreferredPadding">24dp</dimen>
+
 </resources>


### PR DESCRIPTION
* Fixed missing padding constant for API < 22 in ColorPickerDialog's xml 
* French translations 

Fixes #1395