### PR TITLE
Trigger media store scan after rename operation is successful

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/filesystem/Operations.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/Operations.java
@@ -15,6 +15,7 @@ import com.amaze.filemanager.utils.OTGUtil;
 import com.amaze.filemanager.utils.OpenMode;
 import com.amaze.filemanager.utils.RootUtils;
 import com.amaze.filemanager.utils.cloud.CloudUtil;
+import com.amaze.filemanager.utils.files.FileUtils;
 import com.cloudrail.si.interfaces.CloudStorage;
 
 import net.schmizz.sshj.sftp.SFTPClient;
@@ -476,6 +477,13 @@ public class Operations {
                     }
                 }
                 return null;
+            }
+
+            @Override
+            protected void onPostExecute(Void aVoid) {
+                super.onPostExecute(aVoid);
+                if (newFile != null)
+                    FileUtils.scanFile(newFile, context);
             }
         }.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
 

--- a/app/src/main/java/com/amaze/filemanager/utils/files/FileUtils.java
+++ b/app/src/main/java/com/amaze/filemanager/utils/files/FileUtils.java
@@ -54,6 +54,7 @@ import com.amaze.filemanager.activities.DatabaseViewerActivity;
 import com.amaze.filemanager.activities.MainActivity;
 import com.amaze.filemanager.activities.superclasses.PermissionsActivity;
 import com.amaze.filemanager.activities.superclasses.ThemedActivity;
+import com.amaze.filemanager.filesystem.FileUtil;
 import com.amaze.filemanager.filesystem.HybridFile;
 import com.amaze.filemanager.filesystem.HybridFileParcelable;
 import com.amaze.filemanager.filesystem.Operations;
@@ -218,7 +219,7 @@ public class FileUtils {
      * @param file File to scan
      * @param c {@link Context}
      */
-    public static void scanFile(@NonNull File file, @NonNull Context c){
+    public static void scanFile(@NonNull File file, @NonNull Context c) {
         scanFile(Uri.fromFile(file), c);
     }
 
@@ -228,10 +229,29 @@ public class FileUtils {
      * @param uri File's {@link Uri}
      * @param c {@link Context}
      */
-    public static void scanFile(@NonNull Uri uri, @NonNull Context c){
+    private static void scanFile(@NonNull Uri uri, @NonNull Context c) {
         Intent mediaScanIntent = new Intent(Intent.ACTION_MEDIA_SCANNER_SCAN_FILE, uri);
         c.sendBroadcast(mediaScanIntent);
     }
+
+    /**
+     * Triggers media store for the file path
+     * @param hybridFile the file which was changed (directory not supported)
+     * @param context
+     */
+    public static void scanFile(@NonNull HybridFile hybridFile, Context context) {
+
+        if((hybridFile.isLocal() || hybridFile.isOtgFile()) && hybridFile.exists(context)) {
+
+            DocumentFile documentFile = FileUtil.getDocumentFile(hybridFile.getFile(), false, context);
+            //If FileUtil.getDocumentFile() returns null, fall back to DocumentFile.fromFile()
+            if(documentFile == null)
+                documentFile = DocumentFile.fromFile(hybridFile.getFile());
+
+            FileUtils.scanFile(documentFile.getUri(), context);
+        }
+    }
+
 
     public static void crossfade(View buttons,final View pathbar) {
         // Set the content view to 0% opacity but visible, so that it is visible

--- a/app/src/main/java/com/amaze/filemanager/utils/files/GenericCopyUtil.java
+++ b/app/src/main/java/com/amaze/filemanager/utils/files/GenericCopyUtil.java
@@ -307,16 +307,8 @@ public class GenericCopyUtil {
 
             //If target file is copied onto the device and copy was successful, trigger media store
             //rescan
-
-            if((mTargetFile.isLocal() || mTargetFile.isOtgFile()) && mTargetFile.exists(mContext)) {
-
-                DocumentFile documentFile = FileUtil.getDocumentFile(mTargetFile.getFile(), false, mContext);
-                //If FileUtil.getDocumentFile() returns null, fall back to DocumentFile.fromFile()
-                if(documentFile == null)
-                    documentFile = DocumentFile.fromFile(mTargetFile.getFile());
-
-                FileUtils.scanFile(documentFile.getUri(), mContext);
-            }
+            if (mTargetFile != null)
+                FileUtils.scanFile(mTargetFile, mContext);
         }
     }
 


### PR DESCRIPTION
Should fix #1475 
Although on my device, media scanner was automatically fired anyways. I think it's largely dependent on filesystem too. But this fix is there just to be sure we're up to date.