### PR TITLE
Shortcut path fix

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/utils/DataUtils.java
+++ b/app/src/main/java/com/amaze/filemanager/utils/DataUtils.java
@@ -22,6 +22,7 @@
  */
 package com.amaze.filemanager.utils;
 
+import android.text.TextUtils;
 import android.view.MenuItem;
 import androidx.annotation.Nullable;
 import com.amaze.filemanager.ui.views.drawer.MenuMetadata;
@@ -426,7 +427,8 @@ public class DataUtils {
 
     public void putDrawerMetadata(MenuItem item, MenuMetadata metadata) {
         menuMetadataMap.put(item, metadata);
-        if(metadata.path != null) tree.put(metadata.path, item.getItemId());
+        if(!TextUtils.isEmpty(metadata.path))
+            tree.put(metadata.path, item.getItemId());
     }
 
     /**

--- a/app/src/main/res/layout/dialog_twoedittexts.xml
+++ b/app/src/main/res/layout/dialog_twoedittexts.xml
@@ -9,32 +9,32 @@
               android:paddingRight="24dp"
               android:paddingStart="24dp">
 
-    <com.google.android.material.textfield.TextInputLayout
+    <com.amaze.filemanager.ui.views.WarnableTextInputLayout
         android:id="@+id/text_input1"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         app:errorEnabled="false">
 
-        <androidx.appcompat.widget.AppCompatEditText
+        <EditText
             android:id="@+id/text1"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_gravity="center_horizontal"
             android:inputType="text"/>
-    </com.google.android.material.textfield.TextInputLayout>
+    </com.amaze.filemanager.ui.views.WarnableTextInputLayout>
 
-    <com.google.android.material.textfield.TextInputLayout
+    <com.amaze.filemanager.ui.views.WarnableTextInputLayout
         android:id="@+id/text_input2"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         app:errorEnabled="true">
 
-        <androidx.appcompat.widget.AppCompatEditText
+        <EditText
             android:id="@+id/text2"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_gravity="center_horizontal"
             android:inputType="text"/>
-    </com.google.android.material.textfield.TextInputLayout>
+    </com.amaze.filemanager.ui.views.WarnableTextInputLayout>
 
 </LinearLayout>


### PR DESCRIPTION
Fixes #1858.

- Null/empty check for shortcut path before insert into sidebar. Should never happen, but for safety
- Changed the dialog for create/edit shortcuts to use `WarnableTextInputLayout`