### PR TITLE
Restrict intents sent to control FTP server to Amaze only

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -23,6 +23,9 @@
     xmlns:tools="http://schemas.android.com/tools"
     package="com.amaze.filemanager">
 
+    <permission android:name="com.amaze.filemanager.permission.CONTROL_FTP_SERVER"
+        android:protectionLevel="dangerous" />
+
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
@@ -186,7 +189,8 @@
         <service
             android:name=".asynchronous.services.ftp.FtpService"
             android:enabled="true"
-            android:exported="true" />
+            android:exported="true"
+            android:permission="com.amaze.filemanager.permission.CONTROL_FTP_SERVER"/>
 
         <service android:name=".asynchronous.services.ftp.FtpTileService"
             android:icon="@drawable/ic_ftp_dark"
@@ -200,7 +204,8 @@
 
         <receiver
             android:name=".asynchronous.services.ftp.FtpReceiver"
-            android:exported="true">
+            android:exported="true"
+            android:permission="com.amaze.filemanager.permission.CONTROL_FTP_SERVER">
             <intent-filter>
                 <action android:name="com.amaze.filemanager.services.ftpservice.FTPReceiver.ACTION_START_FTPSERVER" />
                 <action android:name="com.amaze.filemanager.services.ftpservice.FTPReceiver.ACTION_STOP_FTPSERVER" />


### PR DESCRIPTION
Per mail discussion offline it is found that any app may fire an Intent with action com.amaze.filemanager.services.ftpservice.FTPReceiver.ACTION_START_FTPSERVER or com.amaze.filemanager.services.ftpservice.FTPReceiver.ACTION_STOP_FTPSERVER to control Amaze's built-in FTP server without user acknowledgement.

Changes in changeset

- add a custom permission com.amaze.filemanager.permission.CONTROL_FTP_SERVER and set it at signature level
- FtpService requires com.amaze.filemanager.permission.CONTROL_FTP_SERVER permission
- so only Amaze would be able to send intents to start/stop the FTP server

This supercedes #1814 which contained unfinished code that makes the PR difficult to understand. Its work (to work out a way to allow third-party apps to start/stop Amaze's FTP server) will continue on another PR.