### PR TITLE
Restrict intents send to FtpReceiver to control FTP server

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -23,6 +23,9 @@
     xmlns:tools="http://schemas.android.com/tools"
     package="com.amaze.filemanager">
 
+    <permission android:name="com.amaze.filemanager.permission.CONTROL_FTP_SERVER"
+        android:protectionLevel="signature" />
+
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
@@ -200,7 +203,8 @@
 
         <receiver
             android:name=".asynchronous.services.ftp.FtpReceiver"
-            android:exported="true">
+            android:exported="true"
+            android:permission="com.amaze.filemanager.permission.CONTROL_FTP_SERVER">
             <intent-filter>
                 <action android:name="com.amaze.filemanager.services.ftpservice.FTPReceiver.ACTION_START_FTPSERVER" />
                 <action android:name="com.amaze.filemanager.services.ftpservice.FTPReceiver.ACTION_STOP_FTPSERVER" />

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/services/ftp/FtpReceiver.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/services/ftp/FtpReceiver.java
@@ -29,6 +29,4 @@ public class FtpReceiver extends BroadcastReceiver {
             Log.e(TAG, "Failed to start/stop on intent " + e.getMessage());
         }
     }
-
-
 }

--- a/app/src/main/java/com/amaze/filemanager/utils/Utils.java
+++ b/app/src/main/java/com/amaze/filemanager/utils/Utils.java
@@ -30,15 +30,16 @@ import android.content.res.Configuration;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
 import android.os.Build;
-import androidx.annotation.ColorRes;
-import androidx.annotation.NonNull;
-import androidx.core.content.ContextCompat;
-import androidx.core.graphics.drawable.DrawableCompat;
 import android.text.format.DateUtils;
 import android.util.DisplayMetrics;
 import android.view.View;
 import android.widget.CheckBox;
 import android.widget.Toast;
+
+import androidx.annotation.ColorRes;
+import androidx.annotation.NonNull;
+import androidx.core.content.ContextCompat;
+import androidx.core.graphics.drawable.DrawableCompat;
 
 import com.amaze.filemanager.R;
 import com.amaze.filemanager.activities.MainActivity;

--- a/app/src/test/java/com/amaze/filemanager/utils/files/FileListSorterTest.java
+++ b/app/src/test/java/com/amaze/filemanager/utils/files/FileListSorterTest.java
@@ -1,9 +1,13 @@
 package com.amaze.filemanager.utils.files;
 
+import android.content.Context;
+
 import com.amaze.filemanager.adapters.data.LayoutElementParcelable;
 import com.amaze.filemanager.utils.OpenMode;
 
+import org.junit.Before;
 import org.junit.Test;
