### PR TITLE
Feature: add .nomedia to directories with checkbox in Properties

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/ui/dialogs/GeneralDialogCreation.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/dialogs/GeneralDialogCreation.java
@@ -415,7 +415,7 @@ public class GeneralDialogCreation {
             itemsText.setText(items);
             ((TextView) v.findViewById(R.id.t8)).setText(date);
 
-            if (baseFile.isDirectory()) {
+            if (baseFile.isDirectory() && baseFile.isLocal()) {
                 nomediaCheckBox.setVisibility(View.VISIBLE);
                 if (nomediaFile != null) {
                     nomediaCheckBox.setChecked(nomediaFile.exists());

--- a/app/src/main/java/com/amaze/filemanager/ui/dialogs/GeneralDialogCreation.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/dialogs/GeneralDialogCreation.java
@@ -420,8 +420,6 @@ public class GeneralDialogCreation {
                 if (nomediaFile != null) {
                     nomediaCheckBox.setChecked(nomediaFile.exists());
                 }
-            } else {
-                nomediaCheckBox.setVisibility(View.INVISIBLE);
             }
 
             LinearLayout mNameLinearLayout = v.findViewById(R.id.properties_dialog_name);
@@ -550,34 +548,26 @@ public class GeneralDialogCreation {
         builder.positiveColor(accentColor);
         builder.dismissListener(dialog -> executor.shutdown());
         builder.onPositive((dialog, which) -> {
-            if (baseFile.isDirectory()) {
-                if (nomediaFile != null) {
-                    if (nomediaCheckBox.isChecked()) {
-                        // checkbox is checked, create .nomedia
-                        try {
-                            if (!nomediaFile.createNewFile()) {
-                                // failed operation
-                                Log.w(TAG, "'.nomedia' file creation in " + baseFile.getPath()
-                                        + " failed!");
-                            }
-                        } catch (IOException e) {
-                            e.printStackTrace();
-                        }
-                    } else {
-                        // checkbox is unchecked, delete .nomedia
-                        if (!nomediaFile.delete()) {
+            if (baseFile.isDirectory() && nomediaFile != null) {
+                if (nomediaCheckBox.isChecked()) {
+                    // checkbox is checked, create .nomedia
+                    try {
+                        if (!nomediaFile.createNewFile()) {
                             // failed operation
-                            Log.w(TAG,
-                                    "'.nomedia' file deletion in " + baseFile.getPath()
-                                            + " failed!");
+                            Log.w(TAG, "'.nomedia' file creation in " + baseFile.getPath()
+                                    + " failed!");
                         }
+                    } catch (IOException e) {
+                        e.printStackTrace();
                     }
                 } else {
-                    // this should never happen
-                    Log.wtf(TAG,
-                            "'.nomedia' inside '" + baseFile.getPath() + "' shouldn't be null!");
-                    throw new NullPointerException(
-                            "'.nomedia' inside '" + baseFile.getPath() + "' shouldn't be null!");
+                    // checkbox is unchecked, delete .nomedia
+                    if (!nomediaFile.delete()) {
+                        // failed operation
+                        Log.w(TAG,
+                                "'.nomedia' file deletion in " + baseFile.getPath()
+                                        + " failed!");
+                    }
                 }
             }
         });

--- a/app/src/main/java/com/amaze/filemanager/utils/files/FileUtils.java
+++ b/app/src/main/java/com/amaze/filemanager/utils/files/FileUtils.java
@@ -99,6 +99,8 @@ import static androidx.core.content.FileProvider.getUriForFile;
  */
 public class FileUtils {
 
+    public static final String NOMEDIA_FILE = ".nomedia";
+
     public static long folderSize(File directory, OnProgressUpdate<Long> updateState) {
         long length = 0;
         try {

--- a/app/src/main/res/layout/properties_dialog.xml
+++ b/app/src/main/res/layout/properties_dialog.xml
@@ -156,14 +156,24 @@
                 android:text="@string/calculating"
                 android:textSize="@dimen/material_generic_title_summary"/>
         </LinearLayout>
+
+        <LinearLayout
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:paddingStart="-7dp"
+          android:paddingLeft="-7dp"
+          android:paddingRight="-7dp">
+            <CheckBox
+              android:id="@+id/nomediacheckbox"
+              android:layout_width="match_parent"
+              android:layout_height="wrap_content"
+              android:fontFamily="sans-serif-medium"
+              android:text="@string/hide_media"
+              android:visibility="gone"/>
+        </LinearLayout>
     </LinearLayout>
 
-    <CheckBox
-      android:id="@+id/nomediacheckbox"
-      android:layout_width="match_parent"
-      android:layout_height="wrap_content"
-      android:text="@string/hide_media"
-      android:visibility="gone"/>
+
 
     <com.github.mikephil.charting.charts.PieChart
         android:id="@+id/chart"

--- a/app/src/main/res/layout/properties_dialog.xml
+++ b/app/src/main/res/layout/properties_dialog.xml
@@ -158,6 +158,13 @@
         </LinearLayout>
     </LinearLayout>
 
+    <CheckBox
+      android:id="@+id/nomediacheckbox"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:text="@string/hide_media"
+      android:visibility="gone"/>
+
     <com.github.mikephil.charting.charts.PieChart
         android:id="@+id/chart"
         android:layout_width="match_parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -645,5 +645,6 @@
     <string name="empty_string" translatable="false" />
     <string name="cannot_extract_archive">Cannot extract archive \"%s\": %s</string>
     <string name="archive_unsupported_or_corrupt">Cannot open archive \"%s\". Either we cannot open the archive, or the archive was damaged.</string>
+    <string name="hide_media">Hide from media browsers</string>
 </resources>
 


### PR DESCRIPTION
Fixes #769, referenced #844.

Steps to reproduce:
1. Tap the "three dot" button the right of a folder.
2. Tap "Properties".
3. A checkbox labeled "Hide from media browsers" should be visible and its state reflecting the existence of the `.nomedia` file in that directory.
4. Toggle the checkbox and tap "OK". If the `.nomedia` file exists, it will be deleted; if the `.nomedia` file does not exist, it will be created.

Toggling the checkbox will not immediately delete the `.nomedia` file -- "OK" must be tapped in order to commit the action.