### PR TITLE
Use package name as CONTROL_FTP_SERVER permission & FileProvider prefix

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -23,7 +23,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     package="com.amaze.filemanager">
 
-    <permission android:name="com.amaze.filemanager.permission.CONTROL_FTP_SERVER"
+    <permission android:name="${applicationId}.permission.CONTROL_FTP_SERVER"
         android:protectionLevel="dangerous" />
 
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
@@ -190,7 +190,7 @@
             android:name=".asynchronous.services.ftp.FtpService"
             android:enabled="true"
             android:exported="true"
-            android:permission="com.amaze.filemanager.permission.CONTROL_FTP_SERVER"/>
+            android:permission="${applicationId}.permission.CONTROL_FTP_SERVER"/>
 
         <service android:name=".asynchronous.services.ftp.FtpTileService"
             android:icon="@drawable/ic_ftp_dark"
@@ -205,7 +205,7 @@
         <receiver
             android:name=".asynchronous.services.ftp.FtpReceiver"
             android:exported="true"
-            android:permission="com.amaze.filemanager.permission.CONTROL_FTP_SERVER">
+            android:permission="${applicationId}.permission.CONTROL_FTP_SERVER">
             <intent-filter>
                 <action android:name="com.amaze.filemanager.services.ftpservice.FTPReceiver.ACTION_START_FTPSERVER" />
                 <action android:name="com.amaze.filemanager.services.ftpservice.FTPReceiver.ACTION_STOP_FTPSERVER" />
@@ -214,7 +214,7 @@
 
         <provider
             android:name="androidx.core.content.FileProvider"
-            android:authorities="com.amaze.filemanager"
+            android:authorities="${applicationId}"
             android:exported="false"
             android:grantUriPermissions="true">
             <meta-data

--- a/app/src/main/java/com/amaze/filemanager/utils/Utils.java
+++ b/app/src/main/java/com/amaze/filemanager/utils/Utils.java
@@ -217,7 +217,7 @@ public class Utils {
             case ROOT:
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
 
-                    return FileProvider.getUriForFile(context, FileUtils.FILE_PROVIDER_AUTHORITY,
+                    return FileProvider.getUriForFile(context, context.getPackageName(),
                             new File(baseFile.getPath()));
                 } else {
                     return Uri.fromFile(new File(baseFile.getPath()));

--- a/app/src/main/java/com/amaze/filemanager/utils/files/FileUtils.java
+++ b/app/src/main/java/com/amaze/filemanager/utils/files/FileUtils.java
@@ -94,7 +94,6 @@ import java.util.concurrent.atomic.AtomicLong;
  */
 public class FileUtils {
 
-    public static final String FILE_PROVIDER_AUTHORITY = "com.amaze.filemanager";
     public static final String NOMEDIA_FILE = ".nomedia";
 
     public static long folderSize(File directory, OnProgressUpdate<Long> updateState) {
@@ -355,7 +354,7 @@ public class FileUtils {
         ArrayList<Uri> uris = new ArrayList<>();
         boolean b = true;
         for (File f : a) {
-            uris.add(FileProvider.getUriForFile(c, FILE_PROVIDER_AUTHORITY, f));
+            uris.add(FileProvider.getUriForFile(c, c.getPackageName(), f));
         }
 
         String mime = MimeTypes.getMimeType(a.get(0).getPath(), a.get(0).isDirectory());
@@ -395,7 +394,7 @@ public class FileUtils {
         String type = "application/vnd.android.package-archive";
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-            Uri downloadedApk = FileProvider.getUriForFile(permissionsActivity.getApplicationContext(), "com.amaze.filemanager", f);
+            Uri downloadedApk = FileProvider.getUriForFile(permissionsActivity.getApplicationContext(), permissionsActivity.getPackageName(), f);
             intent.setDataAndType(downloadedApk, type);
             intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
         } else {
@@ -529,7 +528,7 @@ public class FileUtils {
         }
 
         chooserIntent.setFlags(Intent.FLAG_ACTIVITY_NO_HISTORY | Intent.FLAG_GRANT_READ_URI_PERMISSION);
-        return FileProvider.getUriForFile(context, FILE_PROVIDER_AUTHORITY, file);
+        return FileProvider.getUriForFile(context, context.getPackageName(), file);
     }
 
     private static Uri fileToContentUri(Context context, String path, boolean isDirectory, String volume) {


### PR DESCRIPTION
Hardcoding `CONTROL_FTP_SERVER` permission name and `FileProvider` name prefix prevents release and debug/developer build co-existence. This commit changes them to use app package name as prefix.