### PR TITLE
Fix renaming files on OTG storage.

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/filesystem/EditableFileAbstraction.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/EditableFileAbstraction.java
@@ -68,7 +68,7 @@ public class EditableFileAbstraction {
                 path = Utils.sanitizeInput(path);
                 this.hybridFileParcelable = new HybridFileParcelable(path);
 
-                String tempN = hybridFileParcelable.getName(context);
+                String tempN = hybridFileParcelable.getName();
                 if(tempN == null) tempN = uri.getLastPathSegment();
                 this.name = tempN;
 

--- a/app/src/main/java/com/amaze/filemanager/filesystem/HybridFile.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/HybridFile.java
@@ -335,7 +335,7 @@ public class HybridFile {
             case ROOT:
                 return new File(path).getName();
             case OTG:
-                return OTGUtil.getDocumentFile(path, context, false).getName();
+                return OTGUtil.getName(path);
             default:
                 StringBuilder builder = new StringBuilder(path);
                 name = builder.substring(builder.lastIndexOf("/")+1, builder.length());

--- a/app/src/main/java/com/amaze/filemanager/filesystem/HybridFile.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/HybridFile.java
@@ -300,9 +300,6 @@ public class HybridFile {
         return path;
     }
 
-    /**
-     * @deprecated use {@link #getName(Context)}
-     */
     public String getName() {
         String name = null;
         switch (mode) {
@@ -315,30 +312,11 @@ public class HybridFile {
                 return new File(path).getName();
             case ROOT:
                 return new File(path).getName();
+            case OTG:
+                return new File(path).getName();
             default:
                 StringBuilder builder = new StringBuilder(path);
                 name = builder.substring(builder.lastIndexOf("/") + 1, builder.length());
-        }
-        return name;
-    }
-
-    public String getName(Context context) {
-        String name = null;
-        switch (mode){
-            case SMB:
-                SmbFile smbFile=getSmbFile();
-                if(smbFile!=null)
-                    return smbFile.getName();
-                break;
-            case FILE:
-                return new File(path).getName();
-            case ROOT:
-                return new File(path).getName();
-            case OTG:
-                return OTGUtil.getName(path);
-            default:
-                StringBuilder builder = new StringBuilder(path);
-                name = builder.substring(builder.lastIndexOf("/")+1, builder.length());
         }
         return name;
     }
@@ -419,7 +397,7 @@ public class HybridFile {
             default:
                 StringBuilder builder = new StringBuilder(path);
                 StringBuilder parentPathBuilder = new StringBuilder(builder.substring(0,
-                        builder.length()-(getName(context).length()+1)));
+                        builder.length()-(getName().length()+1)));
                 return parentPathBuilder.toString();
         }
         return parentPath;
@@ -1175,7 +1153,7 @@ public class HybridFile {
             if (!exists(context)) {
                 DocumentFile parentDirectory = OTGUtil.getDocumentFile(getParent(context), context, false);
                 if (parentDirectory.isDirectory()) {
-                    parentDirectory.createDirectory(getName(context));
+                    parentDirectory.createDirectory(getName());
                 }
             }
         } else if (isDropBoxFile()) {
@@ -1245,7 +1223,7 @@ public class HybridFile {
      * If no extension is found then whole file name is returned
      */
     public String getNameString(Context context) {
-        String fileName = getName(context);
+        String fileName = getName();
 
         int extensionStartIndex = fileName.lastIndexOf(".");
         return fileName.substring(0, extensionStartIndex == -1 ? fileName.length() : extensionStartIndex);

--- a/app/src/main/java/com/amaze/filemanager/filesystem/Operations.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/Operations.java
@@ -88,7 +88,7 @@ public class Operations {
             protected Void doInBackground(Void... params) {
                 // checking whether filename is valid or a recursive call possible
                 if (MainActivityHelper.isNewDirectoryRecursive(file) ||
-                        !Operations.isFileNameValid(file.getName(context))) {
+                        !Operations.isFileNameValid(file.getName())) {
                     errorCallBack.invalidName(file);
                     return null;
                 }
@@ -119,7 +119,7 @@ public class Operations {
 
                     DocumentFile parentDirectory = OTGUtil.getDocumentFile(file.getParent(), context, false);
                     if (parentDirectory.isDirectory()) {
-                        parentDirectory.createDirectory(file.getName(context));
+                        parentDirectory.createDirectory(file.getName());
                         errorCallBack.done(file, true);
                     } else errorCallBack.done(file, false);
                     return null;
@@ -173,7 +173,7 @@ public class Operations {
                             if (file.exists()) errorCallBack.exists(file);
                             try {
 
-                                RootUtils.mkDir(file.getParent(context), file.getName(context));
+                                RootUtils.mkDir(file.getParent(context), file.getName());
                             } catch (ShellNotRunningException e) {
                                 e.printStackTrace();
                             }
@@ -202,7 +202,7 @@ public class Operations {
             @Override
             protected Void doInBackground(Void... params) {
                 // check whether filename is valid or not
-                if (!Operations.isFileNameValid(file.getName(context))) {
+                if (!Operations.isFileNameValid(file.getName())) {
                     errorCallBack.invalidName(file);
                     return null;
                 }
@@ -292,8 +292,8 @@ public class Operations {
 
                     DocumentFile parentDirectory = OTGUtil.getDocumentFile(file.getParent(), context, false);
                     if (parentDirectory.isDirectory()) {
-                        parentDirectory.createFile(file.getName(context).substring(file.getName().lastIndexOf(".")),
-                                file.getName(context));
+                        parentDirectory.createFile(file.getName().substring(file.getName().lastIndexOf(".")),
+                                file.getName());
                         errorCallBack.done(file, true);
                     } else errorCallBack.done(file, false);
                     return null;
@@ -341,7 +341,7 @@ public class Operations {
             protected Void doInBackground(Void... params) {
                 // check whether file names for new file are valid or recursion occurs
                 if (MainActivityHelper.isNewDirectoryRecursive(newFile) ||
-                        !Operations.isFileNameValid(newFile.getName(context))) {
+                        !Operations.isFileNameValid(newFile.getName())) {
                     errorCallBack.invalidName(newFile);
                     return null;
                 }
@@ -430,7 +430,7 @@ public class Operations {
                         errorCallBack.exists(newFile);
                         return null;
                     }
-                    errorCallBack.done(newFile, oldDocumentFile.renameTo(newFile.getName(context)));
+                    errorCallBack.done(newFile, oldDocumentFile.renameTo(newFile.getName()));
                     return null;
                 } else {
 

--- a/app/src/main/java/com/amaze/filemanager/utils/OTGUtil.java
+++ b/app/src/main/java/com/amaze/filemanager/utils/OTGUtil.java
@@ -109,6 +109,23 @@ public class OTGUtil {
     }
 
     /**
+     * Returns the filename from a file in OTG.
+     */
+    public static String getName(String path) {
+        String name = null;
+
+        String[] parts = path.split("/");
+        for (String part : parts) {
+            if (path.equals("otg:/")) break;
+            if (part.equals("otg:") || part.equals("")) continue;
+
+            name = part;
+        }
+
+        return name;
+    }
+
+    /**
      * Checks if there is at least one USB device connected with class MASS STORAGE.
      */
     public static boolean isMassStorageDeviceConnected(@NonNull final Context context) {

--- a/app/src/main/java/com/amaze/filemanager/utils/OTGUtil.java
+++ b/app/src/main/java/com/amaze/filemanager/utils/OTGUtil.java
@@ -109,23 +109,6 @@ public class OTGUtil {
     }
 
     /**
-     * Returns the filename from a file in OTG.
-     */
-    public static String getName(String path) {
-        String name = null;
-
-        String[] parts = path.split("/");
-        for (String part : parts) {
-            if (path.equals("otg:/")) break;
-            if (part.equals("otg:") || part.equals("")) continue;
-
-            name = part;
-        }
-
-        return name;
-    }
-
-    /**
      * Checks if there is at least one USB device connected with class MASS STORAGE.
      */
     public static boolean isMassStorageDeviceConnected(@NonNull final Context context) {


### PR DESCRIPTION
Operations.rename would check if the new file name is valid. OTGUtil.getDocumentFile
would result in a null pointer becuase the new file doesn't exist in the document tree.
In the case of OTG, HybridFile.getName now calls the new OTGUtil.getName method.

Fixes #1419 