### PR TITLE
Add mts file extension as video/mts

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/ui/icons/MimeTypes.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/icons/MimeTypes.java
@@ -138,6 +138,7 @@ public final class MimeTypes {
         MIME_TYPES.put("ogv", "video/ogg");
         MIME_TYPES.put("flv", "video/x-flv");
         MIME_TYPES.put("mkv", "video/x-matroska");
+        MIME_TYPES.put("mts", "video/mp2t");
 
         MIME_TYPES.put(CryptUtil.CRYPT_EXTENSION.replace(".", ""), "crypt/aze");
     }


### PR DESCRIPTION
Fixes #1696.

Tested on Oneplus 2 running Slim7 (7.1.2) with MX Player installed, and LG Nexus 5x running AOSPExtended (9.0) with VLC installed.