+import org.robolectric.RuntimeEnvironment;
 
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.lessThan;
@@ -14,6 +18,13 @@ import static org.junit.Assert.*;
  * so, assume all extension is "*{slash}*"
  */
 public class FileListSorterTest {
+
+    private Context context;
+
+    @Before
+    public void setUp(){
+        context = RuntimeEnvironment.application.getApplicationContext();
+    }
     /**
      * Purpose: when dirsOnTop is 0, if file1 is directory && file2 is not directory, result is -1
      * Input: FileListSorter(0,0,1) dir(=dirsOnTop) is 0 / compare(file1,file2) file1 is dir, file2 is not dir
@@ -23,10 +34,10 @@ public class FileListSorterTest {
     @Test
     public void testDir0File1DirAndFile2NoDir() {
         FileListSorter fileListSorter = new FileListSorter(0,0,1);
-        LayoutElementParcelable file1 = new LayoutElementParcelable("abc1", "C:\\AmazeFileManager\\abc1", "user",
+        LayoutElementParcelable file1 = new LayoutElementParcelable(context, "abc1", "C:\\AmazeFileManager\\abc1", "user",
                 "symlink", "100", 123L, true,
                 "1234", true,false, OpenMode.UNKNOWN);
-        LayoutElementParcelable file2 = new LayoutElementParcelable("abc2.txt", "C:\\AmazeFileManager\\abc2", "user",
+        LayoutElementParcelable file2 = new LayoutElementParcelable(context, "abc2.txt", "C:\\AmazeFileManager\\abc2", "user",
                 "symlink", "101", 124L, true,
                 "1235", false,false, OpenMode.UNKNOWN);
 
@@ -48,10 +59,10 @@ public class FileListSorterTest {
     @Test
     public void testDir0File1NoDirAndFile2Dir() {
         FileListSorter fileListSorter = new FileListSorter(0,0,1);
-        LayoutElementParcelable file1 = new LayoutElementParcelable("abc1.txt", "C:\\AmazeFileManager\\abc1", "user",
+        LayoutElementParcelable file1 = new LayoutElementParcelable(context, "abc1.txt", "C:\\AmazeFileManager\\abc1", "user",
                 "symlink", "100", 123L, true,
                 "1234", false,false, OpenMode.UNKNOWN);
-        LayoutElementParcelable file2 = new LayoutElementParcelable("abc2", "C:\\AmazeFileManager\\abc2", "user",
+        LayoutElementParcelable file2 = new LayoutElementParcelable(context, "abc2", "C:\\AmazeFileManager\\abc2", "user",
                 "symlink", "101", 124L, true,
                 "1235", true,false, OpenMode.UNKNOWN);
 
@@ -67,10 +78,10 @@ public class FileListSorterTest {
     @Test
     public void testDir1File1DirAndFile2NoDir() {
         FileListSorter fileListSorter = new FileListSorter(1,0,1);
-        LayoutElementParcelable file1 = new LayoutElementParcelable("abc1", "C:\\AmazeFileManager\\abc1", "user",
+        LayoutElementParcelable file1 = new LayoutElementParcelable(context, "abc1", "C:\\AmazeFileManager\\abc1", "user",
                 "symlink", "100", 123L, true,
                 "1234", true,false, OpenMode.UNKNOWN);
-        LayoutElementParcelable file2 = new LayoutElementParcelable("abc2.txt", "C:\\AmazeFileManager\\abc2", "user",
+        LayoutElementParcelable file2 = new LayoutElementParcelable(context, "abc2.txt", "C:\\AmazeFileManager\\abc2", "user",
                 "symlink", "101", 124L, true,
                 "1235", false,false, OpenMode.UNKNOWN);
 
@@ -86,10 +97,10 @@ public class FileListSorterTest {
     @Test
     public void testDir1File1NoDirAndFile2Dir() {
         FileListSorter fileListSorter = new FileListSorter(1,0,1);
-        LayoutElementParcelable file1 = new LayoutElementParcelable("abc1.txt", "C:\\AmazeFileManager\\abc1", "user",
+        LayoutElementParcelable file1 = new LayoutElementParcelable(context, "abc1.txt", "C:\\AmazeFileManager\\abc1", "user",
                 "symlink", "100", 123L, true,
                 "1234", false,false, OpenMode.UNKNOWN);
-        LayoutElementParcelable file2 = new LayoutElementParcelable("abc2", "C:\\AmazeFileManager\\abc2", "user",
+        LayoutElementParcelable file2 = new LayoutElementParcelable(context, "abc2", "C:\\AmazeFileManager\\abc2", "user",
                 "symlink", "101", 124L, true,
                 "1235", true,false, OpenMode.UNKNOWN);
 
@@ -107,10 +118,10 @@ public class FileListSorterTest {
     @Test
     public void testSort0File1TitleBigger() {
         FileListSorter fileListSorter = new FileListSorter(-1,0,1);
-        LayoutElementParcelable file1 = new LayoutElementParcelable("abc1.txt", "C:\\AmazeFileManager\\abc1", "user",
+        LayoutElementParcelable file1 = new LayoutElementParcelable(context, "abc1.txt", "C:\\AmazeFileManager\\abc1", "user",
                 "symlink", "100", 123L, true,
                 "1234", false,false, OpenMode.UNKNOWN);
-        LayoutElementParcelable file2 = new LayoutElementParcelable("abc.txt", "C:\\AmazeFileManager\\abc", "user",
+        LayoutElementParcelable file2 = new LayoutElementParcelable(context, "abc.txt", "C:\\AmazeFileManager\\abc", "user",
                 "symlink", "101", 124L, true,
                 "1235", false,false, OpenMode.UNKNOWN);
 
@@ -126,10 +137,10 @@ public class FileListSorterTest {
     @Test
     public void testSort0File2TitleBigger() {
         FileListSorter fileListSorter = new FileListSorter(-1,0,1);
-        LayoutElementParcelable file1 = new LayoutElementParcelable("abc.txt", "C:\\AmazeFileManager\\abc", "user",
+        LayoutElementParcelable file1 = new LayoutElementParcelable(context, "abc.txt", "C:\\AmazeFileManager\\abc", "user",
                 "symlink", "100", 123L, true,
                 "1234", false,false, OpenMode.UNKNOWN);
-        LayoutElementParcelable file2 = new LayoutElementParcelable("abc2.txt", "C:\\AmazeFileManager\\abc2", "user",
+        LayoutElementParcelable file2 = new LayoutElementParcelable(context, "abc2.txt", "C:\\AmazeFileManager\\abc2", "user",
                 "symlink", "101", 124L, true,
                 "1235", false,false, OpenMode.UNKNOWN);
 
@@ -145,10 +156,10 @@ public class FileListSorterTest {
     @Test
     public void testSort0TitleSame() {
         FileListSorter fileListSorter = new FileListSorter(-1,0,1);
-        LayoutElementParcelable file1 = new LayoutElementParcelable("abc.txt", "C:\\AmazeFileManager\\abc", "user",
+        LayoutElementParcelable file1 = new LayoutElementParcelable(context, "abc.txt", "C:\\AmazeFileManager\\abc", "user",
                 "symlink", "100", 123L, true,
                 "1234", false,false, OpenMode.UNKNOWN);
-        LayoutElementParcelable file2 = new LayoutElementParcelable("ABC.txt", "C:\\AmazeFileManager\\ABC", "user",
+        LayoutElementParcelable file2 = new LayoutElementParcelable(context, "ABC.txt", "C:\\AmazeFileManager\\ABC", "user",
                 "symlink", "101", 124L, true,
                 "1235", false,false, OpenMode.UNKNOWN);
 
@@ -164,10 +175,10 @@ public class FileListSorterTest {
     @Test
     public void testSort1File1DateLastest() {
         FileListSorter fileListSorter = new FileListSorter(-1,1,1);
-        LayoutElementParcelable file1 = new LayoutElementParcelable("abc.txt", "C:\\AmazeFileManager\\abc", "user",
+        LayoutElementParcelable file1 = new LayoutElementParcelable(context, "abc.txt", "C:\\AmazeFileManager\\abc", "user",
                 "symlink", "100", 123L, true,
                 "1235", false,false, OpenMode.UNKNOWN);
-        LayoutElementParcelable file2 = new LayoutElementParcelable("abc2.txt", "C:\\AmazeFileManager\\abc2", "user",
+        LayoutElementParcelable file2 = new LayoutElementParcelable(context, "abc2.txt", "C:\\AmazeFileManager\\abc2", "user",
                 "symlink", "101", 124L, true,
                 "1234", false,false, OpenMode.UNKNOWN);
 
@@ -183,10 +194,10 @@ public class FileListSorterTest {
     @Test
     public void testSort1File2DateLastest() {
         FileListSorter fileListSorter = new FileListSorter(-1,1,1);
-        LayoutElementParcelable file1 = new LayoutElementParcelable("abc.txt", "C:\\AmazeFileManager\\abc", "user",
+        LayoutElementParcelable file1 = new LayoutElementParcelable(context, "abc.txt", "C:\\AmazeFileManager\\abc", "user",
                 "symlink", "100", 123L, true,
                 "1234", false,false, OpenMode.UNKNOWN);
-        LayoutElementParcelable file2 = new LayoutElementParcelable("abc2.txt", "C:\\AmazeFileManager\\abc2", "user",
+        LayoutElementParcelable file2 = new LayoutElementParcelable(context, "abc2.txt", "C:\\AmazeFileManager\\abc2", "user",
                 "symlink", "101", 124L, true,
                 "1235", false,false, OpenMode.UNKNOWN);
 
@@ -202,10 +213,10 @@ public class FileListSorterTest {
     @Test
     public void testSort1FileDateSame() {
         FileListSorter fileListSorter = new FileListSorter(-1,1,1);
-        LayoutElementParcelable file1 = new LayoutElementParcelable("abc.txt", "C:\\AmazeFileManager\\abc", "user",
+        LayoutElementParcelable file1 = new LayoutElementParcelable(context, "abc.txt", "C:\\AmazeFileManager\\abc", "user",
                 "symlink", "100", 123L, true,
                 "1234", false,false, OpenMode.UNKNOWN);
-        LayoutElementParcelable file2 = new LayoutElementParcelable("abc2.txt", "C:\\AmazeFileManager\\abc2", "user",
+        LayoutElementParcelable file2 = new LayoutElementParcelable(context, "abc2.txt", "C:\\AmazeFileManager\\abc2", "user",
                 "symlink", "101", 124L, true,
                 "1234", false,false, OpenMode.UNKNOWN);
 
@@ -221,10 +232,10 @@ public class FileListSorterTest {
     @Test
     public void testSort2NoDirAndFile1SizeBigger() {
         FileListSorter fileListSorter = new FileListSorter(-1,2,1);
-        LayoutElementParcelable file1 = new LayoutElementParcelable("abc.txt", "C:\\AmazeFileManager\\abc", "user",
+        LayoutElementParcelable file1 = new LayoutElementParcelable(context, "abc.txt", "C:\\AmazeFileManager\\abc", "user",
                 "symlink", "101", 124L, true,
                 "1234", false,false, OpenMode.UNKNOWN);
-        LayoutElementParcelable file2 = new LayoutElementParcelable("abc2.txt", "C:\\AmazeFileManager\\abc2", "user",
+        LayoutElementParcelable file2 = new LayoutElementParcelable(context, "abc2.txt", "C:\\AmazeFileManager\\abc2", "user",
                 "symlink", "100", 123L, true,
                 "1234", false,false, OpenMode.UNKNOWN);
 
@@ -240,10 +251,10 @@ public class FileListSorterTest {
     @Test
     public void testSort2NoDirAndFile2SizeBigger() {
         FileListSorter fileListSorter = new FileListSorter(-1,2,1);
-        LayoutElementParcelable file1 = new LayoutElementParcelable("abc.txt", "C:\\AmazeFileManager\\abc", "user",
+        LayoutElementParcelable file1 = new LayoutElementParcelable(context, "abc.txt", "C:\\AmazeFileManager\\abc", "user",
                 "symlink", "100", 123L, true,
                 "1234", false,false, OpenMode.UNKNOWN);
-        LayoutElementParcelable file2 = new LayoutElementParcelable("abc2.txt", "C:\\AmazeFileManager\\abc2", "user",
+        LayoutElementParcelable file2 = new LayoutElementParcelable(context, "abc2.txt", "C:\\AmazeFileManager\\abc2", "user",
                 "symlink", "101", 124L, true,
                 "1234", false,false, OpenMode.UNKNOWN);
 
@@ -259,10 +270,10 @@ public class FileListSorterTest {
     @Test
     public void testSort2NoDirAndFileSizeSame() {
         FileListSorter fileListSorter = new FileListSorter(-1,2,1);
-        LayoutElementParcelable file1 = new LayoutElementParcelable("abc.txt", "C:\\AmazeFileManager\\abc", "user",
+        LayoutElementParcelable file1 = new LayoutElementParcelable(context, "abc.txt", "C:\\AmazeFileManager\\abc", "user",
                 "symlink", "100", 123L, true,
                 "1234", false,false, OpenMode.UNKNOWN);
-        LayoutElementParcelable file2 = new LayoutElementParcelable("abc2.txt", "C:\\AmazeFileManager\\abc2", "user",
+        LayoutElementParcelable file2 = new LayoutElementParcelable(context, "abc2.txt", "C:\\AmazeFileManager\\abc2", "user",
                 "symlink", "100", 123L, true,
                 "1234", false,false, OpenMode.UNKNOWN);
 
@@ -278,10 +289,10 @@ public class FileListSorterTest {
     @Test
     public void testSort2File1DirAndFile1TitleBigger() {
         FileListSorter fileListSorter = new FileListSorter(-1,2,1);
-        LayoutElementParcelable file1 = new LayoutElementParcelable("abc1", "C:\\AmazeFileManager\\abc1", "user",
+        LayoutElementParcelable file1 = new LayoutElementParcelable(context, "abc1", "C:\\AmazeFileManager\\abc1", "user",
                 "symlink", "101", 124L, true,
                 "1234", true,false, OpenMode.UNKNOWN);
-        LayoutElementParcelable file2 = new LayoutElementParcelable("abc.txt", "C:\\AmazeFileManager\\abc", "user",
+        LayoutElementParcelable file2 = new LayoutElementParcelable(context, "abc.txt", "C:\\AmazeFileManager\\abc", "user",
                 "symlink", "100", 123L, true,
                 "1234", false,false, OpenMode.UNKNOWN);
 
@@ -297,10 +308,10 @@ public class FileListSorterTest {
     @Test
     public void testSort2File1DirAndFile2TitleBigger() {
         FileListSorter fileListSorter = new FileListSorter(-1,2,1);
-        LayoutElementParcelable file1 = new LayoutElementParcelable("abc", "C:\\AmazeFileManager\\abc", "user",
+        LayoutElementParcelable file1 = new LayoutElementParcelable(context, "abc", "C:\\AmazeFileManager\\abc", "user",
                 "symlink", "100", 123L, true,
                 "1234", true,false, OpenMode.UNKNOWN);
-        LayoutElementParcelable file2 = new LayoutElementParcelable("abc2.txt", "C:\\AmazeFileManager\\abc2", "user",
+        LayoutElementParcelable file2 = new LayoutElementParcelable(context, "abc2.txt", "C:\\AmazeFileManager\\abc2", "user",
                 "symlink", "101", 124L, true,
                 "1234", false,false, OpenMode.UNKNOWN);
 
@@ -316,10 +327,10 @@ public class FileListSorterTest {
     @Test
     public void testSort2File2DirAndFile1TitleBigger() {
         FileListSorter fileListSorter = new FileListSorter(-1,2,1);
-        LayoutElementParcelable file1 = new LayoutElementParcelable("abc1.txt", "C:\\AmazeFileManager\\abc1", "user",
+        LayoutElementParcelable file1 = new LayoutElementParcelable(context, "abc1.txt", "C:\\AmazeFileManager\\abc1", "user",
                 "symlink", "101", 124L, true,
                 "1234", false,false, OpenMode.UNKNOWN);
-        LayoutElementParcelable file2 = new LayoutElementParcelable("abc", "C:\\AmazeFileManager\\abc", "user",
+        LayoutElementParcelable file2 = new LayoutElementParcelable(context, "abc", "C:\\AmazeFileManager\\abc", "user",
                 "symlink", "100", 123L, true,
                 "1234", true,false, OpenMode.UNKNOWN);
 
@@ -335,10 +346,10 @@ public class FileListSorterTest {
     @Test
     public void testSort2File2DirAndFile2TitleBigger() {
         FileListSorter fileListSorter = new FileListSorter(-1,2,1);
-        LayoutElementParcelable file1 = new LayoutElementParcelable("abc.txt", "C:\\AmazeFileManager\\abc", "user",
+        LayoutElementParcelable file1 = new LayoutElementParcelable(context, "abc.txt", "C:\\AmazeFileManager\\abc", "user",
                 "symlink", "100", 123L, true,
                 "1234", false,false, OpenMode.UNKNOWN);
-        LayoutElementParcelable file2 = new LayoutElementParcelable("abc2", "C:\\AmazeFileManager\\abc2", "user",
+        LayoutElementParcelable file2 = new LayoutElementParcelable(context, "abc2", "C:\\AmazeFileManager\\abc2", "user",
                 "symlink", "101", 124L, true,
                 "1234", true,false, OpenMode.UNKNOWN);
 
@@ -354,10 +365,10 @@ public class FileListSorterTest {
     @Test
     public void testSort2File2DirAndFileTitleSame() {
         FileListSorter fileListSorter = new FileListSorter(-1,2,1);
-        LayoutElementParcelable file1 = new LayoutElementParcelable("abc", "C:\\AmazeFileManager\\abc", "user",
+        LayoutElementParcelable file1 = new LayoutElementParcelable(context, "abc", "C:\\AmazeFileManager\\abc", "user",
                 "symlink", "100", 123L, true,
                 "1234", true,false, OpenMode.UNKNOWN);
-        LayoutElementParcelable file2 = new LayoutElementParcelable("abc", "C:\\AmazeFileManager\\abc", "user",
+        LayoutElementParcelable file2 = new LayoutElementParcelable(context, "abc", "C:\\AmazeFileManager\\abc", "user",
                 "symlink", "101", 124L, true,
                 "1234", true,false, OpenMode.UNKNOWN);
 
@@ -373,10 +384,10 @@ public class FileListSorterTest {
     @Test
     public void testSort3FileExtensionSameAndFile1TitleBigger() {
         FileListSorter fileListSorter = new FileListSorter(-1,3,1);
-        LayoutElementParcelable file1 = new LayoutElementParcelable("abc1.txt", "C:\\AmazeFileManager\\abc1", "user",
+        LayoutElementParcelable file1 = new LayoutElementParcelable(context, "abc1.txt", "C:\\AmazeFileManager\\abc1", "user",
                 "symlink", "100", 123L, true,
                 "1234", false,false, OpenMode.UNKNOWN);
-        LayoutElementParcelable file2 = new LayoutElementParcelable("abc.txt", "C:\\AmazeFileManager\\abc", "user",
+        LayoutElementParcelable file2 = new LayoutElementParcelable(context, "abc.txt", "C:\\AmazeFileManager\\abc", "user",
                 "symlink", "101", 124L, true,
                 "1234", false,false, OpenMode.UNKNOWN);
 
@@ -392,10 +403,10 @@ public class FileListSorterTest {
     @Test
     public void testSort3FileExtensionSameAndFile2TitleBigger() {
         FileListSorter fileListSorter = new FileListSorter(-1,3,1);
-        LayoutElementParcelable file1 = new LayoutElementParcelable("abc.txt", "C:\\AmazeFileManager\\abc", "user",
+        LayoutElementParcelable file1 = new LayoutElementParcelable(context, "abc.txt", "C:\\AmazeFileManager\\abc", "user",
                 "symlink", "100", 123L, true,
                 "1234", false,false, OpenMode.UNKNOWN);
-        LayoutElementParcelable file2 = new LayoutElementParcelable("abc2.txt", "C:\\AmazeFileManager\\abc2", "user",
+        LayoutElementParcelable file2 = new LayoutElementParcelable(context, "abc2.txt", "C:\\AmazeFileManager\\abc2", "user",
                 "symlink", "101", 124L, true,
                 "1234", false,false, OpenMode.UNKNOWN);
 
@@ -411,10 +422,10 @@ public class FileListSorterTest {
     @Test
     public void testSort3FileExtensionSameAndFileTitleSame() {
         FileListSorter fileListSorter = new FileListSorter(-1,3,1);
-        LayoutElementParcelable file1 = new LayoutElementParcelable("abc.txt", "C:\\AmazeFileManager\\abc", "user",
+        LayoutElementParcelable file1 = new LayoutElementParcelable(context, "abc.txt", "C:\\AmazeFileManager\\abc", "user",
                 "symlink", "100", 123L, true,
                 "1234", false,false, OpenMode.UNKNOWN);
-        LayoutElementParcelable file2 = new LayoutElementParcelable("ABC.txt", "C:\\AmazeFileManager\\ABC", "user",
+        LayoutElementParcelable file2 = new LayoutElementParcelable(context, "ABC.txt", "C:\\AmazeFileManager\\ABC", "user",
                 "symlink", "101", 124L, true,
                 "1234", false,false, OpenMode.UNKNOWN);
 
@@ -430,10 +441,10 @@ public class FileListSorterTest {
     @Test
     public void testSortAnotherNumber() {
         FileListSorter fileListSorter = new FileListSorter(-1,4,1);
-        LayoutElementParcelable file1 = new LayoutElementParcelable("abc.txt", "C:\\AmazeFileManager\\abc", "user",
+        LayoutElementParcelable file1 = new LayoutElementParcelable(context, "abc.txt", "C:\\AmazeFileManager\\abc", "user",
                 "symlink", "100", 123L, true,
                 "1234", false,false, OpenMode.UNKNOWN);
-        LayoutElementParcelable file2 = new LayoutElementParcelable("ABC.txt", "C:\\AmazeFileManager\\ABC", "user",
+        LayoutElementParcelable file2 = new LayoutElementParcelable(context, "ABC.txt", "C:\\AmazeFileManager\\ABC", "user",
                 "symlink", "101", 124L, true,
                 "1234", false,false, OpenMode.UNKNOWN);
 


### PR DESCRIPTION
Per mail discussion offline it is found that any app may fire an Intent with action `com.amaze.filemanager.services.ftpservice.FTPReceiver.ACTION_START_FTPSERVER` or `com.amaze.filemanager.services.ftpservice.FTPReceiver.ACTION_STOP_FTPSERVER` to control Amaze's built-in FTP server without user acknowledgement.

Changes in changeset
- add a custom permission `com.amaze.filemanager.permission.CONTROL_FTP_SERVER` and set it at `signature` level
- `FtpService` requires `com.amaze.filemanager.permission.CONTROL_FTP_SERVER` permission
- Intents sent to `FtpReceiver` requires package name which is sender's app package name. Will check if the app is installed; also it will deny intents sent from system apps - they won't send intents to us anyway

This can be considered as a "part 1" of the bigger task on improving FTP server security; another PR will be created for re-enabling integration with external apps, by prompting user on external apps sending intents to `FtpReceiver`.