### PR TITLE
Removed PREFERENCE_SHOW_HIDDENFILES check for showing hidden files list

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/activities/MainActivity.java
+++ b/app/src/main/java/com/amaze/filemanager/activities/MainActivity.java
@@ -859,7 +859,7 @@ public class MainActivity extends PermissionsActivity implements SmbConnectionLi
             menu.findItem(R.id.history).setVisible(true);
             menu.findItem(R.id.sethome).setVisible(true);
             menu.findItem(R.id.sort).setVisible(true);
-            if (getBoolean(PREFERENCE_SHOW_HIDDENFILES)) menu.findItem(R.id.hiddenitems).setVisible(true);
+            menu.findItem(R.id.hiddenitems).setVisible(true);
             menu.findItem(R.id.view).setVisible(true);
             menu.findItem(R.id.extract).setVisible(false);
             invalidatePasteButton(menu.findItem(R.id.paste));


### PR DESCRIPTION
Removed PREFERENCE_SHOW_HIDDENFILES check for showing hidden files list, because the user would be confused as to how to show the file just hidden (view selecting and clicking hide).