### PR TITLE
FtpService Updates

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -32,6 +32,7 @@
     <uses-permission android:name="android.permission.USE_FINGERPRINT" />
     <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
 
     <uses-feature
         android:name="android.hardware.touchscreen"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -32,7 +32,6 @@
     <uses-permission android:name="android.permission.USE_FINGERPRINT" />
     <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
-    <uses-permission android:name="android.permission.WAKE_LOCK" />
 
     <uses-feature
         android:name="android.hardware.touchscreen"

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/services/ftp/FtpService.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/services/ftp/FtpService.java
@@ -146,8 +146,6 @@ public class FtpService extends Service implements Runnable {
         serverThread = new Thread(this);
         serverThread.start();
 
-        acquireWakeLock();
-
         Notification notification = buildNotification();
 
         startForeground(NotificationConstants.FTP_ID, notification);
@@ -256,8 +254,6 @@ public class FtpService extends Service implements Runnable {
             serverThread = null;
         }
         if (server != null) {
-            releaseWakeLock();
-
             server.stop();
             sendBroadcast(new Intent(FtpService.ACTION_STOPPED).setPackage(getPackageName()));
         }
@@ -393,17 +389,6 @@ public class FtpService extends Service implements Runnable {
 
     public static NotificationCompat.Builder getBuilder() {
         return builder;
-    }
-
-    private void acquireWakeLock(){
-        PowerManager powerManager = (PowerManager) getSystemService(POWER_SERVICE);
-        wakeLock = powerManager.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK,
-                "FtpService::Wakelock");
-        wakeLock.acquire();
-    }
-
-    private void releaseWakeLock(){
-        wakeLock.release();
     }
 
     private Notification buildNotification(){

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/services/ftp/FtpService.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/services/ftp/FtpService.java
@@ -123,10 +123,6 @@ public class FtpService extends Service implements Runnable {
 
     private boolean isStartedByTile = false;
 
-    private static NotificationCompat.Builder builder;
-
-    private PowerManager.WakeLock wakeLock;
-
     @Override
     public int onStartCommand(Intent intent, int flags, int startId) {
         isStartedByTile = intent.getBooleanExtra(TAG_STARTED_BY_TILE, false);
@@ -387,12 +383,9 @@ public class FtpService extends Service implements Runnable {
         return r;
     }
 
-    public static NotificationCompat.Builder getBuilder() {
-        return builder;
-    }
-
     private Notification buildNotification(){
         Notification notification;
+        NotificationCompat.Builder builder;
 
         Intent notificationIntent = new Intent(this, MainActivity.class);
         notificationIntent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP);
@@ -436,4 +429,5 @@ public class FtpService extends Service implements Runnable {
 
         return notification;
     }
+
 }

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/services/ftp/FtpService.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/services/ftp/FtpService.java
@@ -136,7 +136,7 @@ public class FtpService extends Service implements Runnable {
         serverThread = new Thread(this);
         serverThread.start();
 
-        Notification notification = FtpNotification.startNotification(getApplicationContext());
+        Notification notification = FtpNotification.startNotification(getApplicationContext(), isStartedByTile);
 
         startForeground(NotificationConstants.FTP_ID, notification);
 

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/services/ftp/FtpService.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/services/ftp/FtpService.java
@@ -28,7 +28,6 @@ package com.amaze.filemanager.asynchronous.services.ftp;
 
 import android.app.AlarmManager;
 import android.app.Notification;
-import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.app.Service;
 import android.content.Context;
@@ -38,7 +37,6 @@ import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
 import android.net.wifi.WifiManager;
 import android.os.Build;
-import android.os.Bundle;
 import android.os.Environment;
 import android.os.IBinder;
 import android.os.SystemClock;
@@ -46,7 +44,6 @@ import android.preference.PreferenceManager;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v4.app.NotificationCompat;
-import android.util.Log;
 import android.widget.Toast;
 
 import com.amaze.filemanager.R;

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/services/ftp/FtpService.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/services/ftp/FtpService.java
@@ -28,6 +28,8 @@ package com.amaze.filemanager.asynchronous.services.ftp;
 
 import android.app.AlarmManager;
 import android.app.Notification;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.app.Service;
 import android.content.Context;
@@ -44,6 +46,7 @@ import android.preference.PreferenceManager;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v4.app.NotificationCompat;
+import android.util.Log;
 import android.widget.Toast;
 
 import com.amaze.filemanager.R;
@@ -155,18 +158,30 @@ public class FtpService extends Service implements Runnable {
                 .setOngoing(true)
                 .setOnlyAlertOnce(true);
 
-        Notification notification;
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
-            int stopIcon = android.R.drawable.ic_menu_close_clear_cancel;
-            CharSequence stopText = this.getString(R.string.ftp_notif_stop_server);
-            Intent stopIntent = new Intent(FtpService.ACTION_STOP_FTPSERVER).setPackage(this.getPackageName());
-            PendingIntent stopPendingIntent = PendingIntent.getBroadcast(this, 0,
-                    stopIntent, PendingIntent.FLAG_ONE_SHOT);
+        int stopIcon = android.R.drawable.ic_menu_close_clear_cancel;
+        CharSequence stopText = this.getString(R.string.ftp_notif_stop_server);
+        Intent stopIntent = new Intent(FtpService.ACTION_STOP_FTPSERVER).setPackage(getApplicationContext().getPackageName());
+        PendingIntent stopPendingIntent = PendingIntent.getBroadcast(getApplicationContext(), 0,
+                stopIntent, PendingIntent.FLAG_ONE_SHOT);
 
-            builder.addAction(stopIcon, stopText, stopPendingIntent);
-            builder.setShowWhen(false);
+        builder.addAction(stopIcon, stopText, stopPendingIntent);
+
+        Notification notification;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN && Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+            Log.i("Got here", "got here 1");
+            notification = builder.build();
+        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O){
+            Log.i("Got here", "got here 2");
+            String channelName = NotificationConstants.CHANNEL_FTP_NAME;
+
+            NotificationChannel chan = new NotificationChannel(NotificationConstants.CHANNEL_FTP_ID, channelName, NotificationManager.IMPORTANCE_DEFAULT);
+
+            NotificationManager manager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
+            manager.createNotificationChannel(chan);
+
             notification = builder.build();
         } else {
+            Log.i("Got here", "got here 2");
             notification = builder.getNotification();
         }
 
@@ -174,6 +189,7 @@ public class FtpService extends Service implements Runnable {
 
         return START_STICKY;
     }
+
 
     @Override
     public IBinder onBind(Intent intent) {

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/services/ftp/FtpService.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/services/ftp/FtpService.java
@@ -108,7 +108,6 @@ public class FtpService extends Service implements Runnable {
     static public final String ACTION_STOP_FTPSERVER = "com.amaze.filemanager.services.ftpservice.FTPReceiver.ACTION_STOP_FTPSERVER";
 
     static public final String TAG_STARTED_BY_TILE = "started_by_tile";  // attribute of action_started, used by notification
-    static public final String TAG_NOTIFICATION = "notification";  // attribute of action_started, used by notification
 
     private String username, password;
     private boolean isPasswordProtected = false;
@@ -139,18 +138,16 @@ public class FtpService extends Service implements Runnable {
         serverThread = new Thread(this);
         serverThread.start();
 
-        //TODO: should I be using getApplicatoinContext() or this for context?
-
         CharSequence tickerText = this.getString(R.string.ftp_notif_starting);
         long when = System.currentTimeMillis();
 
-        Intent notificationIntent = new Intent(getApplicationContext(), MainActivity.class);
+        Intent notificationIntent = new Intent(this, MainActivity.class);
         notificationIntent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP);
-        PendingIntent contentIntent = PendingIntent.getActivity(getApplicationContext(), 0, notificationIntent, 0);
+        PendingIntent contentIntent = PendingIntent.getActivity(this, 0, notificationIntent, 0);
 
-        builder  = new NotificationCompat.Builder(getApplicationContext(), NotificationConstants.CHANNEL_FTP_ID)
-                .setContentTitle(getApplicationContext().getString(R.string.ftp_notif_starting_title))
-                .setContentText(getApplicationContext().getString(R.string.ftp_notif_starting))
+        builder  = new NotificationCompat.Builder(this, NotificationConstants.CHANNEL_FTP_ID)
+                .setContentTitle(this.getString(R.string.ftp_notif_starting_title))
+                .setContentText(this.getString(R.string.ftp_notif_starting))
                 .setContentIntent(contentIntent)
                 .setSmallIcon(R.drawable.ic_ftp_light)
                 .setTicker(tickerText)
@@ -161,9 +158,9 @@ public class FtpService extends Service implements Runnable {
         Notification notification;
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
             int stopIcon = android.R.drawable.ic_menu_close_clear_cancel;
-            CharSequence stopText = getApplicationContext().getString(R.string.ftp_notif_stop_server);
-            Intent stopIntent = new Intent(FtpService.ACTION_STOP_FTPSERVER).setPackage(getApplicationContext().getPackageName());
-            PendingIntent stopPendingIntent = PendingIntent.getBroadcast(getApplicationContext(), 0,
+            CharSequence stopText = this.getString(R.string.ftp_notif_stop_server);
+            Intent stopIntent = new Intent(FtpService.ACTION_STOP_FTPSERVER).setPackage(this.getPackageName());
+            PendingIntent stopPendingIntent = PendingIntent.getBroadcast(this, 0,
                     stopIntent, PendingIntent.FLAG_ONE_SHOT);
 
             builder.addAction(stopIcon, stopText, stopPendingIntent);

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/services/ftp/FtpService.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/services/ftp/FtpService.java
@@ -384,7 +384,6 @@ public class FtpService extends Service implements Runnable {
     }
 
     private Notification buildNotification(){
-        Notification notification;
         NotificationCompat.Builder builder;
 
         Intent notificationIntent = new Intent(this, MainActivity.class);
@@ -412,22 +411,9 @@ public class FtpService extends Service implements Runnable {
 
         builder.addAction(stopIcon, stopText, stopPendingIntent);
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN && Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
-            notification = builder.build();
-        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O){
-            String channelName = NotificationConstants.CHANNEL_FTP_NAME;
+        NotificationConstants.setMetadata(getApplicationContext(), builder, NotificationConstants.TYPE_FTP);
 
-            NotificationChannel chan = new NotificationChannel(NotificationConstants.CHANNEL_FTP_ID, channelName, NotificationManager.IMPORTANCE_DEFAULT);
-
-            NotificationManager manager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
-            manager.createNotificationChannel(chan);
-
-            notification = builder.build();
-        } else {
-            notification = builder.getNotification();
-        }
-
-        return notification;
+        return builder.build();
     }
 
 }

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/services/ftp/FtpService.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/services/ftp/FtpService.java
@@ -30,8 +30,6 @@ package com.amaze.filemanager.asynchronous.services.ftp;
 
 import android.app.AlarmManager;
 import android.app.Notification;
-import android.app.NotificationChannel;
-import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.app.Service;
 import android.content.Context;
@@ -40,20 +38,15 @@ import android.content.SharedPreferences;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
 import android.net.wifi.WifiManager;
-import android.os.Build;
 import android.os.Environment;
 import android.os.IBinder;
-import android.os.PowerManager;
 import android.os.SystemClock;
 import android.preference.PreferenceManager;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
-import android.support.v4.app.NotificationCompat;
-import android.util.Log;
 import android.widget.Toast;
 
 import com.amaze.filemanager.R;
-import com.amaze.filemanager.activities.MainActivity;
 import com.amaze.filemanager.ui.notifications.FtpNotification;
 import com.amaze.filemanager.ui.notifications.NotificationConstants;
 import com.amaze.filemanager.utils.files.CryptUtil;
@@ -143,7 +136,7 @@ public class FtpService extends Service implements Runnable {
         serverThread = new Thread(this);
         serverThread.start();
 
-        Notification notification = FtpNotification.buildNotification(getApplicationContext());
+        Notification notification = FtpNotification.startNotification(getApplicationContext());
 
         startForeground(NotificationConstants.FTP_ID, notification);
 

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/services/ftp/FtpService.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/services/ftp/FtpService.java
@@ -145,6 +145,7 @@ public class FtpService extends Service implements Runnable {
         //TODO: How do I handle multiple languages instead of hardcoding these strings?
         //TODO: also, the server starts up pretty fast and it sends out two notifications back to back. Not ideal...
         //TODO: do I have the context right? Compare to FtpNotification
+        //TODO: Test timeout setting
 
         CharSequence tickerText = this.getString(R.string.ftp_notif_starting);
         long when = System.currentTimeMillis();

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/services/ftp/FtpService.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/services/ftp/FtpService.java
@@ -54,6 +54,7 @@ import android.widget.Toast;
 
 import com.amaze.filemanager.R;
 import com.amaze.filemanager.activities.MainActivity;
+import com.amaze.filemanager.ui.notifications.FtpNotification;
 import com.amaze.filemanager.ui.notifications.NotificationConstants;
 import com.amaze.filemanager.utils.files.CryptUtil;
 
@@ -142,7 +143,7 @@ public class FtpService extends Service implements Runnable {
         serverThread = new Thread(this);
         serverThread.start();
 
-        Notification notification = buildNotification();
+        Notification notification = FtpNotification.buildNotification(getApplicationContext());
 
         startForeground(NotificationConstants.FTP_ID, notification);
 
@@ -381,39 +382,6 @@ public class FtpService extends Service implements Runnable {
         }
 
         return r;
-    }
-
-    private Notification buildNotification(){
-        NotificationCompat.Builder builder;
-
-        Intent notificationIntent = new Intent(this, MainActivity.class);
-        notificationIntent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP);
-        PendingIntent contentIntent = PendingIntent.getActivity(this, 0, notificationIntent, 0);
-
-        CharSequence tickerText = this.getString(R.string.ftp_notif_starting);
-        long when = System.currentTimeMillis();
-
-        builder  = new NotificationCompat.Builder(getApplicationContext(), NotificationConstants.CHANNEL_FTP_ID)
-                .setContentTitle(this.getString(R.string.ftp_notif_starting_title))
-                .setContentText(this.getString(R.string.ftp_notif_starting))
-                .setContentIntent(contentIntent)
-                .setSmallIcon(R.drawable.ic_ftp_light)
-                .setTicker(tickerText)
-                .setWhen(when)
-                .setOngoing(true)
-                .setOnlyAlertOnce(true);
-
-        int stopIcon = android.R.drawable.ic_menu_close_clear_cancel;
-        CharSequence stopText = this.getString(R.string.ftp_notif_stop_server);
-        Intent stopIntent = new Intent(FtpService.ACTION_STOP_FTPSERVER).setPackage(getApplicationContext().getPackageName());
-        PendingIntent stopPendingIntent = PendingIntent.getBroadcast(getApplicationContext(), 0,
-                stopIntent, PendingIntent.FLAG_ONE_SHOT);
-
-        builder.addAction(stopIcon, stopText, stopPendingIntent);
-
-        NotificationConstants.setMetadata(getApplicationContext(), builder, NotificationConstants.TYPE_FTP);
-
-        return builder.build();
     }
 
 }

--- a/app/src/main/java/com/amaze/filemanager/ui/notifications/FtpNotification.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/notifications/FtpNotification.java
@@ -23,6 +23,11 @@ import java.net.InetAddress;
  */
 public class FtpNotification extends BroadcastReceiver {
 
+    private static NotificationCompat.Builder builder;
+    private static CharSequence tickerText;
+    private static String contentTitle;
+    private static String contentText;
+
     @Override
     public void onReceive(Context context, Intent intent) {
         switch(intent.getAction()){
@@ -35,19 +40,16 @@ public class FtpNotification extends BroadcastReceiver {
         }
     }
 
-    public static Notification buildNotification(Context context){
-        NotificationCompat.Builder builder;
-
+    private static void buildNotification(Context context){
         Intent notificationIntent = new Intent(context, MainActivity.class);
         notificationIntent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP);
         PendingIntent contentIntent = PendingIntent.getActivity(context, 0, notificationIntent, 0);
 
-        CharSequence tickerText = context.getString(R.string.ftp_notif_starting);
         long when = System.currentTimeMillis();
 
         builder  = new NotificationCompat.Builder(context, NotificationConstants.CHANNEL_FTP_ID)
-                .setContentTitle(context.getString(R.string.ftp_notif_starting_title))
-                .setContentText(context.getString(R.string.ftp_notif_starting))
+                .setContentTitle(contentTitle)
+                .setContentText(contentText)
                 .setContentIntent(contentIntent)
                 .setSmallIcon(R.drawable.ic_ftp_light)
                 .setTicker(tickerText)
@@ -64,12 +66,19 @@ public class FtpNotification extends BroadcastReceiver {
         builder.addAction(stopIcon, stopText, stopPendingIntent);
 
         NotificationConstants.setMetadata(context, builder, NotificationConstants.TYPE_FTP);
+    }
+
+    public static Notification startNotification(Context context){
+        tickerText = context.getString(R.string.ftp_notif_starting);
+        contentTitle = context.getString(R.string.ftp_notif_starting_title);
+        contentText = context.getString(R.string.ftp_notif_starting);
+
+        buildNotification(context);
 
         return builder.build();
     }
 
     private static void updateNotification(Context context) {
-
         String notificationService = Context.NOTIFICATION_SERVICE;
         NotificationManager notificationManager = (NotificationManager) context.getSystemService(notificationService);
 
@@ -83,29 +92,11 @@ public class FtpNotification extends BroadcastReceiver {
                 + address.getHostAddress() + ":"
                 + port + "/";
 
-        NotificationCompat.Builder builder = new NotificationCompat.Builder(context.getApplicationContext(), NotificationConstants.CHANNEL_FTP_ID);
+        tickerText = context.getString(R.string.ftp_notif_starting);
+        contentTitle = context.getString(R.string.ftp_notif_title);
+        contentText = String.format(context.getString(R.string.ftp_notif_text), iptext);
 
-        int icon = R.drawable.ic_ftp_light;
-        CharSequence tickerText = context.getString(R.string.ftp_notif_starting);
-        long when = System.currentTimeMillis();
-
-        CharSequence contentTitle = context.getString(R.string.ftp_notif_title);
-        CharSequence contentText = String.format(context.getString(R.string.ftp_notif_text), iptext);
-
-        builder.setContentTitle(contentTitle)
-                .setContentText(contentText)
-                .setSmallIcon(icon)
-                .setTicker(tickerText)
-                .setWhen(when)
-                .setOngoing(true);
-
-        int stopIcon = android.R.drawable.ic_menu_close_clear_cancel;
-        CharSequence stopText = context.getString(R.string.ftp_notif_stop_server);
-        Intent stopIntent = new Intent(FtpService.ACTION_STOP_FTPSERVER).setPackage(context.getApplicationContext().getPackageName());
-        PendingIntent stopPendingIntent = PendingIntent.getBroadcast(context.getApplicationContext(), 0,
-                stopIntent, PendingIntent.FLAG_ONE_SHOT);
-
-        builder.addAction(stopIcon, stopText, stopPendingIntent);
+        buildNotification(context);
 
         notificationManager.notify(NotificationConstants.FTP_ID, builder.build());
     }

--- a/app/src/main/java/com/amaze/filemanager/ui/notifications/FtpNotification.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/notifications/FtpNotification.java
@@ -1,13 +1,10 @@
 package com.amaze.filemanager.ui.notifications;
 
-import android.app.Notification;
 import android.app.NotificationManager;
-import android.app.PendingIntent;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
-import android.os.Build;
 import android.preference.PreferenceManager;
 import android.support.v4.app.NotificationCompat;
 

--- a/app/src/main/java/com/amaze/filemanager/ui/notifications/FtpNotification.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/notifications/FtpNotification.java
@@ -1,5 +1,6 @@
 package com.amaze.filemanager.ui.notifications;
 
+import android.app.Notification;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.content.BroadcastReceiver;
@@ -34,7 +35,40 @@ public class FtpNotification extends BroadcastReceiver {
         }
     }
 
-    private void updateNotification(Context context) {
+    public static Notification buildNotification(Context context){
+        NotificationCompat.Builder builder;
+
+        Intent notificationIntent = new Intent(context, MainActivity.class);
+        notificationIntent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP);
+        PendingIntent contentIntent = PendingIntent.getActivity(context, 0, notificationIntent, 0);
+
+        CharSequence tickerText = context.getString(R.string.ftp_notif_starting);
+        long when = System.currentTimeMillis();
+
+        builder  = new NotificationCompat.Builder(context, NotificationConstants.CHANNEL_FTP_ID)
+                .setContentTitle(context.getString(R.string.ftp_notif_starting_title))
+                .setContentText(context.getString(R.string.ftp_notif_starting))
+                .setContentIntent(contentIntent)
+                .setSmallIcon(R.drawable.ic_ftp_light)
+                .setTicker(tickerText)
+                .setWhen(when)
+                .setOngoing(true)
+                .setOnlyAlertOnce(true);
+
+        int stopIcon = android.R.drawable.ic_menu_close_clear_cancel;
+        CharSequence stopText = context.getString(R.string.ftp_notif_stop_server);
+        Intent stopIntent = new Intent(FtpService.ACTION_STOP_FTPSERVER).setPackage(context.getPackageName());
+        PendingIntent stopPendingIntent = PendingIntent.getBroadcast(context, 0,
+                stopIntent, PendingIntent.FLAG_ONE_SHOT);
+
+        builder.addAction(stopIcon, stopText, stopPendingIntent);
+
+        NotificationConstants.setMetadata(context, builder, NotificationConstants.TYPE_FTP);
+
+        return builder.build();
+    }
+
+    private static void updateNotification(Context context) {
 
         String notificationService = Context.NOTIFICATION_SERVICE;
         NotificationManager notificationManager = (NotificationManager) context.getSystemService(notificationService);
@@ -76,7 +110,7 @@ public class FtpNotification extends BroadcastReceiver {
         notificationManager.notify(NotificationConstants.FTP_ID, builder.build());
     }
 
-    private void removeNotification(Context context){
+    private static void removeNotification(Context context){
         String ns = Context.NOTIFICATION_SERVICE;
         NotificationManager nm = (NotificationManager) context.getSystemService(ns);
         nm.cancelAll();

--- a/app/src/main/java/com/amaze/filemanager/ui/notifications/FtpNotification.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/notifications/FtpNotification.java
@@ -28,7 +28,7 @@ public class FtpNotification extends BroadcastReceiver {
     public void onReceive(Context context, Intent intent) {
         switch(intent.getAction()){
             case FtpService.ACTION_STARTED:
-                updateNotification(context);
+                updateNotification(context, intent.getBooleanExtra(FtpService.TAG_STARTED_BY_TILE, false));
                 break;
             case FtpService.ACTION_STOPPED:
                 removeNotification(context);
@@ -38,7 +38,8 @@ public class FtpNotification extends BroadcastReceiver {
 
     private static NotificationCompat.Builder buildNotification(Context context,
                                                                 @StringRes int contentTitleRes,
-                                                                String contentText){
+                                                                String contentText,
+                                                                boolean noStopButton){
         Intent notificationIntent = new Intent(context, MainActivity.class);
         notificationIntent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP);
         PendingIntent contentIntent = PendingIntent.getActivity(context, 0, notificationIntent, 0);
@@ -55,27 +56,29 @@ public class FtpNotification extends BroadcastReceiver {
                 .setOngoing(true)
                 .setOnlyAlertOnce(true);
 
-        int stopIcon = android.R.drawable.ic_menu_close_clear_cancel;
-        CharSequence stopText = context.getString(R.string.ftp_notif_stop_server);
-        Intent stopIntent = new Intent(FtpService.ACTION_STOP_FTPSERVER).setPackage(context.getPackageName());
-        PendingIntent stopPendingIntent = PendingIntent.getBroadcast(context, 0,
-                stopIntent, PendingIntent.FLAG_ONE_SHOT);
+        if(!noStopButton) {
+            int stopIcon = android.R.drawable.ic_menu_close_clear_cancel;
+            CharSequence stopText = context.getString(R.string.ftp_notif_stop_server);
+            Intent stopIntent = new Intent(FtpService.ACTION_STOP_FTPSERVER).setPackage(context.getPackageName());
+            PendingIntent stopPendingIntent = PendingIntent.getBroadcast(context, 0,
+                    stopIntent, PendingIntent.FLAG_ONE_SHOT);
 
-        builder.addAction(stopIcon, stopText, stopPendingIntent);
+            builder.addAction(stopIcon, stopText, stopPendingIntent);
+        }
 
         NotificationConstants.setMetadata(context, builder, NotificationConstants.TYPE_FTP);
 
         return builder;
     }
 
-    public static Notification startNotification(Context context){
+    public static Notification startNotification(Context context, boolean noStopButton){
         NotificationCompat.Builder builder = buildNotification(context,
-                R.string.ftp_notif_starting_title, context.getString(R.string.ftp_notif_starting));
+                R.string.ftp_notif_starting_title, context.getString(R.string.ftp_notif_starting), noStopButton);
 
         return builder.build();
     }
 
-    private static void updateNotification(Context context) {
+    private static void updateNotification(Context context, boolean noStopButton) {
         String notificationService = Context.NOTIFICATION_SERVICE;
         NotificationManager notificationManager = (NotificationManager) context.getSystemService(notificationService);
 
@@ -90,7 +93,7 @@ public class FtpNotification extends BroadcastReceiver {
                 + port + "/";
 
         NotificationCompat.Builder builder = buildNotification(context,
-                R.string.ftp_notif_title, context.getString(R.string.ftp_notif_text, iptext));
+                R.string.ftp_notif_title, context.getString(R.string.ftp_notif_text, iptext), noStopButton);
 
         notificationManager.notify(NotificationConstants.FTP_ID, builder.build());
     }

--- a/app/src/main/java/com/amaze/filemanager/ui/notifications/FtpNotification.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/notifications/FtpNotification.java
@@ -49,58 +49,24 @@ public class FtpNotification extends BroadcastReceiver {
                 + address.getHostAddress() + ":"
                 + port + "/";
 
-        //TODO: the below notification needs to change to update the notification to the server information since the server has now started
-        //TODO: do I get the notification to update out of the notification manager? do I have to create a new notification manager object?
-        //TODO: I guress I need to send the notification builder with the intent to update it here, something like:
+        //TODO: is this an appropriate way to get the builder from FtpService to update the notification here?
+        NotificationCompat.Builder builder = FtpService.getBuilder();
 
-        /*
-        * mBuilder.setContentText(message)
-            .setProgress(100, progress, true);
-
-            mNotificationManager.notify(mNotificationId, mBuilder.build());
-        *
-        * */
-
-/*        int icon = R.drawable.ic_ftp_light;
+        int icon = R.drawable.ic_ftp_light;
         CharSequence tickerText = context.getString(R.string.ftp_notif_starting);
         long when = System.currentTimeMillis();
-
 
         CharSequence contentTitle = context.getString(R.string.ftp_notif_title);
         CharSequence contentText = String.format(context.getString(R.string.ftp_notif_text), iptext);
 
-        Intent notificationIntent = new Intent(context, MainActivity.class);
-        notificationIntent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP);
-        PendingIntent contentIntent = PendingIntent.getActivity(context, 0, notificationIntent, 0);
-
-        NotificationCompat.Builder notificationBuilder = new NotificationCompat.Builder(context, NotificationConstants.CHANNEL_FTP_ID)
-                .setContentTitle(contentTitle)
+        builder.setContentTitle(contentTitle)
                 .setContentText(contentText)
-                .setContentIntent(contentIntent)
                 .setSmallIcon(icon)
                 .setTicker(tickerText)
                 .setWhen(when)
                 .setOngoing(true);
 
-        NotificationConstants.setMetadata(context, notificationBuilder, NotificationConstants.TYPE_FTP);
-
-        Notification notification;
-        if (!noStopButton && Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
-            int stopIcon = android.R.drawable.ic_menu_close_clear_cancel;
-            CharSequence stopText = context.getString(R.string.ftp_notif_stop_server);
-            Intent stopIntent = new Intent(FtpService.ACTION_STOP_FTPSERVER).setPackage(context.getPackageName());
-            PendingIntent stopPendingIntent = PendingIntent.getBroadcast(context, 0,
-                    stopIntent, PendingIntent.FLAG_ONE_SHOT);
-
-            notificationBuilder.addAction(stopIcon, stopText, stopPendingIntent);
-            notificationBuilder.setShowWhen(false);
-            notification = notificationBuilder.build();
-        } else {
-            notification = notificationBuilder.getNotification();
-        }
-
-        // Pass Notification to NotificationManager
-        notificationManager.notify(NotificationConstants.FTP_ID, notification);*/
+        notificationManager.notify(NotificationConstants.FTP_ID, builder.build());
     }
 
     private void removeNotification(Context context){

--- a/app/src/main/java/com/amaze/filemanager/ui/notifications/FtpNotification.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/notifications/FtpNotification.java
@@ -16,6 +16,8 @@ import java.net.InetAddress;
 
 /**
  * Created by yashwanthreddyg on 19-06-2016.
+ *
+ * Edited by zent-co on 30-07-2019
  */
 public class FtpNotification extends BroadcastReceiver {
 

--- a/app/src/main/java/com/amaze/filemanager/ui/notifications/FtpNotification.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/notifications/FtpNotification.java
@@ -49,7 +49,19 @@ public class FtpNotification extends BroadcastReceiver {
                 + address.getHostAddress() + ":"
                 + port + "/";
 
-        int icon = R.drawable.ic_ftp_light;
+        //TODO: the below notification needs to change to update the notification to the server information since the server has now started
+        //TODO: do I get the notification to update out of the notification manager? do I have to create a new notification manager object?
+        //TODO: I guress I need to send the notification builder with the intent to update it here, something like:
+
+        /*
+        * mBuilder.setContentText(message)
+            .setProgress(100, progress, true);
+
+            mNotificationManager.notify(mNotificationId, mBuilder.build());
+        *
+        * */
+
+/*        int icon = R.drawable.ic_ftp_light;
         CharSequence tickerText = context.getString(R.string.ftp_notif_starting);
         long when = System.currentTimeMillis();
 
@@ -88,7 +100,7 @@ public class FtpNotification extends BroadcastReceiver {
         }
 
         // Pass Notification to NotificationManager
-        notificationManager.notify(NotificationConstants.FTP_ID, notification);
+        notificationManager.notify(NotificationConstants.FTP_ID, notification);*/
     }
 
     private void removeNotification(Context context){

--- a/app/src/main/java/com/amaze/filemanager/ui/notifications/FtpNotification.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/notifications/FtpNotification.java
@@ -8,6 +8,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.preference.PreferenceManager;
+import android.support.annotation.StringRes;
 import android.support.v4.app.NotificationCompat;
 
 import com.amaze.filemanager.R;
@@ -23,11 +24,6 @@ import java.net.InetAddress;
  */
 public class FtpNotification extends BroadcastReceiver {
 
-    private static NotificationCompat.Builder builder;
-    private static CharSequence tickerText;
-    private static String contentTitle;
-    private static String contentText;
-
     @Override
     public void onReceive(Context context, Intent intent) {
         switch(intent.getAction()){
@@ -40,19 +36,21 @@ public class FtpNotification extends BroadcastReceiver {
         }
     }
 
-    private static void buildNotification(Context context){
+    private static NotificationCompat.Builder buildNotification(Context context,
+                                                                @StringRes int contentTitleRes,
+                                                                String contentText){
         Intent notificationIntent = new Intent(context, MainActivity.class);
         notificationIntent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP);
         PendingIntent contentIntent = PendingIntent.getActivity(context, 0, notificationIntent, 0);
 
         long when = System.currentTimeMillis();
 
-        builder  = new NotificationCompat.Builder(context, NotificationConstants.CHANNEL_FTP_ID)
-                .setContentTitle(contentTitle)
+        NotificationCompat.Builder builder = new NotificationCompat.Builder(context, NotificationConstants.CHANNEL_FTP_ID)
+                .setContentTitle(context.getString(contentTitleRes))
                 .setContentText(contentText)
                 .setContentIntent(contentIntent)
                 .setSmallIcon(R.drawable.ic_ftp_light)
-                .setTicker(tickerText)
+                .setTicker(context.getString( R.string.ftp_notif_starting))
                 .setWhen(when)
                 .setOngoing(true)
                 .setOnlyAlertOnce(true);
@@ -66,14 +64,13 @@ public class FtpNotification extends BroadcastReceiver {
         builder.addAction(stopIcon, stopText, stopPendingIntent);
 
         NotificationConstants.setMetadata(context, builder, NotificationConstants.TYPE_FTP);
+
+        return builder;
     }
 
     public static Notification startNotification(Context context){
-        tickerText = context.getString(R.string.ftp_notif_starting);
-        contentTitle = context.getString(R.string.ftp_notif_starting_title);
-        contentText = context.getString(R.string.ftp_notif_starting);
-
-        buildNotification(context);
+        NotificationCompat.Builder builder = buildNotification(context,
+                R.string.ftp_notif_starting_title, context.getString(R.string.ftp_notif_starting));
 
         return builder.build();
     }
@@ -92,11 +89,8 @@ public class FtpNotification extends BroadcastReceiver {
                 + address.getHostAddress() + ":"
                 + port + "/";
 
-        tickerText = context.getString(R.string.ftp_notif_starting);
-        contentTitle = context.getString(R.string.ftp_notif_title);
-        contentText = String.format(context.getString(R.string.ftp_notif_text), iptext);
-
-        buildNotification(context);
+        NotificationCompat.Builder builder = buildNotification(context,
+                R.string.ftp_notif_title, context.getString(R.string.ftp_notif_text, iptext));
 
         notificationManager.notify(NotificationConstants.FTP_ID, builder.build());
     }

--- a/app/src/main/java/com/amaze/filemanager/ui/notifications/FtpNotification.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/notifications/FtpNotification.java
@@ -1,6 +1,7 @@
 package com.amaze.filemanager.ui.notifications;
 
 import android.app.NotificationManager;
+import android.app.PendingIntent;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
@@ -25,7 +26,7 @@ public class FtpNotification extends BroadcastReceiver {
     public void onReceive(Context context, Intent intent) {
         switch(intent.getAction()){
             case FtpService.ACTION_STARTED:
-                createNotification(context, intent.getBooleanExtra(FtpService.TAG_STARTED_BY_TILE, false));
+                updateNotification(context);
                 break;
             case FtpService.ACTION_STOPPED:
                 removeNotification(context);
@@ -33,7 +34,7 @@ public class FtpNotification extends BroadcastReceiver {
         }
     }
 
-    private void createNotification(Context context, boolean noStopButton) {
+    private void updateNotification(Context context) {
 
         String notificationService = Context.NOTIFICATION_SERVICE;
         NotificationManager notificationManager = (NotificationManager) context.getSystemService(notificationService);
@@ -48,7 +49,7 @@ public class FtpNotification extends BroadcastReceiver {
                 + address.getHostAddress() + ":"
                 + port + "/";
 
-        NotificationCompat.Builder builder = FtpService.getBuilder();
+        NotificationCompat.Builder builder = new NotificationCompat.Builder(context.getApplicationContext(), NotificationConstants.CHANNEL_FTP_ID);
 
         int icon = R.drawable.ic_ftp_light;
         CharSequence tickerText = context.getString(R.string.ftp_notif_starting);
@@ -63,6 +64,14 @@ public class FtpNotification extends BroadcastReceiver {
                 .setTicker(tickerText)
                 .setWhen(when)
                 .setOngoing(true);
+
+        int stopIcon = android.R.drawable.ic_menu_close_clear_cancel;
+        CharSequence stopText = context.getString(R.string.ftp_notif_stop_server);
+        Intent stopIntent = new Intent(FtpService.ACTION_STOP_FTPSERVER).setPackage(context.getApplicationContext().getPackageName());
+        PendingIntent stopPendingIntent = PendingIntent.getBroadcast(context.getApplicationContext(), 0,
+                stopIntent, PendingIntent.FLAG_ONE_SHOT);
+
+        builder.addAction(stopIcon, stopText, stopPendingIntent);
 
         notificationManager.notify(NotificationConstants.FTP_ID, builder.build());
     }

--- a/app/src/main/java/com/amaze/filemanager/ui/notifications/FtpNotification.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/notifications/FtpNotification.java
@@ -46,7 +46,6 @@ public class FtpNotification extends BroadcastReceiver {
                 + address.getHostAddress() + ":"
                 + port + "/";
 
-        //TODO: is this an appropriate way to get the builder from FtpService to update the notification here?
         NotificationCompat.Builder builder = FtpService.getBuilder();
 
         int icon = R.drawable.ic_ftp_light;

--- a/app/src/main/java/com/amaze/filemanager/ui/notifications/NotificationConstants.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/notifications/NotificationConstants.java
@@ -30,9 +30,7 @@ public class NotificationConstants {
 
     public static final String CHANNEL_NORMAL_ID = "normalChannel";
     public static final String CHANNEL_FTP_ID = "ftpChannel";
-
-    public static final String CHANNEL_FTP_NAME = "FtpChannel";
-
+    
     /**
      * This creates a channel (API >= 26) or applies the correct metadata to a notification (API < 26)
      */

--- a/app/src/main/java/com/amaze/filemanager/ui/notifications/NotificationConstants.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/notifications/NotificationConstants.java
@@ -31,6 +31,8 @@ public class NotificationConstants {
     public static final String CHANNEL_NORMAL_ID = "normalChannel";
     public static final String CHANNEL_FTP_ID = "ftpChannel";
 
+    public static final String CHANNEL_FTP_NAME = "FtpChannel";
+
     /**
      * This creates a channel (API >= 26) or applies the correct metadata to a notification (API < 26)
      */

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -302,6 +302,7 @@
     <string name="domain">Domain</string>
     <string name="invalid">Invalid %s</string>
     <string name="ftp_notif_starting">FTP Server is starting</string>
+    <string name="ftp_notif_starting_title">FTP Server</string>
     <string name="ftp_notif_title">Amaze FTP Server running</string>
     <string name="ftp_notif_text">at %s</string>
     <string name="ftp_notif_stop_server">STOP</string>


### PR DESCRIPTION
I've observed Android shutting down the FTP Server on my Samsung S8+ running Android 9 and my Nexus 5x running LineageOS (Android 8.1.0). This service was not started as a foreground service and according to [Services overview](https://developer.android.com/guide/components/services): "If the service is bound to an activity that has user focus, it's less likely to be killed; if the service is declared to run in the foreground, it's rarely killed." 

The master branch code on both of my devices could not transfer large files via FTP because the version of Android on both of these phones killed the Service before the transfer was complete. The FTP Server service now stays running until it is stopped by the user. 

This PR improves the FTP Server performance, but it doesn't address Issue #1572.. Even with LineageOS, I could not duplicate the same behavior as Issue #1572. I also tried using a wakelock with the foreground service, but this combination did not help the user who submitted the issue. I think there is something beyond our control with that user's version of LineageOS that is taking over the FTP Service when his phone goes into standby. 

Even though I couldn't figure out what is going on with #1572, I believe this is still an improvement that should be included in future releases.

(edited by @TranceLove: please add # for convenient reference to issues/PR)