### PR TITLE
Use DateUtils to format date

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/adapters/CompressedExplorerAdapter.java
+++ b/app/src/main/java/com/amaze/filemanager/adapters/CompressedExplorerAdapter.java
@@ -217,7 +217,7 @@ public class CompressedExplorerAdapter extends RecyclerView.Adapter<CompressedIt
             GlideApp.with(compressedExplorerFragment).load(rowItem.iconData.image).into(holder.genericIcon);
 
             if (compressedExplorerFragment.showLastModified)
-                holder.date.setText(Utils.getDate(rowItem.date));
+                holder.date.setText(Utils.getDate(context, rowItem.date));
             if (rowItem.directory) {
                 holder.genericIcon.setImageDrawable(folder);
                 gradientDrawable.setColor(compressedExplorerFragment.iconskin);

--- a/app/src/main/java/com/amaze/filemanager/adapters/data/LayoutElementParcelable.java
+++ b/app/src/main/java/com/amaze/filemanager/adapters/data/LayoutElementParcelable.java
@@ -20,9 +20,12 @@
 
 package com.amaze.filemanager.adapters.data;
 
+import android.content.Context;
 import android.os.Parcel;
 import android.os.Parcelable;
 import android.support.annotation.DrawableRes;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 
 import com.amaze.filemanager.filesystem.HybridFileParcelable;
 import com.amaze.filemanager.ui.icons.Icons;
@@ -49,30 +52,34 @@ public class LayoutElementParcelable implements Parcelable {
     public final String dateModification;
     public final boolean header;
 
+    @Nullable
+    private final Context context;
+
     //same as hfile.modes but different than openmode in Main.java
     private OpenMode mode = OpenMode.FILE;
 
-    public LayoutElementParcelable(boolean isBack, String goback, boolean showThumbs) {
-        this(true, new File("..").getName(), "..", "", "", goback, 0,
+    public LayoutElementParcelable(@NonNull Context c, boolean isBack, String goback, boolean showThumbs) {
+        this(c,true, new File("..").getName(), "..", "", "", goback, 0,
                 false, "", true, showThumbs, OpenMode.UNKNOWN);
     }
 
-    public LayoutElementParcelable(String path, String permissions, String symlink,
+    public LayoutElementParcelable(@NonNull Context c, String path, String permissions, String symlink,
                                    String size, long longSize,boolean header, String date,
                                    boolean isDirectory, boolean useThumbs, OpenMode openMode) {
-        this(new File(path).getName(), path, permissions, symlink, size, longSize, header,
+        this(c, new File(path).getName(), path, permissions, symlink, size, longSize, header,
                 date, isDirectory, useThumbs, openMode);
     }
 
-    public LayoutElementParcelable(String title, String path, String permissions,
+    public LayoutElementParcelable(@NonNull Context c, String title, String path, String permissions,
                                    String symlink, String size, long longSize, boolean header,
                                    String date, boolean isDirectory, boolean useThumbs, OpenMode openMode) {
-        this(false, title, path, permissions, symlink, size, longSize, header, date, isDirectory, useThumbs, openMode);
+        this(c,false, title, path, permissions, symlink, size, longSize, header, date, isDirectory, useThumbs, openMode);
     }
 
-    public LayoutElementParcelable(boolean isBack, String title, String path, String permissions,
+    public LayoutElementParcelable(@NonNull Context c, boolean isBack, String title, String path, String permissions,
                                    String symlink, String size, long longSize, boolean header,
                                    String date, boolean isDirectory, boolean useThumbs, OpenMode openMode) {
+        this.context = c;
         filetype = Icons.getTypeOfFile(path, isDirectory);
         @DrawableRes int fallbackIcon = Icons.loadMimeIcon(path, isDirectory);
         this.mode = openMode;
@@ -111,7 +118,7 @@ public class LayoutElementParcelable implements Parcelable {
         this.isDirectory = isDirectory;
         if (!date.trim().equals("")) {
             this.date = Long.parseLong(date);
-            this.dateModification = Utils.getDate(this.date);
+            this.dateModification = Utils.getDate(context, this.date);
         } else {
             this.date = 0;
             this.dateModification = "";
@@ -143,7 +150,9 @@ public class LayoutElementParcelable implements Parcelable {
         return title + "\n" + desc;
     }
 
+    //Hopefully it should be safe - nobody else is using this
     public LayoutElementParcelable(Parcel im) {
+        context = null;
         filetype = im.readInt();
         iconData = im.readParcelable(IconDataParcelable.class.getClassLoader());
         title = im.readString();

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/LoadFilesListTask.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/LoadFilesListTask.java
@@ -244,7 +244,7 @@ public class LoadFilesListTask extends AsyncTask<Void, Void, Pair<OpenMode, Arra
                 ma.file_count++;
             }
 
-            LayoutElementParcelable layoutElement = new LayoutElementParcelable(baseFile.getName(),
+            LayoutElementParcelable layoutElement = new LayoutElementParcelable(c, baseFile.getName(),
                     baseFile.getPath(), baseFile.getPermission(), baseFile.getLink(), size,
                     longSize, false, baseFile.getDate() + "", baseFile.isDirectory(),
                     showThumbs, baseFile.getMode());

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/handlers/FileHandler.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/handlers/FileHandler.java
@@ -49,7 +49,7 @@ public class FileHandler extends Handler {
             case CustomFileObserver.NEW_ITEM:
                 HybridFile fileCreated = new HybridFile(main.openMode,
                         main.getCurrentPath() + "/" + path);
-                main.getElementsList().add(fileCreated.generateLayoutElement(useThumbs));
+                main.getElementsList().add(fileCreated.generateLayoutElement(main.getContext(), useThumbs));
                 break;
             case CustomFileObserver.DELETED_ITEM:
                 for (int i = 0; i < main.getElementsList().size(); i++) {

--- a/app/src/main/java/com/amaze/filemanager/filesystem/HybridFile.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/HybridFile.java
@@ -1255,7 +1255,7 @@ public class HybridFile {
      * Generates a {@link LayoutElementParcelable} adapted compatible element.
      * Currently supports only local filesystem
      */
-    public LayoutElementParcelable generateLayoutElement(boolean showThumbs) {
+    public LayoutElementParcelable generateLayoutElement(@NonNull Context c, boolean showThumbs) {
         switch (mode) {
             case FILE:
             case ROOT:
@@ -1263,11 +1263,11 @@ public class HybridFile {
                 LayoutElementParcelable layoutElement;
                 if (isDirectory()) {
 
-                    layoutElement = new LayoutElementParcelable(path, RootHelper.parseFilePermission(file),
+                    layoutElement = new LayoutElementParcelable(c, path, RootHelper.parseFilePermission(file),
                             "", folderSize() + "", 0, true, file.lastModified() + "",
                             false, showThumbs, mode);
                 } else {
-                    layoutElement = new LayoutElementParcelable(
+                    layoutElement = new LayoutElementParcelable(c,
                             file.getPath(), RootHelper.parseFilePermission(file),
                             file.getPath(), file.length() + "", file.length(), false, file.lastModified() + "",
                             false, showThumbs, mode);

--- a/app/src/main/java/com/amaze/filemanager/fragments/MainFragment.java
+++ b/app/src/main/java/com/amaze/filemanager/fragments/MainFragment.java
@@ -1163,7 +1163,7 @@ public class MainFragment extends android.support.v4.app.Fragment implements Bot
 
     private LayoutElementParcelable getBackElement() {
         if (back == null) {
-            back = new LayoutElementParcelable(true, getString(R.string.goback), getBoolean(PREFERENCE_SHOW_THUMB));
+            back = new LayoutElementParcelable(getContext(), true, getString(R.string.goback), getBoolean(PREFERENCE_SHOW_THUMB));
         }
 
         return back;
@@ -1468,7 +1468,7 @@ public class MainFragment extends android.support.v4.app.Fragment implements Bot
             if (aMFile.isDirectory()) {
                 folder_count++;
 
-                LayoutElementParcelable layoutElement = new LayoutElementParcelable(name, aMFile.getPath(),
+                LayoutElementParcelable layoutElement = new LayoutElementParcelable(getContext(), name, aMFile.getPath(),
                         "", "", "", 0, false,
                         aMFile.lastModified() + "", true,
                         getBoolean(PREFERENCE_SHOW_THUMB), OpenMode.SMB);
@@ -1478,7 +1478,7 @@ public class MainFragment extends android.support.v4.app.Fragment implements Bot
 
             } else {
                 file_count++;
-                LayoutElementParcelable layoutElement = new LayoutElementParcelable(name,
+                LayoutElementParcelable layoutElement = new LayoutElementParcelable(getContext(), name,
                         aMFile.getPath(), "", "", Formatter.formatFileSize(getContext(),
                         aMFile.length()), aMFile.length(), false, aMFile.lastModified() + "",
                         false, getBoolean(PREFERENCE_SHOW_THUMB), OpenMode.SMB);
@@ -1497,7 +1497,7 @@ public class MainFragment extends android.support.v4.app.Fragment implements Bot
         if (!dataUtils.isFileHidden(mFile.getPath())) {
             if (mFile.isDirectory()) {
                 size = "";
-                LayoutElementParcelable layoutElement = new LayoutElementParcelable(f.getPath(), mFile.getPermission(),
+                LayoutElementParcelable layoutElement = new LayoutElementParcelable(getContext(), f.getPath(), mFile.getPermission(),
                         mFile.getLink(), size, 0, true,
                         mFile.getDate() + "", false,
                         getBoolean(PREFERENCE_SHOW_THUMB), mFile.getMode());
@@ -1519,7 +1519,7 @@ public class MainFragment extends android.support.v4.app.Fragment implements Bot
                     //e.printStackTrace();
                 }
                 try {
-                    LayoutElementParcelable layoutElement = new LayoutElementParcelable(f.getPath(),
+                    LayoutElementParcelable layoutElement = new LayoutElementParcelable(getContext(), f.getPath(),
                             mFile.getPermission(), mFile.getLink(), size, longSize, false,
                             mFile.getDate() + "", false,
                             getBoolean(PREFERENCE_SHOW_THUMB), mFile.getMode());

--- a/app/src/main/java/com/amaze/filemanager/fragments/PropertiesSheet.java
+++ b/app/src/main/java/com/amaze/filemanager/fragments/PropertiesSheet.java
@@ -72,9 +72,9 @@ public class PropertiesSheet extends BottomSheetDialogFragment {
         mFileLocationTextView = rootView.findViewById(R.id.text_view_file_location);
         mFileLocationTextView.setText(mFile.getPath());
         mFileAccessedTextView = rootView.findViewById(R.id.text_view_file_accessed);
-        mFileAccessedTextView.setText(Utils.getDate(mFile.getDate()));
+        mFileAccessedTextView.setText(Utils.getDate(getContext(), mFile.getDate()));
         mFileModifiedTextView = rootView.findViewById(R.id.text_view_file_modified);
-        mFileModifiedTextView.setText(Utils.getDate(mFile.getDate()));
+        mFileModifiedTextView.setText(Utils.getDate(getContext(), mFile.getDate()));
 
         CoordinatorLayout.LayoutParams layoutParams = (CoordinatorLayout.LayoutParams) ((View) rootView.getParent()).getLayoutParams();
 

--- a/app/src/main/java/com/amaze/filemanager/ui/dialogs/GeneralDialogCreation.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/dialogs/GeneralDialogCreation.java
@@ -375,7 +375,7 @@ public class GeneralDialogCreation {
         final Context c = base.getApplicationContext();
         int accentColor = base.getAccent();
         long last = baseFile.getDate();
-        final String date = Utils.getDate(last),
+        final String date = Utils.getDate(base, last),
                 items = c.getString(R.string.calculating),
                 name = baseFile.getName(),
                 parent = baseFile.getReadablePath(baseFile.getParent(c));

--- a/app/src/main/java/com/amaze/filemanager/utils/Utils.java
+++ b/app/src/main/java/com/amaze/filemanager/utils/Utils.java
@@ -31,8 +31,10 @@ import android.graphics.drawable.Drawable;
 import android.net.Uri;
 import android.os.Build;
 import android.support.annotation.ColorRes;
+import android.support.annotation.NonNull;
 import android.support.v4.content.ContextCompat;
 import android.support.v4.graphics.drawable.DrawableCompat;
+import android.text.format.DateUtils;
 import android.util.DisplayMetrics;
 import android.view.View;
 import android.widget.CheckBox;
@@ -43,8 +45,6 @@ import com.amaze.filemanager.activities.MainActivity;
 import com.amaze.filemanager.filesystem.HybridFileParcelable;
 
 import java.io.File;
-import java.text.SimpleDateFormat;
-import java.util.Locale;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -57,12 +57,11 @@ import java.util.concurrent.TimeUnit;
 public class Utils {
 
     private static final int INDEX_NOT_FOUND = -1;
-    private static final SimpleDateFormat DATE_NO_MINUTES = new SimpleDateFormat("MMM dd, yyyy");
-    private static final SimpleDateFormat DATE_WITH_MINUTES = new SimpleDateFormat("MMM dd yyyy | HH:mm");
     private static final String INPUT_INTENT_BLACKLIST_COLON = ";";
     private static final String INPUT_INTENT_BLACKLIST_PIPE = "\\|";
     private static final String INPUT_INTENT_BLACKLIST_AMP = "&&";
     private static final String INPUT_INTENT_BLACKLIST_DOTS = "\\.\\.\\.";
+    private static final String DATE_TIME_FORMAT = "%s | %s";
 
     //methods for fastscroller
     public static float clamp(float min, float max, float value) {
@@ -94,15 +93,8 @@ public class Utils {
         }
     }
 
-    public static String getDate(long f) {
-        return DATE_WITH_MINUTES.format(f);
-    }
-
-    public static String getDate(long f, String year) {
-        String date = DATE_NO_MINUTES.format(f);
-        if (date.substring(date.length() - 4, date.length()).equals(year))
-            date = date.substring(0, date.length() - 6);
-        return date;
+    public static String getDate(@NonNull Context c, long f) {
+        return String.format(DATE_TIME_FORMAT, DateUtils.formatDateTime(c, f, DateUtils.FORMAT_SHOW_DATE), DateUtils.formatDateTime(c, f, DateUtils.FORMAT_SHOW_TIME));
     }
 
     /**
@@ -111,6 +103,7 @@ public class Utils {
      * @param color the resource id for the color
      * @return the color
      */
+    @SuppressWarnings("deprecation")
     public static int getColor(Context c, @ColorRes int color) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             return c.getColor(color);


### PR DESCRIPTION
Fixes #1456, by adding Context to Utils.getDate(long) for calling [DateUtils.formatDateTime()](https://developer.android.com/reference/android/text/format/DateUtils.html#formatDateTime(android.content.Context,%20long,%20int)).

Also removed unused Utils.getDate(long, String).

Tested on Oneplus 2 running Slim7 (7.1.2) and LG Nexus 5x running AOSPExtended (9.0).