### PR TITLE
Added code to check if decompressor is null. Throw a toast if it is.

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/fragments/CompressedExplorerFragment.java
+++ b/app/src/main/java/com/amaze/filemanager/fragments/CompressedExplorerFragment.java
@@ -406,19 +406,22 @@ public class CompressedExplorerFragment extends Fragment implements BottomBarBut
 
         boolean addGoBackItem = gobackitem && !isRoot(folder);
         String finalfolder = folder;
-        decompressor.changePath(folder, addGoBackItem, result -> {
-            if(result.exception == null) {
-                elements = result.result;
-                createViews(elements, finalfolder);
-                swipeRefreshLayout.setRefreshing(false);
-                updateBottomBar();
-            } else {
-                Toast.makeText(getActivity(), getActivity().getString(R.string.archive_unsupported_or_corrupt, compressedFile.getAbsolutePath()), Toast.LENGTH_LONG).show();
-                getActivity().getSupportFragmentManager().beginTransaction().remove(this).commit();
-            }
-        }).execute();
-        swipeRefreshLayout.setRefreshing(true);
-        updateBottomBar();
+        if(decompressor!=null) {
+            decompressor.changePath(folder, addGoBackItem, result -> {
+                if (result.exception == null) {
+                    elements = result.result;
+                    createViews(elements, finalfolder);
+                    swipeRefreshLayout.setRefreshing(false);
+                    updateBottomBar();
+                } else {
+                    archiveCorruptOrUnsupportedToast();
+                }
+            }).execute();
+            swipeRefreshLayout.setRefreshing(true);
+            updateBottomBar();
+        } else {
+            archiveCorruptOrUnsupportedToast();
+        }
     }
 
     @Override
@@ -497,6 +500,11 @@ public class CompressedExplorerFragment extends Fragment implements BottomBarBut
 
     private boolean isRoot(String folder) {
         return folder == null || folder.isEmpty();
+    }
+
+    private void archiveCorruptOrUnsupportedToast(){
+        Toast.makeText(getActivity(), getActivity().getString(R.string.archive_unsupported_or_corrupt, compressedFile.getAbsolutePath()), Toast.LENGTH_LONG).show();
+        getActivity().getSupportFragmentManager().beginTransaction().remove(this).commit();
     }
 
 }


### PR DESCRIPTION
I found that if the file type doesn't match a known compressed file type, the decompressor object returned by static method CompressedHelper.getCompressorInstance() is null. 

If decompressor is null, then the changePath() method throws the NPE on decompressor.changePath(). In order to prevent this, I check to make sure that decompressor is not null, and if it is I throw a toast to indicate there is an issue with the file. 

Depending on expectations, the UI response may need to be changed. 