### PR TITLE
Fix Utils.getDate(Context, long, String) missing a format arg

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/adapters/CompressedExplorerAdapter.java
+++ b/app/src/main/java/com/amaze/filemanager/adapters/CompressedExplorerAdapter.java
@@ -219,7 +219,7 @@ public class CompressedExplorerAdapter extends RecyclerView.Adapter<CompressedIt
 
             final StringBuilder stringBuilder = new StringBuilder(rowItem.name);
             if (compressedExplorerFragment.showLastModified)
-                holder.date.setText(Utils.getDate(context, rowItem.date, compressedExplorerFragment.year));
+                holder.date.setText(Utils.getDate(context, rowItem.date));
             if (rowItem.directory) {
                 holder.genericIcon.setImageDrawable(folder);
                 gradientDrawable.setColor(compressedExplorerFragment.iconskin);

--- a/app/src/main/java/com/amaze/filemanager/adapters/data/LayoutElementParcelable.java
+++ b/app/src/main/java/com/amaze/filemanager/adapters/data/LayoutElementParcelable.java
@@ -114,7 +114,7 @@ public class LayoutElementParcelable implements Parcelable {
         this.isDirectory = isDirectory;
         if (!date.trim().equals("")) {
             this.date = Long.parseLong(date);
-            this.date1 = Utils.getDate(c, this.date, CURRENT_YEAR);
+            this.date1 = Utils.getDate(c, this.date);
         } else {
             this.date = 0;
             this.date1 = "";

--- a/app/src/main/java/com/amaze/filemanager/utils/Utils.java
+++ b/app/src/main/java/com/amaze/filemanager/utils/Utils.java
@@ -40,7 +40,7 @@ public class Utils {
     private static final String INPUT_INTENT_BLACKLIST_PIPE = "\\|";
     private static final String INPUT_INTENT_BLACKLIST_AMP = "&&";
     private static final String INPUT_INTENT_BLACKLIST_DOTS = "\\.\\.\\.";
-    private static final String DATE_TIME_FORMAT = "%s | %s %s";
+    private static final String DATE_TIME_FORMAT = "%s | %s";
 
     //methods for fastscroller
     public static float clamp(float min, float max, float value) {
@@ -73,16 +73,7 @@ public class Utils {
     }
 
     public static String getDate(@NonNull Context c, long f) {
-        return String.format(DATE_TIME_FORMAT,
-                DateUtils.formatDateTime(c, f, DateUtils.FORMAT_SHOW_DATE),
-                DateUtils.formatDateTime(c, f, DateUtils.FORMAT_SHOW_TIME));
-    }
-
-    public static String getDate(@NonNull Context c, long f, @NonNull String year) {
-        return String.format(DATE_TIME_FORMAT,
-                DateUtils.formatDateTime(c, f, DateUtils.FORMAT_SHOW_DATE),
-                DateUtils.formatDateTime(c, f, DateUtils.FORMAT_SHOW_TIME),
-                year);
+        return String.format(DATE_TIME_FORMAT, DateUtils.formatDateTime(c, f, DateUtils.FORMAT_SHOW_DATE), DateUtils.formatDateTime(c, f, DateUtils.FORMAT_SHOW_TIME));
     }
 
     /**


### PR DESCRIPTION
Fix Utils.getDate(Context, long, String) missing a format arg

Fix #1672 