### PR TITLE
TextEditorActivity: Exit onCreate() if no URI provided in intent

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/activities/TextEditorActivity.java
+++ b/app/src/main/java/com/amaze/filemanager/activities/TextEditorActivity.java
@@ -193,6 +193,7 @@ public class TextEditorActivity extends ThemedActivity implements TextWatcher, V
         } else {
             Toast.makeText(this, R.string.no_file_error, Toast.LENGTH_LONG).show();
             finish();
+            return;
         }
 
         getSupportActionBar().setTitle(mFile.name);


### PR DESCRIPTION
Fixes #1808.

Previous `finish()` is not enough to quit the Activity but an additional `return` can do.

Tested on Oneplus 2 running Slim7 (7.1.2) and LG Nexus 5x running AOSPExtended (9.0).