### PR TITLE
super huge folder

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/LoadFilesListTask.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/LoadFilesListTask.java
@@ -29,8 +29,10 @@ import android.text.format.Formatter;
 
 import com.amaze.filemanager.R;
 import com.amaze.filemanager.adapters.data.LayoutElementParcelable;
+import com.amaze.filemanager.database.FolderHandler;
 import com.amaze.filemanager.database.SortHandler;
 import com.amaze.filemanager.database.UtilsHandler;
+import com.amaze.filemanager.database.models.Folder;
 import com.amaze.filemanager.exceptions.CloudPluginException;
 import com.amaze.filemanager.filesystem.HybridFile;
 import com.amaze.filemanager.filesystem.HybridFileParcelable;
@@ -68,6 +70,7 @@ public class LoadFilesListTask extends AsyncTask<Void, Void, Pair<OpenMode, Arra
     private boolean showHiddenFiles, showThumbs;
     private DataUtils dataUtils = DataUtils.getInstance();
     private OnAsyncTaskFinished<Pair<OpenMode, ArrayList<LayoutElementParcelable>>> listener;
+    private FolderHandler folderHandler ;
 
     public LoadFilesListTask(Context c, String path, MainFragment ma, OpenMode openmode,
                              boolean showThumbs, boolean showHiddenFiles,
@@ -79,6 +82,7 @@ public class LoadFilesListTask extends AsyncTask<Void, Void, Pair<OpenMode, Arra
         this.showThumbs = showThumbs;
         this.showHiddenFiles = showHiddenFiles;
         this.listener = l;
+        folderHandler = new FolderHandler(c);
     }
 
     @Override
