### PR TITLE
HybridFile: Add back calling HybridFile(mode, path) constructor

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/filesystem/HybridFile.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/HybridFile.java
@@ -74,7 +74,7 @@ public class HybridFile {
     }
 
     public HybridFile(OpenMode mode, String path, String name, boolean isDirectory) {
-        this.mode = mode;
+        this(mode, path);
         if (path.startsWith("smb://") || isSmb()) {
             if (!isDirectory) this.path += name;
             else if (!name.endsWith("/")) this.path += name + "/";


### PR DESCRIPTION
To make sure `mode` and `path` are populated. Fixes #1488