### PR TITLE
Fix #1817 Use root-path in provider

### DIFF
--- a/app/src/main/res/xml/provider_paths.xml
+++ b/app/src/main/res/xml/provider_paths.xml
@@ -1,5 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <paths>
     <external-path path="Android/data/com.amaze.filemanager/" name="package_root" />
-    <external-path path="." name="storage_root" />
+    <!--
+    root-path is suggested in https://stackoverflow.com/q/42516126
+    as a workaround to access files only accessible via root
+    -->
+    <root-path path="." name="storage_root" />
 </paths>


### PR DESCRIPTION
Fixes #1817.

Related issues:
https://issuetracker.google.com/issues/36981306
https://stackoverflow.com/questions/42516126/fileprovider-illegalargumentexception-failed-to-find-configured-root

Using `root-path` seems to be the only working (and undocumented) workaround.

Please test this with non-root and external storage (sdcard).

_(Edited by @TranceLove: Added tag for auto-closing issue)_