### PR TITLE
Update proguard config for eventbus

### DIFF
--- a/app/proguard.cfg
+++ b/app/proguard.cfg
@@ -124,6 +124,12 @@
 -keep class org.bouncycastle.jcajce.spec.* {*;}
 -keep class org.bouncycastle.jce.** {*;}
 
+#EventBus
+-keep class org.greenrobot.eventbus.** {*;}
+-keepclassmembers class * {
+    @org.greenrobot.eventbus.Subscribe *;
+}
+
 -dontwarn javax.naming.**
 
 #From here sshj. We are not using GSSAPI to connect to SSH


### PR DESCRIPTION
Fixes #1805. Please enable class minification (`minifyEnabled true`) in build.gradle if you're still doing debug builds.

Tested on Oneplus 2 running Slim7 (7.1.2) and Pixel 2 emulator running stock 9.0.