### PR TITLE
Prevents crash when extracting Rar files on devices using Android 9(Pie)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -107,7 +107,6 @@ dependencies {
     testImplementation "org.robolectric:robolectric:$robolectricVersion"//tests android interaction
     testImplementation "org.robolectric:shadows-multidex:$robolectricVersion"//tests android interaction
     testImplementation "org.robolectric:shadows-httpclient:$robolectricVersion"//tests android interaction
-    testImplementation "commons-logging:commons-logging:1.2" //required by junrar. Damn.
 
     testImplementation "org.apache.sshd:sshd-core:1.7.0"
 
@@ -146,6 +145,8 @@ dependencies {
     implementation group: 'org.slf4j', name: 'slf4j-api', version: '1.7.25'
     // https://mvnrepository.com/artifact/org.slf4j/slf4j-simple
     implementation group: 'org.slf4j', name: 'slf4j-android', version: '1.7.25'
+    // https://mvnrepository.com/artifact/org.slf4j/jcl-over-slf4j
+    implementation group: 'org.slf4j', name: 'jcl-over-slf4j', version: '1.7.25'
 
     //implementation files('libs/ftplet-api-1.1.0-SNAPSHOT.jar')
     // https://mvnrepository.com/artifact/org.apache.ftpserver/ftplet-api


### PR DESCRIPTION

Fixes [#1600](https://github.com/TeamAmaze/AmazeFileManager/issues/1600)

Fixes the crash that is caused on devices running Android 9. Starting Android 6.0 `Apache HTTP client` was deprecated. So to use it those lines had to be added the `android manifest` file.

Tested on:
Nokia 3.1 running Android 9 and works.