### PR TITLE
SCP/SFTP dialog PEM file select intent fix for RESULT_OK code return

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/ui/dialogs/SftpConnectDialog.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/dialogs/SftpConnectDialog.java
@@ -142,10 +142,10 @@ public class SftpConnectDialog extends DialogFragment {
         //If MaterialDialog.Builder can be upgraded we may use their file selection dialog too
         selectPemBTN.setOnClickListener(v -> {
         Intent intent = new Intent()
-                .setType("*/*")
+                .setType("text/plain")
                 .setAction(Intent.ACTION_GET_CONTENT);
 
-        startActivityForResult(intent, SELECT_PEM_INTENT);
+        startActivityForResult(Intent.createChooser(intent, getString(R.string.select_pem_file)), SELECT_PEM_INTENT);
         });
 
         //Define action for buttons

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -515,4 +515,5 @@
     <string name="no_name">Файл должен иметь имя</string>
     <string name="add_item">Добавить элемент</string>
     <string name="addshortcut_not_supported_by_launcher">Создание ярлыков не поддерживается Вашим лаунчером.</string>
+    <string name="select_pem_file">Выберите PEM файл</string>
 </resources>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -503,5 +503,6 @@
     <string name="item">Елемент</string>
     <string name="items">Елементи</string>
     <string name="bytes">Байт</string>
+    <string name="select_pem_file">Оберіть PEM файл</string>
     <!-- end of plurals -->
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -643,5 +643,6 @@
     <string name="multiple_invalid_archive_entries">Some files in the archive cannot be extracted; archive may be damaged or came from malicious source.</string>
     <string name="saf_otg_explanation">You\'ll now go to Android\'s filesystem for security reasons. Please select the USB device from the list on the left.</string>
     <string name="donation_thanks">Thank you for the donation, this keeps us motivated! (:</string>
+    <string name="select_pem_file">Select PEM file</string>
 </resources>
 


### PR DESCRIPTION
"SSH key select" intent always return -1 (RESULT_CANCELED) after file selection. Therefore onActivityResult code is not executed (SftpConnectDialog.java, line 270):
`if(SELECT_PEM_INTENT == requestCode && Activity.RESULT_OK == resultCode)`

Fix: Wrapped to chooser intent.