### PR TITLE
Verification for support of "new format" OpenSSH keys

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -72,6 +72,7 @@ ext {
     supportLibVersion = '27.1.1'
     robolectricVersion = '3.8'
     glideVersion = '4.8.0'
+    sshjVersion = '0.26.0'
 }
 
 dependencies {
@@ -150,7 +151,7 @@ dependencies {
     implementation 'com.github.npgall:concurrent-trees:2.6.1'//Concurrent tries
 
     //SFTP
-    implementation 'com.hierynomus:sshj:0.23.0'
+    implementation "com.hierynomus:sshj:$sshjVersion"
 
     implementation 'com.madgag.spongycastle:bcpkix-jdk15on:1.58.0.0'
     implementation 'com.madgag.spongycastle:prov:1.58.0.0'

--- a/app/src/androidTest/java/com/amaze/filemanager/asynchronous/asynctasks/ssh/PemToKeyPairTaskTest2.java
+++ b/app/src/androidTest/java/com/amaze/filemanager/asynchronous/asynctasks/ssh/PemToKeyPairTaskTest2.java
@@ -1,0 +1,78 @@
+package com.amaze.filemanager.asynchronous.asynctasks.ssh;
+
+import android.support.test.runner.AndroidJUnit4;
+
+import net.schmizz.sshj.userauth.password.PasswordFinder;
+import net.schmizz.sshj.userauth.password.Resource;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.lang.reflect.Field;
+import java.util.concurrent.CountDownLatch;
+
+import static org.junit.Assert.assertNotNull;
+
+@RunWith(AndroidJUnit4.class)
+public class PemToKeyPairTaskTest2 {
+
+    //public key for authorized_keys: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGxJHFewxU9tJn9hUq9e2C/+ELFw83NpmJ5NLFOzU7O3 test-openssh-key
+    private static final String unencryptedOpenSshKey = "-----BEGIN OPENSSH PRIVATE KEY-----\n" +
+            "b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW\n" +
+            "QyNTUxOQAAACBsSRxXsMVPbSZ/YVKvXtgv/hCxcPNzaZieTSxTs1OztwAAAJhX2WUxV9ll\n" +
+            "MQAAAAtzc2gtZWQyNTUxOQAAACBsSRxXsMVPbSZ/YVKvXtgv/hCxcPNzaZieTSxTs1Oztw\n" +
+            "AAAECjSjwwMXPzbZWq/EBoA4HA9Lr7B1/Tw78K+k1zqAJwA2xJHFewxU9tJn9hUq9e2C/+\n" +
+            "ELFw83NpmJ5NLFOzU7O3AAAADmFpcndhdmVAaHN2MDEwAQIDBAUGBw==\n" +
+            "-----END OPENSSH PRIVATE KEY-----";
+
+    //Passphrase = 12345678
+    //public key for authorized_keys: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHio1/33U0XoewL1qGLmTzxyVNeYP5b0Tunv/SQrQi92 test-openssh-key
+    private static final String encryptedOpenSshKey = "-----BEGIN OPENSSH PRIVATE KEY-----\n" +
+            "b3BlbnNzaC1rZXktdjEAAAAACmFlczI1Ni1jdHIAAAAGYmNyeXB0AAAAGAAAABCwlfECA9\n" +
+            "+EGLwKVApTmomnAAAAZAAAAAEAAAAzAAAAC3NzaC1lZDI1NTE5AAAAIHio1/33U0XoewL1\n" +
+            "qGLmTzxyVNeYP5b0Tunv/SQrQi92AAAAoD2dysYInLaJgXIv6k/xFv7OblU9vWkCwcYnDW\n" +
+            "8Zj5+ke8QL2/r7EUBEvY1H02GenlEH1Ufct8ce7/eAWwd7aWukaSQXlKW9IBt5YrxW8+P/\n" +
+            "wrHcd/Z92eQ0E7NV6b6LnghGYlyCjpSBW+mxa0AAYPD21c95d/HvJF6zxQl/IKCCLdOrr/\n" +
+            "ilMCSIGQEdg71hA3MMZsRbUvazsnZTZXD9PLI=\n" +
+            "-----END OPENSSH PRIVATE KEY-----";
+
+    @Test
+    public void testUnencryptedKeyToKeyPair() throws InterruptedException {
+        CountDownLatch waiter = new CountDownLatch(1);
+        PemToKeyPairTask task = new PemToKeyPairTask(unencryptedOpenSshKey, result -> {
+            assertNotNull(result);
+            assertNotNull(result.getPublic());
+            assertNotNull(result.getPrivate());
+            waiter.countDown();
+        });
+        task.execute();
+        waiter.await();
+    }
+
+    @Test
+    public void testEncryptedKeyToKeyPair() throws InterruptedException, NoSuchFieldException, IllegalAccessException {
+        CountDownLatch waiter = new CountDownLatch(1);
+        PemToKeyPairTask task = new PemToKeyPairTask(encryptedOpenSshKey, result -> {
+            assertNotNull(result);
+            assertNotNull(result.getPublic());
+            assertNotNull(result.getPrivate());
+            waiter.countDown();
+        });
+        Field field = PemToKeyPairTask.class.getDeclaredField("passwordFinder");
+        field.setAccessible(true);
+        field.set(task, new PasswordFinder() {
+            @Override
+            public char[] reqPassword(Resource<?> resource) {
+                return "12345678".toCharArray();
+            }
+
+            @Override
+            public boolean shouldRetry(Resource<?> resource) {
+                return false;
+            }
+        });
+        task.execute();
+        waiter.await();
+
+    }
+}

--- a/app/src/test/java/com/amaze/filemanager/filesystem/ssh/CreateFileOnSshdTest.java
+++ b/app/src/test/java/com/amaze/filemanager/filesystem/ssh/CreateFileOnSshdTest.java
@@ -33,11 +33,13 @@ public class CreateFileOnSshdTest extends AbstractSftpServerTest {
 
     @Test
     public void testCreateFileNormal() throws Exception {
+        tearDown();
         createSshServer(new VirtualFileSystemFactory(Paths.get(Environment.getExternalStorageDirectory().getAbsolutePath())));
     }
 
     @Test
     public void testCreateFilePermissionDenied() throws Exception{
+        tearDown();
         createSshServer(new VirtualFileSystemFactory(){
             @Override
             public FileSystem createFileSystem(Session session) throws IOException {


### PR DESCRIPTION
For verification of #1485.

 * Upgrade sshj to 0.26.0
 * Made sshj version number a variable in build.gradle
 * Added Espresso tests for parsing "new format" OpenSSH keys
 * Fix `CreateFileOnSshdTest`

The keys were generated after reading [this](https://blog.g3rt.nl/upgrade-your-ssh-keys.html), using

`ssh-keygen -o -a 100 -t ed25519`

Please read `PemToKeyPairTaskTest2` for the actual contents of the public and private keys.



