### PR TITLE
Debug version name is now "Amaze Debug" and other fixes

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 28
-    buildToolsVersion '27.0.3'
 
     dexOptions {
         jumboMode = true

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -84,7 +84,7 @@ android {
 }
 
 ext {
-    supportLibVersion = '27.1.1'
+    supportLibVersion = '28.0.0'
     robolectricVersion = '3.8'
     glideVersion = '4.8.0'
     sshjVersion = '0.26.0'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -38,6 +38,7 @@ android {
 
     buildTypes {
         debug {
+            applicationIdSuffix ".debug"
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard.cfg'
             testProguardFile 'tests-proguard.cfg'

--- a/app/src/debug/res/values/strings.xml
+++ b/app/src/debug/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="appbar_name" translatable="false">Amaze Debug</string>
+</resources>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -45,7 +45,7 @@
         android:icon="@mipmap/ic_launcher"
         android:roundIcon="@mipmap/ic_launcher_round"
         tools:replace="android:label"
-        android:label="Amaze"
+        android:label="@string/appbar_name"
         android:banner="@drawable/about_header">
 
         <activity

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -115,5 +115,7 @@
 
     <!-- Warning error for InputTextLayout -->
     <color name="warningColor">#ffe082</color>
+    <!-- Error error for InputTextLayout -->
+    <color name="error_color_material">#F4511E</color>
 
 </resources>


### PR DESCRIPTION
* Copied private color from MaterailDialog lib
* Update support lib to 28.0.0
* Removed unnecessary buildToolsVersion declaration in build.gradle 
* Debug version's name is now "Amaze Debug" and package is suffixed with ".debug"