@@ -220,12 +224,19 @@ public class LoadFilesListTask extends AsyncTask<Void, Void, Pair<OpenMode, Arra
     }
 
     private LayoutElementParcelable createListParcelables(HybridFileParcelable baseFile) {
-        if (!dataUtils.isFileHidden(baseFile.getPath())) {
+        String path = baseFile.getPath();
+        if (!dataUtils.isFileHidden(path)) {
             String size = "";
             long longSize= 0;
 
             if (baseFile.isDirectory()) {
                 ma.folder_count++;
+                Folder oldFolder = folderHandler.findEntry(path);
+                if (oldFolder != null) {
+                    longSize = oldFolder.size;
+                    size = Formatter.formatFileSize(c, longSize);
+                }
+
             } else {
                 if (baseFile.getSize() != -1) {
                     try {

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/LoadFolderSpaceDataTask.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/LoadFolderSpaceDataTask.java
@@ -53,7 +53,7 @@ public class LoadFolderSpaceDataTask extends AsyncTask<Void, Long, Pair<String, 
 
     @Override
     protected Pair<String, List<PieEntry>> doInBackground(Void... params) {
-        long[] dataArray = FileUtils.getSpaces(file, context, this::publishProgress);
+        Long[] dataArray = FileUtils.getSpaces(file, context, this::publishProgress);
 
         if (dataArray[0] != -1 && dataArray[0] != 0) {
             long totalSpace = dataArray[0];
@@ -72,7 +72,7 @@ public class LoadFolderSpaceDataTask extends AsyncTask<Void, Long, Pair<String, 
             long totalSpace = dataArray[0];
 
             List<PieEntry> entries = createEntriesFromArray(
-                    new long[]{dataArray[0], dataArray[1], dataArray[2]},
+                    new Long[]{dataArray[0], dataArray[1], dataArray[2]},
                     true);
 
             updateChart(Formatter.formatFileSize(context, totalSpace), entries);
@@ -95,7 +95,7 @@ public class LoadFolderSpaceDataTask extends AsyncTask<Void, Long, Pair<String, 
         chart.invalidate();
     }
 
-    private List<PieEntry> createEntriesFromArray(long[] dataArray, boolean loading) {
+    private List<PieEntry> createEntriesFromArray(Long[] dataArray, boolean loading) {
         long usedByFolder = dataArray[2],
                 usedByOther = dataArray[0] - dataArray[1] - dataArray[2],
                 freeSpace = dataArray[1];

--- a/app/src/main/java/com/amaze/filemanager/database/FolderHandler.java
+++ b/app/src/main/java/com/amaze/filemanager/database/FolderHandler.java
@@ -1,0 +1,109 @@
+package com.amaze.filemanager.database;
+
+import android.content.ContentValues;
+import android.content.Context;
+import android.database.Cursor;
+import android.database.sqlite.SQLiteDatabase;
+import android.database.sqlite.SQLiteOpenHelper;
+import android.support.annotation.Nullable;
+import android.text.TextUtils;
+
+import com.amaze.filemanager.database.models.Folder;
+
+/**
+ * Created by llrraa on 10/28/2018. To store folder size.
+ */
+
+public class FolderHandler extends SQLiteOpenHelper {
+    protected static final String DATABASE_NAME = "folders.db";
+    protected static final String TABLE_FOLDER = "folders1";
+
+    public static final String COLUMN_FOLDER_PATH = "path";
+    public static final String COLUMN_FOLDER_SIZE = "size";
+    public static final String COLUMN_FOLDER_TIME = "time";
+
+    public FolderHandler(Context context) {
+        super(context, DATABASE_NAME, null, TabHandler.DATABASE_VERSION);
+    }
+
+    @Override
+    public void onCreate(SQLiteDatabase db) {
+        String CREATE_TABLE_SORT = "CREATE TABLE IF NOT EXISTS " + TABLE_FOLDER + "("
+                + COLUMN_FOLDER_PATH
+                + " TEXT PRIMARY KEY,"
+                + COLUMN_FOLDER_SIZE + " INTEGER," + COLUMN_FOLDER_TIME + " INTEGER" + ")";
+         db.execSQL(CREATE_TABLE_SORT);
+    }
+
+    @Override
+    public void onUpgrade(SQLiteDatabase db, int oldVersion, int newVersion) {
+        db.execSQL("drop table if exists " + TABLE_FOLDER);
+        onCreate(db);
+    }
+
+    @Override
+    public void onDowngrade(SQLiteDatabase db, int oldVersion, int newVersion) {
+        onUpgrade(db, oldVersion, newVersion);
+    }
+    public void addEntry(Folder folder) {
+        if (TextUtils.isEmpty(folder.path)) {
+            return;
+        }
+        ContentValues contentValues = new ContentValues();
+        contentValues.put(COLUMN_FOLDER_PATH, folder.path);
+        contentValues.put(COLUMN_FOLDER_SIZE, folder.size);
+        contentValues.put(COLUMN_FOLDER_TIME, folder.time);
+
+        SQLiteDatabase sqLiteDatabase = getWritableDatabase();
+        sqLiteDatabase.insert(TABLE_FOLDER, null, contentValues);
+    }
+
+
+    public void updateEntry(Folder oldFolder, Folder newFolder) {
+        if (TextUtils.isEmpty(oldFolder.path) || TextUtils.isEmpty(newFolder.path)) {
+            return;
+        }
+
+        SQLiteDatabase sqLiteDatabase = getWritableDatabase();
+        ContentValues contentValues = new ContentValues();
+        contentValues.put(COLUMN_FOLDER_PATH, newFolder.path);
+        contentValues.put(COLUMN_FOLDER_SIZE, newFolder.size);
+        contentValues.put(COLUMN_FOLDER_TIME, newFolder.time);
+
+        sqLiteDatabase.update(TABLE_FOLDER, contentValues, COLUMN_FOLDER_PATH + " = ?",
+                new String[]{oldFolder.path});
+    }
+
+
+    public void updateEntry(Folder newFolder) {
+        Folder oldFolder = findEntry(newFolder.path);
+        if (oldFolder == null) {
+            addEntry(newFolder);
+        } else {
+            updateEntry(oldFolder, newFolder);
+        }
+
+    }
+
+        @Nullable
+    public Folder findEntry(String path) {
+        if (TextUtils.isEmpty(path)) {
+            return null;
+        }
+
+        String query = "Select * FROM " + TABLE_FOLDER + " WHERE " + COLUMN_FOLDER_PATH
+                + "= \"" + path + "\"";
+        SQLiteDatabase sqLiteDatabase = getReadableDatabase();
+        Cursor cursor = sqLiteDatabase.rawQuery(query, null);
+        Folder folder;
+        if (cursor.moveToFirst()) {
+            folder = new Folder(cursor.getString(0), cursor.getLong(1),  cursor.getLong(2));
+            cursor.close();
+        } else {
+            folder = null;
+        }
+        return folder;
+    }
+
+
+}

--- a/app/src/main/java/com/amaze/filemanager/database/models/Folder.java
+++ b/app/src/main/java/com/amaze/filemanager/database/models/Folder.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2018 Emmanuel Messulam <emmanuelbendavid@gmail.com>
+ * Copyright (C) 2014 Vishal Nehra <vishalmeham2@gmail.com>
+ *
+ * This file is part of Amaze File Manager.
+ *
+ * Amaze File Manager is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.amaze.filemanager.database.models;
+
+/**
+ * Created by llrraa on 10/28/2018.
+ */
+public class Folder {
+    public final String path;
+    public final long size;
+    public final long time;
+
+
+    public Folder(String path, long size, long time) {
+        this.path = path;
+        this.size = size;
+        this.time = time;
+    }
+
+}

--- a/app/src/main/java/com/amaze/filemanager/filesystem/HybridFile.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/HybridFile.java
@@ -11,6 +11,7 @@ import android.util.Log;
 
 import com.amaze.filemanager.adapters.data.LayoutElementParcelable;
 import com.amaze.filemanager.database.CloudHandler;
+import com.amaze.filemanager.database.FolderHandler;
 import com.amaze.filemanager.exceptions.CloudPluginException;
 import com.amaze.filemanager.exceptions.ShellNotRunningException;
 import com.amaze.filemanager.filesystem.ssh.Statvfs;
@@ -19,6 +20,7 @@ import com.amaze.filemanager.fragments.preference_fragments.PreferencesConstants
 import com.amaze.filemanager.filesystem.ssh.SFtpClientTemplate;
 import com.amaze.filemanager.filesystem.ssh.SshClientTemplate;
 import com.amaze.filemanager.filesystem.ssh.SshClientUtils;
+import com.amaze.filemanager.utils.OnProgressUpdate;
 import com.amaze.filemanager.utils.application.AppConfig;
 
 import com.amaze.filemanager.utils.DataUtils;
@@ -79,15 +81,15 @@ public class HybridFile {
             if (!isDirectory) this.path += name;
             else if (!name.endsWith("/")) this.path += name + "/";
             else this.path += name;
-        } else if(path.startsWith("ssh://") || isSftp()) {
+		} else if(path.startsWith("ssh://") || isSftp()) {
             this.path += "/" + name;
         } else if (isRoot() && path.equals("/")) {
             // root of filesystem, don't concat another '/'
             this.path += name;
         } else {
             this.path += "/" + name;
-        }
-    }
+        }    
+	}
 
     public void generateMode(Context context) {
         if (path.startsWith("smb://")) {
@@ -598,6 +600,51 @@ public class HybridFile {
                 break;
             case FILE:
                 size = FileUtils.folderSize(new File(path), null);
+                break;
+            case ROOT:
+                HybridFileParcelable baseFile=generateBaseFileFromParent();
+                if(baseFile!=null) size = baseFile.getSize();
+                break;
+            case OTG:
+                size = FileUtils.otgFolderSize(path, context);
+                break;
+            case DROPBOX:
+            case BOX:
+            case GDRIVE:
+            case ONEDRIVE:
+                size = FileUtils.folderSizeCloud(mode,
+                        dataUtils.getAccount(mode).getMetadata(CloudUtil.stripPath(mode, path)));
+                break;
+            default:
+                return 0l;
+        }
+        return size;
+    }
+
+
+    public long folderSize(Context context,  final OnProgressUpdate<Long[]> updateState, Long[] spaces) {    //llrraa
+
+        long size = 0l;
+
+        switch (mode){
+            case SFTP:
+                return SshClientUtils.execute(new SFtpClientTemplate(path) {
+                    @Override
+                    public Long execute(SFTPClient client) throws IOException {
+                        return client.size(SshClientUtils.extractRemotePathFrom(path));
+                    }
+                });
+            case SMB:
+                try {
+                    size = FileUtils.folderSize(new SmbFile(path));
+                } catch (MalformedURLException e) {
+                    size = 0l;
+                    e.printStackTrace();
+                }
+                break;
+            case FILE:
+                FolderHandler folderHandler = new FolderHandler(context);
+                size = FileUtils.folderSize(new File(path), updateState, spaces, folderHandler);
                 break;
             case ROOT:
                 HybridFileParcelable baseFile=generateBaseFileFromParent();

--- a/app/src/main/java/com/amaze/filemanager/utils/files/FileListSorter.java
+++ b/app/src/main/java/com/amaze/filemanager/utils/files/FileListSorter.java
@@ -92,7 +92,7 @@ public class FileListSorter implements Comparator<LayoutElementParcelable> {
         } else if (sort == 2) {
 
             // sort by size
-            if (!file1.isDirectory && !file2.isDirectory) {
+            if ((!file1.isDirectory && !file2.isDirectory)||(file1.isDirectory && file2.isDirectory)) {
 
                 return asc * Long.valueOf(file1.longSize).compareTo(file2.longSize);
             } else {


### PR DESCRIPTION
To deal with super huge folder which contains tons of sub-folders and files, I make the following changes:
1. Add folder database to store the size and last sizing time of the folder.
2. When properties menu of a folder is clicked, if the last sizing time is lessing than 3 days, folderSize will directly read the size from the database. Or else,  folderSize will size the folder and save the size in database.
3. When LoadFilesListTask works, it will check if the size of the folder is in database or not. If yes, it will load the size.
4. If sorted by size, folder will also do.
This may not be needed by everyone, so it will be better if someone make super huge folder as a setting, so we can use it when we need it.