### PR TITLE
Prevent crash when going directly from inside a zip file to the apk manager (via side panel)

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/fragments/MainFragment.java
+++ b/app/src/main/java/com/amaze/filemanager/fragments/MainFragment.java
@@ -171,6 +171,7 @@ public class MainFragment extends android.support.v4.app.Fragment implements Bot
     private DataUtils dataUtils;
     private boolean isEncryptOpen = false;       // do we have to open a file when service is begin destroyed
     private HybridFileParcelable encryptBaseFile;            // the cached base file which we're to open, delete it later
+    private int ordinalValue;
 
     /**
      *  a list of encrypted base files which are supposed to be deleted
@@ -206,6 +207,9 @@ public class MainFragment extends android.support.v4.app.Fragment implements Bot
         no = getArguments().getInt("no", 1);
         home = getArguments().getString("home");
         CURRENT_PATH = getArguments().getString("lastpath");
+        ordinalValue = getArguments().getInt("openmode", -1);
+
+        if (ordinalValue != -1) openMode = OpenMode.getOpenMode(ordinalValue);
 
         IS_LIST = dataUtils.getListOrGridForPath(CURRENT_PATH, DataUtils.LIST) == DataUtils.LIST;
 

--- a/app/src/main/java/com/amaze/filemanager/fragments/TabFragment.java
+++ b/app/src/main/java/com/amaze/filemanager/fragments/TabFragment.java
@@ -352,6 +352,7 @@ public class TabFragment extends Fragment
 
         if (path != null && path.length() != 0) {
             b.putString("lastpath", path);
+            b.putInt("openmode", OpenMode.UNKNOWN.ordinal());
         } else {
             b.putString("lastpath", tab.getOriginalPath(savepaths, mainActivity.getPrefs()));
         }


### PR DESCRIPTION

Fixes [#1620](https://github.com/TeamAmaze/AmazeFileManager/issues/1620)

Fix crash when going directly from inside a zip file to the apk manager (via side panel) and then trying to go back.
The correct title is now shown in the window title.

Tested on:
Nokia 3.1 running Android 9 and works.