### PR TITLE
Add android.permission.FOREGROUND_SERVICE to AndroidManifest.xml

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -31,6 +31,7 @@
     <uses-permission android:name="com.amaze.cloud.permission.ACCESS_PROVIDER" />
     <uses-permission android:name="android.permission.USE_FINGERPRINT" />
     <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 
     <uses-feature
         android:name="android.hardware.touchscreen"


### PR DESCRIPTION
Fixes #1537 
Fixes #1458 

[Reference to the solution](https://stackoverflow.com/a/52382711), and from the answer on SO [Android had stated such permission is required](https://developer.android.com/about/versions/pie/android-9.0-migration?hl=en#tya) when foreground services is used. 