### PR TITLE
Use EventBus to transmit FtpReceiverActions of FTP server status

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -156,7 +156,8 @@ dependencies {
     // https://mvnrepository.com/artifact/org.apache.ftpserver/ftpserver-core
     implementation group: 'org.apache.ftpserver', name: 'ftpserver-core', version: '1.1.0'
 
-    //implementation 'com.jcraft:jsch:0.1.53'
+    implementation 'org.greenrobot:eventbus:3.1.1'
+
     implementation 'com.android.volley:volley:1.1.1'
 
     implementation 'eu.chainfire:libsuperuser:1.0.0.+'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -207,15 +207,6 @@
             </intent-filter>
         </receiver>
 
-        <receiver
-            android:name="com.amaze.filemanager.ui.notifications.FtpNotification"
-            android:exported="true">
-            <intent-filter>
-                <action android:name="com.amaze.filemanager.services.ftpservice.FTPReceiver.FTPSERVER_STARTED" />
-                <action android:name="com.amaze.filemanager.services.ftpservice.FTPReceiver.FTPSERVER_STOPPED" />
-            </intent-filter>
-        </receiver>
-        
         <provider
             android:authorities="${applicationId}.FILE_PROVIDER"
             android:name=".utils.GenericFileProvider"

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/services/ftp/FtpTileService.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/services/ftp/FtpTileService.java
@@ -13,35 +13,32 @@ import android.widget.Toast;
 
 import com.amaze.filemanager.R;
 
+import org.greenrobot.eventbus.EventBus;
+import org.greenrobot.eventbus.Subscribe;
+
 /**
  * Created by vishal on 1/1/17.
  */
 
 @TargetApi(Build.VERSION_CODES.N)
 public class FtpTileService extends TileService {
-    private BroadcastReceiver ftpReceiver = new BroadcastReceiver() {
-        @Override
-        public void onReceive(Context context, Intent intent) {
-            updateTileState();
-        }
-    };
+
+    @Subscribe
+    public void onFtpReceiverActions(FtpService.FtpReceiverActions signal) {
+        updateTileState();
+    }
 
     @Override
     public void onStartListening() {
         super.onStartListening();
-
-        IntentFilter f = new IntentFilter();
-        f.addAction(FtpService.ACTION_STARTED);
-        f.addAction(FtpService.ACTION_STOPPED);
-        registerReceiver(ftpReceiver, f);
+        EventBus.getDefault().register(this);
         updateTileState();
     }
 
     @Override
     public void onStopListening() {
         super.onStopListening();
-
-        unregisterReceiver(ftpReceiver);
+        EventBus.getDefault().unregister(this);
     }
 
     @Override

--- a/app/src/main/java/com/amaze/filemanager/fragments/FtpServerFragment.java
+++ b/app/src/main/java/com/amaze/filemanager/fragments/FtpServerFragment.java
@@ -33,6 +33,8 @@ import android.net.NetworkInfo;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
 import androidx.annotation.Nullable;
+
+import com.amaze.filemanager.ui.notifications.FtpNotification;
 import com.google.android.material.textfield.TextInputLayout;
 import androidx.fragment.app.Fragment;
 import androidx.appcompat.widget.AppCompatCheckBox;
@@ -60,10 +62,16 @@ import com.amaze.filemanager.utils.OneCharacterCharSequence;
 import com.amaze.filemanager.utils.Utils;
 import com.amaze.filemanager.utils.files.CryptUtil;
 
+import org.greenrobot.eventbus.EventBus;
+import org.greenrobot.eventbus.Subscribe;
+import org.greenrobot.eventbus.ThreadMode;
+
 import java.io.File;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.security.GeneralSecurityException;
+
+import static com.amaze.filemanager.asynchronous.services.ftp.FtpService.FtpReceiverActions.STARTED_FROM_TILE;
 
 /**
  * Created by yashwanthreddyg on 10-06-2016.
@@ -331,37 +339,35 @@ public class FtpServerFragment extends Fragment {
         }
     };
 
-    private BroadcastReceiver ftpReceiver = new BroadcastReceiver() {
-        @Override
-        public void onReceive(Context context, Intent intent) {
-            updateSpans();
-            switch (intent.getAction()) {
-                case FtpService.ACTION_STARTED:
-                    if (getSecurePreference()) {
-                        statusText.setText(spannedStatusSecure);
-                    } else {
-                        statusText.setText(spannedStatusConnected);
-                    }
-                    url.setText(spannedStatusUrl);
-                    ftpBtn.setText(getResources().getString(R.string.stop_ftp).toUpperCase());
-                    break;
-                case FtpService.ACTION_FAILEDTOSTART:
-                    statusText.setText(spannedStatusNotRunning);
+    @Subscribe(threadMode = ThreadMode.MAIN_ORDERED)
+    public void onFtpReceiveActions(FtpService.FtpReceiverActions signal) {
+        updateSpans();
+        switch (signal) {
+            case STARTED:
+            case STARTED_FROM_TILE:
+                if (getSecurePreference()) {
+                    statusText.setText(spannedStatusSecure);
+                } else {
+                    statusText.setText(spannedStatusConnected);
+                }
+                url.setText(spannedStatusUrl);
+                ftpBtn.setText(getResources().getString(R.string.stop_ftp).toUpperCase());
+                FtpNotification.updateNotification(getContext(), STARTED_FROM_TILE.equals(signal));
+                break;
+            case FAILED_TO_START:
+                statusText.setText(spannedStatusNotRunning);
+                Toast.makeText(getContext(), getResources().getString(R.string.unknown_error), Toast.LENGTH_LONG).show();
+                ftpBtn.setText(getResources().getString(R.string.start_ftp).toUpperCase());
+                url.setText("URL: ");
+                break;
 
-                    Toast.makeText(getContext(),
-                            getResources().getString(R.string.unknown_error), Toast.LENGTH_LONG).show();
-
-                    ftpBtn.setText(getResources().getString(R.string.start_ftp).toUpperCase());
-                    url.setText("URL: ");
-                    break;
-                case FtpService.ACTION_STOPPED:
-                    statusText.setText(spannedStatusNotRunning);
-                    url.setText("URL: ");
-                    ftpBtn.setText(getResources().getString(R.string.start_ftp).toUpperCase());
-                    break;
-            }
+            case STOPPED:
+                statusText.setText(spannedStatusNotRunning);
+                url.setText("URL: ");
+                ftpBtn.setText(getResources().getString(R.string.start_ftp).toUpperCase());
+                break;
         }
-    };
+    }
 
     /**
      * Sends a broadcast to start ftp server
@@ -384,18 +390,14 @@ public class FtpServerFragment extends Fragment {
         IntentFilter wifiFilter = new IntentFilter();
         wifiFilter.addAction(ConnectivityManager.CONNECTIVITY_ACTION);
         getContext().registerReceiver(mWifiReceiver, wifiFilter);
-        IntentFilter ftpFilter = new IntentFilter();
-        ftpFilter.addAction(FtpService.ACTION_STARTED);
-        ftpFilter.addAction(FtpService.ACTION_STOPPED);
-        ftpFilter.addAction(FtpService.ACTION_FAILEDTOSTART);
-        getContext().registerReceiver(ftpReceiver, ftpFilter);
+        EventBus.getDefault().register(this);
     }
 
     @Override
     public void onPause() {
         super.onPause();
         getContext().unregisterReceiver(mWifiReceiver);
-        getContext().unregisterReceiver(ftpReceiver);
+        EventBus.getDefault().unregister(this);
     }
 
     /**

--- a/app/src/main/java/com/amaze/filemanager/ui/notifications/FtpNotification.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/notifications/FtpNotification.java
@@ -22,19 +22,7 @@ import java.net.InetAddress;
  *
  * Edited by zent-co on 30-07-2019
  */
-public class FtpNotification extends BroadcastReceiver {
-
-    @Override
-    public void onReceive(Context context, Intent intent) {
-        switch(intent.getAction()){
-            case FtpService.ACTION_STARTED:
-                updateNotification(context, intent.getBooleanExtra(FtpService.TAG_STARTED_BY_TILE, false));
-                break;
-            case FtpService.ACTION_STOPPED:
-                removeNotification(context);
-                break;
-        }
-    }
+public class FtpNotification {
 
     private static NotificationCompat.Builder buildNotification(Context context,
                                                                 @StringRes int contentTitleRes,
@@ -78,7 +66,7 @@ public class FtpNotification extends BroadcastReceiver {
         return builder.build();
     }
 
-    private static void updateNotification(Context context, boolean noStopButton) {
+    public static void updateNotification(Context context, boolean noStopButton) {
         String notificationService = Context.NOTIFICATION_SERVICE;
         NotificationManager notificationManager = (NotificationManager) context.getSystemService(notificationService);
 


### PR DESCRIPTION
This reduces overhead and prevent malicious apps outside Amaze to clear FTP server status with Intents.

Tested only on Oneplus 2 running Slim7 (7.1.2) though.