### PR TITLE
Explicitly specify package name in FTP server related intents

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/asynchronous/services/ftp/FtpService.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/services/ftp/FtpService.java
@@ -213,9 +213,9 @@ public class FtpService extends Service implements Runnable {
         try {
             server = serverFactory.createServer();
             server.start();
-            sendBroadcast(new Intent(FtpService.ACTION_STARTED).putExtra(TAG_STARTED_BY_TILE, isStartedByTile));
+            sendBroadcast(new Intent(FtpService.ACTION_STARTED).setPackage(getPackageName()).putExtra(TAG_STARTED_BY_TILE, isStartedByTile));
         } catch (Exception e) {
-            sendBroadcast(new Intent(FtpService.ACTION_FAILEDTOSTART));
+            sendBroadcast(new Intent(FtpService.ACTION_FAILEDTOSTART).setPackage(getPackageName()));
         }
     }
 
@@ -234,7 +234,7 @@ public class FtpService extends Service implements Runnable {
         }
         if (server != null) {
             server.stop();
-            sendBroadcast(new Intent(FtpService.ACTION_STOPPED));
+            sendBroadcast(new Intent(FtpService.ACTION_STOPPED).setPackage(getPackageName()));
         }
     }
 

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/services/ftp/FtpTileService.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/services/ftp/FtpTileService.java
@@ -49,12 +49,12 @@ public class FtpTileService extends TileService {
         super.onClick();
 
         if (getQsTile().getState() == Tile.STATE_ACTIVE) {
-            getApplicationContext().sendBroadcast(new Intent(FtpService.ACTION_STOP_FTPSERVER));
+            getApplicationContext().sendBroadcast(new Intent(FtpService.ACTION_STOP_FTPSERVER).setPackage(getPackageName()));
         } else {
             if (FtpService.isConnectedToWifi(getApplicationContext())
                     || FtpService.isConnectedToLocalNetwork(getApplicationContext())
                     || FtpService.isEnabledWifiHotspot(getApplicationContext())) {
-                Intent i = new Intent(FtpService.ACTION_START_FTPSERVER);
+                Intent i = new Intent(FtpService.ACTION_START_FTPSERVER).setPackage(getPackageName());
                 i.putExtra(FtpService.TAG_STARTED_BY_TILE, true);
                 getApplicationContext().sendBroadcast(i);
             } else {

--- a/app/src/main/java/com/amaze/filemanager/fragments/FtpServerFragment.java
+++ b/app/src/main/java/com/amaze/filemanager/fragments/FtpServerFragment.java
@@ -104,6 +104,7 @@ public class FtpServerFragment extends Fragment {
         View startDividerView = rootView.findViewById(R.id.divider_ftp_start);
         View statusDividerView = rootView.findViewById(R.id.divider_ftp_status);
         ftpPasswordVisibleButton = rootView.findViewById(R.id.ftp_password_visible);
+        accentColor = mainActivity.getAccent();
 
         updateSpans();
         updateStatus();
@@ -150,7 +151,6 @@ public class FtpServerFragment extends Fragment {
 
         int skin_color = mainActivity.getCurrentColorPreference().primaryFirstTab;
         int skinTwoColor = mainActivity.getCurrentColorPreference().primarySecondTab;
-        accentColor = mainActivity.getAccent();
 
         mainActivity.updateViews(new ColorDrawable(MainActivity.currentTab==1 ?
                 skinTwoColor : skin_color));
@@ -417,6 +417,7 @@ public class FtpServerFragment extends Fragment {
             ftpBtn.setText(getResources().getString(R.string.start_ftp).toUpperCase());
 
         } else {
+            accentColor = mainActivity.getAccent();
             url.setText(spannedStatusUrl);
             statusText.setText(spannedStatusConnected);
             ftpBtn.setEnabled(true);

--- a/app/src/main/java/com/amaze/filemanager/fragments/FtpServerFragment.java
+++ b/app/src/main/java/com/amaze/filemanager/fragments/FtpServerFragment.java
@@ -367,14 +367,14 @@ public class FtpServerFragment extends Fragment {
      * Sends a broadcast to start ftp server
      */
     private void startServer() {
-        getContext().sendBroadcast(new Intent(FtpService.ACTION_START_FTPSERVER));
+        getContext().sendBroadcast(new Intent(FtpService.ACTION_START_FTPSERVER).setPackage(getContext().getPackageName()));
     }
 
     /**
      * Sends a broadcast to stop ftp server
      */
     private void stopServer() {
-        getContext().sendBroadcast(new Intent(FtpService.ACTION_STOP_FTPSERVER));
+        getContext().sendBroadcast(new Intent(FtpService.ACTION_STOP_FTPSERVER).setPackage(getContext().getPackageName()));
     }
 
     @Override

--- a/app/src/main/java/com/amaze/filemanager/ui/notifications/FtpNotification.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/notifications/FtpNotification.java
@@ -76,7 +76,7 @@ public class FtpNotification extends BroadcastReceiver {
         if (!noStopButton && Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
             int stopIcon = android.R.drawable.ic_menu_close_clear_cancel;
             CharSequence stopText = context.getString(R.string.ftp_notif_stop_server);
-            Intent stopIntent = new Intent(FtpService.ACTION_STOP_FTPSERVER);
+            Intent stopIntent = new Intent(FtpService.ACTION_STOP_FTPSERVER).setPackage(context.getPackageName());
             PendingIntent stopPendingIntent = PendingIntent.getBroadcast(context, 0,
                     stopIntent, PendingIntent.FLAG_ONE_SHOT);
 


### PR DESCRIPTION
This fixes FTP server cannot start on Android 8 due to implicit intent broadcasts are prohibited from Android 8 (as mentioned [here](https://github.com/TeamAmaze/AmazeFileManager/issues/1337#issuecomment-423780217)).

Additionally, also fixed a display glitch that status message at `FtpServerFragment` is not in the activity's accent colour when FTP server is started from the tile (which is then becomes plain black).

Tested with non-rooted LG Nexus 5x running stock firmware 8.1.0.

Partially related to #1337, but may not be fixing it.