### PR TITLE
Remove existing path history entry before inserting new ones

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/database/UtilsHandler.java
+++ b/app/src/main/java/com/amaze/filemanager/database/UtilsHandler.java
@@ -523,6 +523,9 @@ public class UtilsHandler extends SQLiteOpenHelper {
         ContentValues contentValues = new ContentValues();
         contentValues.put(COLUMN_PATH, path);
 
+        if(Operation.HISTORY.equals(operation))
+            sqLiteDatabase.delete(getTableForOperation(operation), "path = ?", new String[]{path});
+
         sqLiteDatabase.insert(getTableForOperation(operation), null, contentValues);
     }
 


### PR DESCRIPTION
Fixes #1468.

So `history.path` was the culprit causing the exception, we just remove the previous entry before inserting the new record.