### PR TITLE
Fix removing original SFTP server settings from memory

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/activities/MainActivity.java
+++ b/app/src/main/java/com/amaze/filemanager/activities/MainActivity.java
@@ -1659,7 +1659,7 @@ public class MainActivity extends PermissionsActivity implements SmbConnectionLi
         Bundle bundle = new Bundle();
         bundle.putString("name", name);
         bundle.putString("address", uri.getHost());
-        bundle.putString("port", Integer.toString(uri.getPort()));
+        bundle.putInt("port", uri.getPort());
         bundle.putString("path", path);
         bundle.putString("username", userinfo.indexOf(':') > 0 ?
                 userinfo.substring(0, userinfo.indexOf(':')) : userinfo);

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/ssh/SshAuthenticationTask.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/ssh/SshAuthenticationTask.java
@@ -57,13 +57,14 @@ import static com.amaze.filemanager.filesystem.ssh.SshConnectionPool.SSH_CONNECT
  * @see SSHClient#authPassword(String, String)
  * @see SSHClient#authPublickey(String, KeyProvider...)
  * @see com.amaze.filemanager.ui.dialogs.SftpConnectDialog#authenticateAndSaveSetup(String, String, int, String, String, String, String, KeyPair, boolean)
- * @see com.amaze.filemanager.filesystem.ssh.SshConnectionPool#create(Uri)
+ * @see com.amaze.filemanager.filesystem.ssh.SshConnectionPool#create(String)
  */
 public class SshAuthenticationTask extends AsyncTask<Void, Void, AsyncTaskResult<SSHClient>>
 {
     private final String hostname;
     private final int port;
     private final String hostKey;
+    private final String existingHostKey;
 
     private final String username;
     private final String password;
@@ -89,6 +90,24 @@ public class SshAuthenticationTask extends AsyncTask<Void, Void, AsyncTaskResult
         this.hostname = hostname;
         this.port = port;
         this.hostKey = hostKey;
+        this.existingHostKey = null;
+        this.username = username;
+        this.password = password;
+        this.privateKey = privateKey;
+    }
+
+    public SshAuthenticationTask(@NonNull String hostname,
+                                 @NonNull int port,
+                                 @NonNull String hostKey,
+                                 @NonNull String existingHostKey,
+                                 @NonNull String username,
+                                 String password,
+                                 KeyPair privateKey)
+    {
+        this.hostname = hostname;
+        this.port = port;
+        this.hostKey = hostKey;
+        this.existingHostKey = existingHostKey;
         this.username = username;
         this.password = password;
         this.privateKey = privateKey;

--- a/app/src/main/java/com/amaze/filemanager/filesystem/ssh/SshConnectionPool.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/ssh/SshConnectionPool.java
@@ -80,6 +80,24 @@ public class SshConnectionPool
     }
 
     /**
+     * Remove a SSH connection from connection pool. Disconnects from server before removing.
+     *
+     * For updating SSH connection settings.
+     *
+     * This method will silently end without feedback if the specified SSH connection URI does not
+     * exist in the connection pool.
+     *
+     * @param url SSH connection URI
+     */
+    public void removeConnection(@NonNull String url) {
+        url = SshClientUtils.extractBaseUriFrom(url);
+
+        if(connections.containsKey(url)) {
+            SshClientUtils.tryDisconnect(connections.remove(url));
+        }
+    }
+
+    /**
      * Obtain a {@link SSHClient} connection from the underlying connection pool.
      *
      * Beneath it will return the connection if it exists; otherwise it will create a new one and

--- a/app/src/main/java/com/amaze/filemanager/ui/dialogs/SftpConnectDialog.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/dialogs/SftpConnectDialog.java
@@ -166,12 +166,41 @@ public class SftpConnectDialog extends DialogFragment {
             final String password = !TextUtils.isEmpty(passwordET.getText()) ?
                     passwordET.getText().toString() : getArguments().getString("password", null);
 
+            //Get original SSH host key
             String sshHostKey = utilsHandler.getSshHostKey(deriveSftpPathFrom(hostname, port,
-                    username, password, selectedParsedKeyPair));
+                    username, getArguments().getString("password", null),
+                    selectedParsedKeyPair));
 
-            if (sshHostKey != null) {
-                authenticateAndSaveSetup(connectionName, hostname, port, sshHostKey, username,
-                        password, selectedParsedKeyPairName, selectedParsedKeyPair, edit);
+            if (!TextUtils.isEmpty(sshHostKey)) {
+                SshConnectionPool.getInstance().removeConnection(
+                        SshClientUtils.deriveSftpPathFrom(hostname, port, username, password,
+                                selectedParsedKeyPair));
+
+                //Verify SSH host key fingerprint by hand, prompt user to override if not match
+                new GetSshHostFingerprintTask(hostname, port, taskResult -> {
+                    PublicKey hostKey = taskResult.result;
+                    if(hostKey != null) {
+                        final String hostKeyFingerprint = SecurityUtils.getFingerprint(hostKey);
+                        if(hostKeyFingerprint.equals(sshHostKey)){
+                            authenticateAndSaveSetup(connectionName, hostname, port, sshHostKey,
+                                username, password, selectedParsedKeyPairName,
+                                selectedParsedKeyPair, edit);
+                        } else {
+                            new AlertDialog.Builder(context)
+                                .setTitle(R.string.ssh_connect_failed_host_key_changed_title)
+                                .setMessage(R.string.ssh_connect_failed_host_key_changed_prompt)
+                                .setPositiveButton(R.string.update_host_key, (dialog1, which1) -> {
+                                    authenticateAndSaveSetup(connectionName, hostname, port,
+                                        hostKeyFingerprint, username, password,
+                                        selectedParsedKeyPairName, selectedParsedKeyPair, edit);
+                                })
+                                .setNegativeButton(R.string.cancel_recommended, (dialog1, which1) -> dialog1.dismiss())
+                                .show();
+                        }
+                    }
+                }).execute();
+                
+
             } else {
                 new GetSshHostFingerprintTask(hostname, port, taskResult -> {
                     PublicKey hostKey = taskResult.result;

--- a/app/src/main/java/com/amaze/filemanager/ui/dialogs/SftpConnectDialog.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/dialogs/SftpConnectDialog.java
@@ -21,6 +21,7 @@
 
 package com.amaze.filemanager.ui.dialogs;
 
+import static android.text.TextUtils.isEmpty;
 import static com.amaze.filemanager.filesystem.ssh.SshClientUtils.deriveSftpPathFrom;
 
 import android.app.Activity;
@@ -32,7 +33,6 @@ import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
 import android.text.Editable;
-import android.text.TextUtils;
 import android.text.TextWatcher;
 import android.util.Log;
 import android.view.View;
@@ -163,15 +163,16 @@ public class SftpConnectDialog extends DialogFragment {
             final String hostname = addressET.getText().toString();
             final int port = Integer.parseInt(portET.getText().toString());
             final String username = usernameET.getText().toString();
-            final String password = !TextUtils.isEmpty(passwordET.getText()) ?
-                    passwordET.getText().toString() : getArguments().getString("password", null);
+            final String password = isEmpty(passwordET.getText()) ?
+                    getArguments().getString("password", null) :
+                    passwordET.getText().toString();
 
             //Get original SSH host key
             String sshHostKey = utilsHandler.getSshHostKey(deriveSftpPathFrom(hostname, port,
                     username, getArguments().getString("password", null),
                     selectedParsedKeyPair));
 
-            if (!TextUtils.isEmpty(sshHostKey)) {
+            if (!isEmpty(sshHostKey)) {
                 SshConnectionPool.getInstance().removeConnection(
                         SshClientUtils.deriveSftpPathFrom(hostname, port, username, password,
                                 selectedParsedKeyPair));
@@ -272,10 +273,10 @@ public class SftpConnectDialog extends DialogFragment {
                 int port = portET.getText().toString().length() > 0 ? Integer.parseInt(portET.getText().toString()) : -1;
                 boolean hasCredential = false;
                 if(edit) {
-                    if(passwordET.getText().length() > 0 || !TextUtils.isEmpty(getArguments().getString("password")))
+                    if(passwordET.getText().length() > 0 || !isEmpty(getArguments().getString("password")))
                         hasCredential = true;
                     else {
-                        hasCredential = !TextUtils.isEmpty(selectedParsedKeyPairName);
+                        hasCredential = !isEmpty(selectedParsedKeyPairName);
                     }
                 } else {
                     hasCredential = passwordET.getText().length() > 0 || selectedParsedKeyPair != null;

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -584,11 +584,7 @@ Wi-Fiに接続する必要があります。\n\n
     <string name="ssh_authentication_failure_key">ログインに失敗しました：指定されたユーザー名と秘密鍵で認証できません。</string>
     <string name="ssh_connect_failed">%1$s:%2$d に接続できません：%3$s</string>
     <string name="ssh_connect_failed_host_key_changed_title">警告: リモートホストのIDが変更されました!</string>
-    <string name="ssh_connect_failed_host_key_changed_message">
-誰かがおかしなことをしている可能性があります!\n\n
-誰かがあなたを盗聴している可能性があります (中間者攻撃)! ホスト鍵が変更された可能性もあります。 リモートホストから送信された公開鍵の指紋が、Amazeに保存されているものと一致しません。\n\n
-サーバへの接続を続行するには、システム管理者に連絡するか、新しい接続を設定してください。
-</string>
+    <string name="ssh_connect_failed_host_key_changed_message">誰かがおかしなことをしている可能性があります!\n\n誰かがあなたを盗聴している可能性があります (中間者攻撃)! ホスト鍵が変更された可能性もあります。 リモートホストから送信された公開鍵の指紋が、Amazeに保存されているものと一致しません。\n\nサーバへの接続を続行するには、システム管理者に連絡するか、新しい接続を設定してください。</string>
     <string name="ssh_key_prompt_passphrase">鍵のパスフレーズを入力ください。</string>
     <string name="add_shortcut_not_supported_by_launcher">ショートカットの作成はランチャーでサポートしておりません。</string>
     
@@ -637,5 +633,8 @@ Wi-Fiに接続する必要があります。\n\n
     <string name="archive_password_prompt">アーカイブのパスワードを入力ください。</string>
     <string name="cannot_extract_archive">アーカイブ \"%s\" を抽出できません: %s</string>
     <string name="archive_unsupported_or_corrupt">アーカイブ \"%s\" を開くことができません。 アーカイブを開くことができないか、アーカイブが破損しています。</string>
+    <string name="ssh_connect_failed_host_key_changed_prompt">誰かがおかしなことをしている可能性があります!\n\n誰かがあなたを盗聴している可能性があります (中間者攻撃)! ホスト鍵が変更された可能性もあります。 リモートホストから送信された公開鍵の指紋が、Amazeに保存されているものと一致しません。\n\nホスト鍵の更新を続行するか、SSH接続設定の更新をキャンセルする。</string>
+    <string name="update_host_key">ホスト鍵を更新</string>
+    <string name="cancel_recommended">キャンセル（推奨）</string>
 </resources>
 

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -633,9 +633,6 @@ Wi-Fiに接続する必要があります。\n\n
     <string name="archive_password_prompt">アーカイブのパスワードを入力ください。</string>
     <string name="cannot_extract_archive">アーカイブ \"%s\" を抽出できません: %s</string>
     <string name="archive_unsupported_or_corrupt">アーカイブ \"%s\" を開くことができません。 アーカイブを開くことができないか、アーカイブが破損しています。</string>
-    <string name="ssh_connect_failed_host_key_changed_prompt">誰かがおかしなことをしている可能性があります!\n\n誰かがあなたを盗聴している可能性があります (中間者攻撃)! ホスト鍵が変更された可能性もあります。 リモートホストから送信された公開鍵の指紋が、Amazeに保存されているものと一致しません。\n\nホスト鍵の更新を続行するか、SSH接続設定の更新をキャンセルする。</string>
-    <string name="update_host_key">ホスト鍵を更新</string>
-    <string name="cancel_recommended">キャンセル（推奨）</string>
     <string name="hide_media">メディアブラウザーから非表示</string>
 </resources>
 

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -598,7 +598,4 @@
   <string name="archive_password_prompt">請輸入壓縮檔的密碼。</string>
   <string name="cannot_extract_archive">不能開啟壓縮檔 \"%s\"： %s</string>
   <string name="archive_unsupported_or_corrupt">不能開啟壓縮檔 \"%s\"。可能是程式庫不支援此壓縮檔，或者壓縮檔真的壞掉了。</string>
-  <string name="ssh_connect_failed_host_key_changed_prompt">似乎有人有不軌企圖！\n\n可能有人在竊聽你的連線（中間人攻擊）！也有可能遠端主機的公鑰真的改變了。遠端主機傳來的公鑰指紋碼和 Amaze記錄的並不相符。\n\n你可以已更新的遠端主機公鑰，或者取消更新 SSH連線設定。</string>
-  <string name="update_host_key">更新遠端主機公鑰</string>
-  <string name="cancel_recommended">取消（建議）</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -559,11 +559,7 @@
   <string name="preselected_configs_title">已選擇的配色</string>
   <string name="ssh_host_key_verification_prompt_title">確認遠端主機</string>
   <string name="ssh_host_key_verification_prompt">未能確認遠端主機\'%1$s\'的身份。\n\n%2$s的公鑰指紋碼為 %3$s.\n\n請按「是」以確認其身份；否則請按「否」。</string>
-  <string name="ssh_connect_failed_host_key_changed_message">
-        似乎有人有不軌企圖！\n\n
-        可能有人在竊聽你的連線（中間人攻擊）！也有可能遠端主機的公鑰真的改變了。遠端主機傳來的公鑰指紋碼和 Amaze記錄的並不相符。\n\n
-        請聯絡你的系統管理員，或重新設定連線。
-    </string>
+  <string name="ssh_connect_failed_host_key_changed_message">似乎有人有不軌企圖！\n\n可能有人在竊聽你的連線（中間人攻擊）！也有可能遠端主機的公鑰真的改變了。遠端主機傳來的公鑰指紋碼和 Amaze記錄的並不相符。\n\n請聯絡你的系統管理員，或重新設定連線。</string>
   <string name="deselect_all">取消全選</string>
   <string name="about_amaze">Material設計風格的 Android檔案管理員</string>
   <string name="license">版權宣告</string>
@@ -594,12 +590,15 @@
   <string name="saved_multi_files">儲存了 %d 個檔案。</string>
   <string name="create_hidden_file_warn">此檔案將會從檔案列表中隱藏。</string>
   <string name="multiple_invalid_archive_entries">壓縮檔有部份檔案未能解壓；壓縮檔可能已損壞或來自不明的來源。</string>
-    <string name="unknown">未知</string>
+  <string name="unknown">未知</string>
   <string name="transfer_rate">傳輸速率</string>
   <string name="time_remaining">剩餘時間</string>
   <string name="grant_apkinstall_permission">程式需要安裝程式的權限以繼續。</string>
-    <string name="internalstorage">內部儲存空間</string>
+  <string name="internalstorage">內部儲存空間</string>
   <string name="archive_password_prompt">請輸入壓縮檔的密碼。</string>
   <string name="cannot_extract_archive">不能開啟壓縮檔 \"%s\"： %s</string>
   <string name="archive_unsupported_or_corrupt">不能開啟壓縮檔 \"%s\"。可能是程式庫不支援此壓縮檔，或者壓縮檔真的壞掉了。</string>
+  <string name="ssh_connect_failed_host_key_changed_prompt">似乎有人有不軌企圖！\n\n可能有人在竊聽你的連線（中間人攻擊）！也有可能遠端主機的公鑰真的改變了。遠端主機傳來的公鑰指紋碼和 Amaze記錄的並不相符。\n\n你可以已更新的遠端主機公鑰，或者取消更新 SSH連線設定。</string>
+  <string name="update_host_key">更新遠端主機公鑰</string>
+  <string name="cancel_recommended">取消（建議）</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -591,11 +591,7 @@
     <string name="ssh_authentication_failure_key">Logon failure: Unable to authenticate with supplied username and private key.</string>
     <string name="ssh_connect_failed">Unable to connect to %1$s:%2$d: %3$s</string>
     <string name="ssh_connect_failed_host_key_changed_title">WARNING: REMOTE HOST IDENTIFICATION HAS CHANGED!</string>
-    <string name="ssh_connect_failed_host_key_changed_message">
-        IT IS POSSIBLE THAT SOMEONE IS DOING SOMETHING NASTY!\n\n
-        Someone could be eavesdropping on you right now (man-in-the-middle attack)! It is also possible that the host key has just been changed. The fingerprint for the public key sent by the remote host does not match the one stored in Amaze.\n\n
-        Please contact your system administrator or setup a new connection to continue connecting to the server.
-    </string>
+    <string name="ssh_connect_failed_host_key_changed_message">IT IS POSSIBLE THAT SOMEONE IS DOING SOMETHING NASTY!\n\nSomeone could be eavesdropping on you right now (man-in-the-middle attack)! It is also possible that the host key has just been changed. The fingerprint for the public key sent by the remote host does not match the one stored in Amaze.\n\nPlease contact your system administrator or setup a new connection to continue connecting to the server.</string>
     <string name="ssh_key_prompt_passphrase">Please enter key passphrase.</string>
     <string name="add_shortcut_not_supported_by_launcher">Shortcuts creation is not supported by your launcher.</string>
     
@@ -646,5 +642,8 @@
     <string name="cannot_extract_archive">Cannot extract archive \"%s\": %s</string>
     <string name="archive_unsupported_or_corrupt">Cannot open archive \"%s\". Either we cannot open the archive, or the archive was damaged.</string>
     <string name="hide_media">Hide from media browsers</string>
+    <string name="ssh_connect_failed_host_key_changed_prompt">IT IS POSSIBLE THAT SOMEONE IS DOING SOMETHING NASTY!\n\nSomeone could be eavesdropping on you right now (man-in-the-middle attack)! It is also possible that the host key has just been changed. The fingerprint for the public key sent by the remote host does not match the one stored in Amaze.\n\nYou may proceed with updating host fingerprint or cancel updating SSH connection settings.</string>
+    <string name="update_host_key">Update Host Key</string>
+    <string name="cancel_recommended">Cancel (Recommended)</string>
 </resources>
 


### PR DESCRIPTION
Fixes #1773.

- use original SSH URI when SftpConnectDialog is in edit mode
- validation routine that causes editing SSH connection settings unable to update due to credential (not)being updated
- pass argument to SftpConnectDialog using integer