### PR TITLE
Use getStorageVolumes()

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/activities/MainActivity.java
+++ b/app/src/main/java/com/amaze/filemanager/activities/MainActivity.java
@@ -632,7 +632,7 @@ public class MainActivity extends PermissionsActivity implements SmbConnectionLi
             StorageManager sm = getSystemService(StorageManager.class);
             for (StorageVolume volume : sm.getStorageVolumes()) {
                 Log.i("MainActivity", "Volume: " + volume + "");
-                if (!volume.getState().equals(Environment.MEDIA_MOUNTED)) {
+                if (!volume.getState().equalsIgnoreCase(Environment.MEDIA_MOUNTED) && !volume.getState().equalsIgnoreCase(Environment.MEDIA_MOUNTED_READ_ONLY)) {
                     continue;
                 }
                 File path = Utils.getVolumeDirectory (volume);

--- a/app/src/main/java/com/amaze/filemanager/activities/MainActivity.java
+++ b/app/src/main/java/com/amaze/filemanager/activities/MainActivity.java
@@ -652,7 +652,12 @@ public class MainActivity extends PermissionsActivity implements SmbConnectionLi
                 icon = R.drawable.ic_phone_android_white_24dp;
             } else {
                 // There is no reliable way to distinguish USB and SD external storage
-                icon = R.drawable.ic_sd_storage_white_24dp;
+                // However it is often enough to check for "USB" String
+                if (name.toUpperCase().contains("USB") || path.getPath().toUpperCase().contains("USB")) {
+                    icon = R.drawable.ic_usb_white_24dp;
+                } else {
+                    icon = R.drawable.ic_sd_storage_white_24dp;
+                }
             }
             volumes.add(new StorageDirectoryParcelable(path.getPath(), name, icon));
         }

--- a/app/src/main/java/com/amaze/filemanager/activities/MainActivity.java
+++ b/app/src/main/java/com/amaze/filemanager/activities/MainActivity.java
@@ -1142,7 +1142,7 @@ public class MainActivity extends PermissionsActivity implements SmbConnectionLi
         unregisterReceiver(mainActivityHelper.mNotificationReceiver);
         unregisterReceiver(receiver2);
 
-        if (SDK_INT >= Build.VERSION_CODES.KITKAT) {
+        if (SDK_INT >= Build.VERSION_CODES.KITKAT && SDK_INT < Build.VERSION_CODES.N) {
             unregisterReceiver(mOtgReceiver);
         }
         killToast();
@@ -1166,7 +1166,7 @@ public class MainActivity extends PermissionsActivity implements SmbConnectionLi
         registerReceiver(mainActivityHelper.mNotificationReceiver, newFilter);
         registerReceiver(receiver2, new IntentFilter(TAG_INTENT_FILTER_GENERAL));
 
-        if (SDK_INT >= Build.VERSION_CODES.KITKAT) {
+        if (SDK_INT >= Build.VERSION_CODES.KITKAT && SDK_INT < Build.VERSION_CODES.N) {
             updateUsbInformation();
         }
     }

--- a/app/src/main/java/com/amaze/filemanager/adapters/data/StorageDirectoryParcelable.java
+++ b/app/src/main/java/com/amaze/filemanager/adapters/data/StorageDirectoryParcelable.java
@@ -1,0 +1,60 @@
+package com.amaze.filemanager.adapters.data;
+
+import android.os.Parcel;
+import android.os.Parcelable;
+
+import androidx.annotation.DrawableRes;
+import androidx.annotation.NonNull;
+
+import java.io.File;
+
+/**
+ * Identifies a mounted volume
+ */
+public class StorageDirectoryParcelable implements Parcelable {
+    public final String path;
+    public final String name;
+    public final @DrawableRes int iconRes;
+
+    public StorageDirectoryParcelable(String path, String name, int iconRes) {
+        this.path = path;
+        this.name = name;
+        this.iconRes = iconRes;
+    }
+
+    public StorageDirectoryParcelable(Parcel im) {
+        path = im.readString();
+        name = im.readString();
+        iconRes = im.readInt();
+    }
+
+    @NonNull
+    @Override
+    public String toString() {
+        return "StorageDirectory(path=" + path + ", name=" + name + ", icon=" + iconRes + ")";
+    }
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(Parcel parcel, int i) {
+        parcel.writeString(path);
+        parcel.writeString(name);
+        parcel.writeInt(iconRes);
+    }
+
+    public static final Creator<StorageDirectoryParcelable> CREATOR =
+            new Creator<StorageDirectoryParcelable>() {
+                public StorageDirectoryParcelable createFromParcel(Parcel in) {
+                    return new StorageDirectoryParcelable(in);
+                }
+
+                public StorageDirectoryParcelable[] newArray(int size) {
+                    return new StorageDirectoryParcelable[size];
+                }
+            };
+
+}

--- a/app/src/main/java/com/amaze/filemanager/filesystem/StorageNaming.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/StorageNaming.java
@@ -1,0 +1,31 @@
+package com.amaze.filemanager.filesystem;
+
+import android.content.Context;
+
+import com.amaze.filemanager.R;
+
+import java.io.File;
+
+public final class StorageNaming {
+
+    /**
+     * Retrofit of {@link android.os.storage.StorageVolume#getDescription(Context)} to older apis
+     */
+    public static String getDeviceDescriptionLegacy(Context context, File file) {
+        String path = file.getPath();
+
+        switch (path) {
+            case "/storage/emulated/legacy":
+            case "/storage/emulated/0":
+            case "/mnt/sdcard":
+                return context.getString(R.string.storage_internal);
+            case "/storage/sdcard":
+            case "/storage/sdcard1":
+                return context.getString(R.string.storage_sd_card);
+            case "/":
+                return context.getString(R.string.root_directory);
+            default:
+                return file.getName();
+        }
+    }
+}

--- a/app/src/main/java/com/amaze/filemanager/fragments/TabFragment.java
+++ b/app/src/main/java/com/amaze/filemanager/fragments/TabFragment.java
@@ -240,21 +240,6 @@ public class TabFragment extends Fragment
         else return a;
     }
 
-    String parsePathForName(String path, OpenMode openmode) {
-        Resources resources = getActivity().getResources();
-        if ("/".equals(path)) {
-            return resources.getString(R.string.root_directory);
-        } else if (openmode == OpenMode.SMB && path.startsWith("smb:/")) {
-            return (new File(parseSmbPath(path)).getName());
-        } else if ("/storage/emulated/0".equals(path)) {
-            return resources.getString(R.string.internalstorage);
-        } else if (openmode == OpenMode.CUSTOM) {
-            return new MainActivityHelper(mainActivity).getIntegralNames(path);
-        } else {
-            return new File(path).getName();
-        }
-    }
-
     @Override
     public void onSaveInstanceState(Bundle outState) {
         super.onSaveInstanceState(outState);

--- a/app/src/main/java/com/amaze/filemanager/ui/views/drawer/Drawer.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/views/drawer/Drawer.java
@@ -34,6 +34,8 @@ import androidx.annotation.ColorInt;
 import androidx.annotation.DrawableRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.StringRes;
+
+import com.amaze.filemanager.adapters.data.StorageDirectoryParcelable;
 import com.google.android.material.navigation.NavigationView;
 import androidx.legacy.app.ActionBarDrawerToggle;
 import androidx.fragment.app.FragmentTransaction;
@@ -86,6 +88,7 @@ import com.cloudrail.si.services.OneDrive;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 
 import static android.os.Build.VERSION.SDK_INT;
 import static com.amaze.filemanager.fragments.preference_fragments.PreferencesConstants.PREFERENCE_SHOW_SIDEBAR_FOLDERS;
@@ -255,34 +258,25 @@ public class Drawer implements NavigationView.OnNavigationItemSelectedListener {
         actionViewStateManager.deselectCurrentActionView();
 
         int order = 0;
-        ArrayList<String> storageDirectories = mainActivity.getStorageDirectories();
+        ArrayList<StorageDirectoryParcelable> storageDirectories = mainActivity.getStorageDirectories();
+        ArrayList<String> storageDirectoryPaths = new ArrayList<>();
         phoneStorageCount = 0;
-        for (String file : storageDirectories) {
+        for (StorageDirectoryParcelable storageDirectory : storageDirectories) {
+            String file = storageDirectory.path;
+            File f = new File(file);
+            String name = storageDirectory.name;
+            int icon = storageDirectory.iconRes;
+
+            storageDirectoryPaths.add(file);
+
             if (file.contains(OTGUtil.PREFIX_OTG)) {
                 addNewItem(menu, STORAGES_GROUP, order++, "OTG", new MenuMetadata(file),
                         R.drawable.ic_usb_white_24dp, R.drawable.ic_show_chart_black_24dp);
                 continue;
             }
 
-            File f = new File(file);
-            String name;
-            @DrawableRes int icon1;
-            if ("/storage/emulated/legacy".equals(file) || "/storage/emulated/0".equals(file) || "/mnt/sdcard".equals(file)) {
-                name = resources.getString(R.string.internalstorage);
-                icon1 = R.drawable.ic_phone_android_white_24dp;
-            } else if ("/storage/sdcard1".equals(file)) {
-                name = resources.getString(R.string.extstorage);
-                icon1 = R.drawable.ic_sd_storage_white_24dp;
-            } else if ("/".equals(file)) {
-                name = resources.getString(R.string.root_directory);
-                icon1 = R.drawable.ic_drawer_root_white;
-            } else {
-                name = f.getName();
-                icon1 = R.drawable.ic_sd_storage_white_24dp;
-            }
-
             if (f.isDirectory() || f.canExecute()) {
-                addNewItem(menu, STORAGES_GROUP, order++, name, new MenuMetadata(file), icon1,
+                addNewItem(menu, STORAGES_GROUP, order++, name, new MenuMetadata(file), icon,
                         R.drawable.ic_show_chart_black_24dp);
                 if(phoneStorageCount == 0) firstPath = file;
                 else if(phoneStorageCount == 1) secondPath = file;
@@ -290,7 +284,7 @@ public class Drawer implements NavigationView.OnNavigationItemSelectedListener {
                 phoneStorageCount++;
             }
         }
-        dataUtils.setStorages(storageDirectories);
+        dataUtils.setStorages(storageDirectoryPaths);
 
         if (dataUtils.getServers().size() > 0) {
             Collections.sort(dataUtils.getServers(), new BookSorter());

--- a/app/src/main/java/com/amaze/filemanager/utils/Utils.java
+++ b/app/src/main/java/com/amaze/filemanager/utils/Utils.java
@@ -22,6 +22,7 @@
 
 package com.amaze.filemanager.utils;
 
+import android.annotation.TargetApi;
 import android.app.Activity;
 import android.content.Context;
 import android.content.pm.ActivityInfo;
@@ -35,6 +36,8 @@ import androidx.annotation.NonNull;
 import androidx.core.content.ContextCompat;
 import androidx.core.content.FileProvider;
 import androidx.core.graphics.drawable.DrawableCompat;
+
+import android.os.storage.StorageVolume;
 import android.text.format.DateUtils;
 import android.util.DisplayMetrics;
 import android.view.View;
@@ -47,6 +50,7 @@ import com.amaze.filemanager.filesystem.HybridFileParcelable;
 import com.amaze.filemanager.utils.files.FileUtils;
 
 import java.io.File;
+import java.lang.reflect.Field;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -264,5 +268,17 @@ public class Utils {
         final long min = TimeUnit.SECONDS.toMinutes(timerInSeconds);
         final long sec = TimeUnit.SECONDS.toSeconds(timerInSeconds - TimeUnit.MINUTES.toSeconds(min));
         return String.format("%02d:%02d", min, sec);
+    }
+
+    @TargetApi(Build.VERSION_CODES.N)
+    public static File getVolumeDirectory(StorageVolume volume) {
+        try {
+            Field f = StorageVolume.class.getDeclaredField("mPath");
+            f.setAccessible(true);
+            return (File) f.get(volume);
+        } catch (Exception e) {
+            // This shouldn't fail, as mPath has been there in every version
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/app/src/main/res/values-ast-rES/strings.xml
+++ b/app/src/main/res/values-ast-rES/strings.xml
@@ -227,7 +227,7 @@ inestable\'l preséu.\\n¿Siguir?</string>
   <string name="username">Nome d\'usuariu</string>
   <string name="password">Contraseña</string>
   <string name="anonymous">Anónimu</string>
-    <string name="folders">Carpetes</string>
+  <string name="folders">Carpetes</string>
   <string name="videos">Vídeos</string>
   <string name="apks">APKs</string>
   <string name="documents">Documentos</string>

--- a/app/src/main/res/values-ast-rES/strings.xml
+++ b/app/src/main/res/values-ast-rES/strings.xml
@@ -227,8 +227,7 @@ inestable\'l preséu.\\n¿Siguir?</string>
   <string name="username">Nome d\'usuariu</string>
   <string name="password">Contraseña</string>
   <string name="anonymous">Anónimu</string>
-  <string name="extstorage">Almacenamientu esternu</string>
-  <string name="folders">Carpetes</string>
+    <string name="folders">Carpetes</string>
   <string name="videos">Vídeos</string>
   <string name="apks">APKs</string>
   <string name="documents">Documentos</string>

--- a/app/src/main/res/values-be-rBY/strings.xml
+++ b/app/src/main/res/values-be-rBY/strings.xml
@@ -237,8 +237,7 @@
   <string name="password">Пароль</string>
   <string name="anonymous">Ананімна</string>
   <string name="bluetooth">Bluetooth</string>
-  <string name="extstorage">Знешняе сховішча</string>
-  <string name="folders">Тэчкi</string>
+    <string name="folders">Тэчкi</string>
   <string name="videos">Відэа</string>
   <string name="apks">Apk</string>
   <string name="documents">Дакументы</string>

--- a/app/src/main/res/values-be-rBY/strings.xml
+++ b/app/src/main/res/values-be-rBY/strings.xml
@@ -237,7 +237,7 @@
   <string name="password">Пароль</string>
   <string name="anonymous">Ананімна</string>
   <string name="bluetooth">Bluetooth</string>
-    <string name="folders">Тэчкi</string>
+  <string name="folders">Тэчкi</string>
   <string name="videos">Відэа</string>
   <string name="apks">Apk</string>
   <string name="documents">Дакументы</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -204,8 +204,7 @@
   <string name="password">Парола</string>
   <string name="anonymous">Анонимен</string>
   <string name="bluetooth">Bluetooth</string>
-  <string name="extstorage">Външна памет</string>
-  <string name="folders">Папки</string>
+    <string name="folders">Папки</string>
   <string name="videos">Видео</string>
   <string name="apks">Apks</string>
   <string name="documents">Документи</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -204,7 +204,7 @@
   <string name="password">Парола</string>
   <string name="anonymous">Анонимен</string>
   <string name="bluetooth">Bluetooth</string>
-    <string name="folders">Папки</string>
+  <string name="folders">Папки</string>
   <string name="videos">Видео</string>
   <string name="apks">Apks</string>
   <string name="documents">Документи</string>

--- a/app/src/main/res/values-bn/strings.xml
+++ b/app/src/main/res/values-bn/strings.xml
@@ -452,8 +452,6 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
     <string name="bluetooth">Bluetooth</string>
 
-    <string name="extstorage">External Storage</string>
-
     <string name="folders">Folders</string>
 
     <string name="videos">Videos</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -237,7 +237,7 @@
   <string name="password">Heslo</string>
   <string name="anonymous">Anonymní</string>
   <string name="bluetooth">Zařízení Bluetooth</string>
-    <string name="folders">Složky</string>
+  <string name="folders">Složky</string>
   <string name="videos">Videa</string>
   <string name="apks">Aplikace</string>
   <string name="documents">Dokumenty</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -237,8 +237,7 @@
   <string name="password">Heslo</string>
   <string name="anonymous">Anonymní</string>
   <string name="bluetooth">Zařízení Bluetooth</string>
-  <string name="extstorage">Externí úložiště</string>
-  <string name="folders">Složky</string>
+    <string name="folders">Složky</string>
   <string name="videos">Videa</string>
   <string name="apks">Aplikace</string>
   <string name="documents">Dokumenty</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -237,8 +237,7 @@
   <string name="password">Passwort</string>
   <string name="anonymous">Unbekannt</string>
   <string name="bluetooth">Bluetooth</string>
-  <string name="extstorage">Externer Speicher</string>
-  <string name="folders">Verzeichnisse</string>
+    <string name="folders">Verzeichnisse</string>
   <string name="videos">Videos</string>
   <string name="apks">APKs</string>
   <string name="documents">Dokumente</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -237,7 +237,7 @@
   <string name="password">Passwort</string>
   <string name="anonymous">Unbekannt</string>
   <string name="bluetooth">Bluetooth</string>
-    <string name="folders">Verzeichnisse</string>
+  <string name="folders">Verzeichnisse</string>
   <string name="videos">Videos</string>
   <string name="apks">APKs</string>
   <string name="documents">Dokumente</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -233,8 +233,7 @@
   <string name="password">Κωδικός</string>
   <string name="anonymous">Ανώνυμος</string>
   <string name="bluetooth">Bluetooth</string>
-  <string name="extstorage">Κάρτα μνήμης</string>
-  <string name="folders">Φάκελοι</string>
+    <string name="folders">Φάκελοι</string>
   <string name="videos">Βίντεο</string>
   <string name="apks">Apks</string>
   <string name="documents">Έγγραφα</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -233,7 +233,7 @@
   <string name="password">Κωδικός</string>
   <string name="anonymous">Ανώνυμος</string>
   <string name="bluetooth">Bluetooth</string>
-    <string name="folders">Φάκελοι</string>
+  <string name="folders">Φάκελοι</string>
   <string name="videos">Βίντεο</string>
   <string name="apks">Apks</string>
   <string name="documents">Έγγραφα</string>

--- a/app/src/main/res/values-eo/strings.xml
+++ b/app/src/main/res/values-eo/strings.xml
@@ -246,7 +246,6 @@
     <string name="password">Pasvorto</string>
     <string name="anonymous">Sennoma</string>
     <string name="bluetooth">Bludenta</string>
-    <string name="extstorage">Ekstera memoro</string>
     <string name="folders">Dosierujoj</string>
     <string name="folderfilecount">%1$d dosierujoj kaj %2$d dosieroj</string>
     <string name="videos">Videoj</string>

--- a/app/src/main/res/values-es-rCO/strings.xml
+++ b/app/src/main/res/values-es-rCO/strings.xml
@@ -233,7 +233,7 @@
   <string name="password">Contraseña</string>
   <string name="anonymous">Anónimo</string>
   <string name="bluetooth">Bluetooth</string>
-    <string name="folders">Directorios</string>
+  <string name="folders">Directorios</string>
   <string name="apks">APKs</string>
   <string name="documents">Documentos</string>
   <string name="images">Imágenes</string>

--- a/app/src/main/res/values-es-rCO/strings.xml
+++ b/app/src/main/res/values-es-rCO/strings.xml
@@ -233,8 +233,7 @@
   <string name="password">Contraseña</string>
   <string name="anonymous">Anónimo</string>
   <string name="bluetooth">Bluetooth</string>
-  <string name="extstorage">Almacenamiento externo</string>
-  <string name="folders">Directorios</string>
+    <string name="folders">Directorios</string>
   <string name="apks">APKs</string>
   <string name="documents">Documentos</string>
   <string name="images">Imágenes</string>

--- a/app/src/main/res/values-es-rMX/strings.xml
+++ b/app/src/main/res/values-es-rMX/strings.xml
@@ -233,7 +233,7 @@
   <string name="password">Contraseña</string>
   <string name="anonymous">Anónimo</string>
   <string name="bluetooth">Bluetooth</string>
-    <string name="folders">Directorios</string>
+  <string name="folders">Directorios</string>
   <string name="apks">APKs</string>
   <string name="documents">Documentos</string>
   <string name="images">Imágenes</string>

--- a/app/src/main/res/values-es-rMX/strings.xml
+++ b/app/src/main/res/values-es-rMX/strings.xml
@@ -233,8 +233,7 @@
   <string name="password">Contraseña</string>
   <string name="anonymous">Anónimo</string>
   <string name="bluetooth">Bluetooth</string>
-  <string name="extstorage">Almacenamiento externo</string>
-  <string name="folders">Directorios</string>
+    <string name="folders">Directorios</string>
   <string name="apks">APKs</string>
   <string name="documents">Documentos</string>
   <string name="images">Imágenes</string>

--- a/app/src/main/res/values-es-rUS/strings.xml
+++ b/app/src/main/res/values-es-rUS/strings.xml
@@ -237,7 +237,7 @@
   <string name="password">Contraseña</string>
   <string name="anonymous">Anónimo</string>
   <string name="bluetooth">Bluetooth</string>
-    <string name="folders">Directorios</string>
+  <string name="folders">Directorios</string>
   <string name="videos">Vídeos</string>
   <string name="apks">APKs</string>
   <string name="documents">Documentos</string>

--- a/app/src/main/res/values-es-rUS/strings.xml
+++ b/app/src/main/res/values-es-rUS/strings.xml
@@ -237,8 +237,7 @@
   <string name="password">Contraseña</string>
   <string name="anonymous">Anónimo</string>
   <string name="bluetooth">Bluetooth</string>
-  <string name="extstorage">Almacenamiento externo</string>
-  <string name="folders">Directorios</string>
+    <string name="folders">Directorios</string>
   <string name="videos">Vídeos</string>
   <string name="apks">APKs</string>
   <string name="documents">Documentos</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -242,7 +242,6 @@
     <string name="password">Contraseña</string>
     <string name="anonymous">Anónimo</string>
     <string name="bluetooth">Bluetooth</string>
-    <string name="extstorage">Almacenamiento externo</string>
     <string name="folders">Carpetas</string>
     <string name="videos">Vídeos</string>
     <string name="apks">APKs</string>

--- a/app/src/main/res/values-eu-rES/strings.xml
+++ b/app/src/main/res/values-eu-rES/strings.xml
@@ -26,7 +26,6 @@
     <string name="drawer_open">Ireki nabigazio tiradera</string>
     <string name="drawer_close">Itxi nabigazio tiradera</string>
     <string name="icon">ikonoa</string>
-    <string name="internalstorage">Barneko biltegia</string>
     <string name="apps">Aplikazio kudeatzailea</string>
     <string name="ftp">FTP zerbitzaria</string>
     <string name="setting">Ezarpenak</string>
@@ -249,7 +248,6 @@
     <string name="password">Pasahitza</string>
     <string name="anonymous">Anonimoa</string>
     <string name="bluetooth">Bluetooth</string>
-    <string name="extstorage">Kanpoko biltegia</string>
     <string name="folders">Karpetak</string>
     <string name="folderfilecount">%1$d karpeta eta %2$d fitxategi</string>
     <string name="videos">Bideoak</string>

--- a/app/src/main/res/values-eu/strings.xml
+++ b/app/src/main/res/values-eu/strings.xml
@@ -26,7 +26,6 @@
     <string name="drawer_open">Ireki nabigazio tiradera</string>
     <string name="drawer_close">Itxi nabigazio tiradera</string>
     <string name="icon">ikonoa</string>
-    <string name="internalstorage">Barneko biltegia</string>
     <string name="apps">Aplikazio kudeatzailea</string>
     <string name="ftp">FTP zerbitzaria</string>
     <string name="setting">Ezarpenak</string>
@@ -249,7 +248,6 @@
     <string name="password">Pasahitza</string>
     <string name="anonymous">Anonimoa</string>
     <string name="bluetooth">Bluetooth</string>
-    <string name="extstorage">Kanpoko biltegia</string>
     <string name="folders">Karpetak</string>
     <string name="folderfilecount">%1$d karpeta eta %2$d fitxategi</string>
     <string name="videos">Bideoak</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -227,7 +227,7 @@
   <string name="password">رمز عبور</string>
   <string name="anonymous">نامشخص</string>
   <string name="bluetooth">بلوث</string>
-    <string name="folders">پوشه ها</string>
+  <string name="folders">پوشه ها</string>
   <string name="videos">ویدئوها</string>
   <string name="apks">برنامه ها</string>
   <string name="documents">اسناد</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -227,8 +227,7 @@
   <string name="password">رمز عبور</string>
   <string name="anonymous">نامشخص</string>
   <string name="bluetooth">بلوث</string>
-  <string name="extstorage">منبع خارجی</string>
-  <string name="folders">پوشه ها</string>
+    <string name="folders">پوشه ها</string>
   <string name="videos">ویدئوها</string>
   <string name="apks">برنامه ها</string>
   <string name="documents">اسناد</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -233,8 +233,7 @@
   <string name="password">Salasana</string>
   <string name="anonymous">Anonyymi</string>
   <string name="bluetooth">Bluetooth</string>
-  <string name="extstorage">Ulkoinen muisti</string>
-  <string name="folders">Kansiot</string>
+    <string name="folders">Kansiot</string>
   <string name="videos">Videot</string>
   <string name="apks">APK:t</string>
   <string name="documents">Dokumentit</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -233,7 +233,7 @@
   <string name="password">Salasana</string>
   <string name="anonymous">Anonyymi</string>
   <string name="bluetooth">Bluetooth</string>
-    <string name="folders">Kansiot</string>
+  <string name="folders">Kansiot</string>
   <string name="videos">Videot</string>
   <string name="apks">APK:t</string>
   <string name="documents">Dokumentit</string>

--- a/app/src/main/res/values-fr-rCA/strings.xml
+++ b/app/src/main/res/values-fr-rCA/strings.xml
@@ -238,8 +238,7 @@
   <string name="password">Mot de passe</string>
   <string name="anonymous">Anonyme</string>
   <string name="bluetooth">Bluetooth</string>
-  <string name="extstorage">Stockage Externe</string>
-  <string name="folders">Dossiers</string>
+    <string name="folders">Dossiers</string>
   <string name="videos">Vidéos</string>
   <string name="apks">Apks</string>
   <string name="documents">Documents</string>

--- a/app/src/main/res/values-fr-rCA/strings.xml
+++ b/app/src/main/res/values-fr-rCA/strings.xml
@@ -238,7 +238,7 @@
   <string name="password">Mot de passe</string>
   <string name="anonymous">Anonyme</string>
   <string name="bluetooth">Bluetooth</string>
-    <string name="folders">Dossiers</string>
+  <string name="folders">Dossiers</string>
   <string name="videos">Vidéos</string>
   <string name="apks">Apks</string>
   <string name="documents">Documents</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -237,7 +237,7 @@
   <string name="password">Mot de passe</string>
   <string name="anonymous">Anonyme</string>
   <string name="bluetooth">Bluetooth</string>
-    <string name="folders">Dossiers</string>
+  <string name="folders">Dossiers</string>
   <string name="videos">Vidéos</string>
   <string name="apks">Apks</string>
   <string name="documents">Documents</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -237,8 +237,7 @@
   <string name="password">Mot de passe</string>
   <string name="anonymous">Anonyme</string>
   <string name="bluetooth">Bluetooth</string>
-  <string name="extstorage">Stockage externe</string>
-  <string name="folders">Dossiers</string>
+    <string name="folders">Dossiers</string>
   <string name="videos">Vidéos</string>
   <string name="apks">Apks</string>
   <string name="documents">Documents</string>

--- a/app/src/main/res/values-he/strings.xml
+++ b/app/src/main/res/values-he/strings.xml
@@ -25,7 +25,6 @@
     <string name="drawer_open">פתיחת תפריט הניווט</string>
     <string name="drawer_close">סגירת תפריט הניווט</string>
     <string name="icon">סמל</string>
-    <string name="internalstorage">אחסון פנימי</string>
     <string name="apps">מנהל היישומונים</string>
     <string name="ftp">שרת FTP</string>
     <string name="setting">הגדרות</string>
@@ -248,7 +247,6 @@
     <string name="password">סיסמה</string>
     <string name="anonymous">אנונימי</string>
     <string name="bluetooth">Bluetooth</string>
-    <string name="extstorage">אחסון חיצוני</string>
     <string name="folders">תיקיות</string>
     <string name="folderfilecount">%1$d תיקיות ו־%2$d קבצים</string>
     <string name="videos">וידאו</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -25,7 +25,6 @@
     <string name="drawer_open">Navigációs fiók megnyitása</string>
     <string name="drawer_close">Navigációs fiók bezárása</string>
     <string name="icon">ikon</string>
-    <string name="internalstorage">Belső tároló</string>
     <string name="apps">Alkalmazáskezelő</string>
     <string name="ftp">FTP-kiszolgáló</string>
     <string name="setting">Beállítások</string>
@@ -248,7 +247,6 @@
     <string name="password">Jelszó</string>
     <string name="anonymous">Névtelen</string>
     <string name="bluetooth">Bluetooth</string>
-    <string name="extstorage">Külső tároló</string>
     <string name="folders">mappa</string>
     <string name="folderfilecount">%1$d mappa és %2$d fájl</string>
     <string name="videos">Videók</string>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -25,7 +25,6 @@
     <string name="drawer_open">Buka laci navigasi</string>
     <string name="drawer_close">Tutup laci navigasi</string>
     <string name="icon">ikon</string>
-    <string name="internalstorage">Penyimpanan Internal</string>
     <string name="apps">Pengelola Aplikasi</string>
     <string name="ftp">Server FTP</string>
     <string name="setting">Pengaturan</string>
@@ -248,7 +247,6 @@
     <string name="password">Sandi</string>
     <string name="anonymous">Anonim</string>
     <string name="bluetooth">Bluetooth</string>
-    <string name="extstorage">Penyimpanan Eksternal</string>
     <string name="folders">Folder</string>
     <string name="folderfilecount">%1$d folder dan %2$d berkas</string>
     <string name="videos">Video</string>

--- a/app/src/main/res/values-is/strings.xml
+++ b/app/src/main/res/values-is/strings.xml
@@ -25,7 +25,6 @@
     <string name="drawer_open">Opna leiðsagnarsleða</string>
     <string name="drawer_close">Loka leiðsagnarsleða</string>
     <string name="icon">táknmynd</string>
-    <string name="internalstorage">Innbyggð geymsla</string>
     <string name="apps">Smáforritastjórnun</string>
     <string name="ftp">FTP-þjónn</string>
     <string name="setting">Stillingar</string>
@@ -248,7 +247,6 @@
     <string name="password">Lykilorð</string>
     <string name="anonymous">Nafnlaus notandi</string>
     <string name="bluetooth">Bluetooth</string>
-    <string name="extstorage">Ytri gagnageymsla</string>
     <string name="folders">Möppur</string>
     <string name="folderfilecount">%1$d möppur og %2$d skrár</string>
     <string name="videos">Myndskeið</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -239,8 +239,7 @@ I cambiamenti saranno effettivi dopo il riavvio dell\'app
   <string name="password">Password</string>
   <string name="anonymous">Anonimo</string>
   <string name="bluetooth">Bluetooth</string>
-  <string name="extstorage">Archiviazione esterna</string>
-  <string name="folders">Cartelle</string>
+    <string name="folders">Cartelle</string>
   <string name="videos">Video</string>
   <string name="apks">File APK</string>
   <string name="documents">Documenti</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -239,7 +239,7 @@ I cambiamenti saranno effettivi dopo il riavvio dell\'app
   <string name="password">Password</string>
   <string name="anonymous">Anonimo</string>
   <string name="bluetooth">Bluetooth</string>
-    <string name="folders">Cartelle</string>
+  <string name="folders">Cartelle</string>
   <string name="videos">Video</string>
   <string name="apks">File APK</string>
   <string name="documents">Documenti</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -25,7 +25,6 @@
     <string name="drawer_open">ナビゲーションドロワーを開く</string>
     <string name="drawer_close">ナビゲーションドロワーを閉じる</string>
     <string name="icon">アイコン</string>
-    <string name="internalstorage">内部ストレージ</string>
     <string name="apps">アプリマネージャー</string>
     <string name="ftp">FTP サーバー</string>
     <string name="setting">設定</string>
@@ -248,7 +247,6 @@
     <string name="password">パスワード</string>
     <string name="anonymous">匿名</string>
     <string name="bluetooth">ブルートゥース</string>
-    <string name="extstorage">外部ストレージ</string>
     <string name="folders">フォルダー</string>
     <string name="folderfilecount">%1$d フォルダと %2$d ファイル</string>
     <string name="videos">ビデオ</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -225,7 +225,7 @@
   <string name="username">사용자 이름</string>
   <string name="password">비밀번호</string>
   <string name="bluetooth">블루투스</string>
-    <string name="folders">폴더</string>
+  <string name="folders">폴더</string>
   <string name="videos">동영상</string>
   <string name="images">사진</string>
   <string name="clear">삭제</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -225,8 +225,7 @@
   <string name="username">사용자 이름</string>
   <string name="password">비밀번호</string>
   <string name="bluetooth">블루투스</string>
-  <string name="extstorage">외장 스토리지</string>
-  <string name="folders">폴더</string>
+    <string name="folders">폴더</string>
   <string name="videos">동영상</string>
   <string name="images">사진</string>
   <string name="clear">삭제</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -233,8 +233,7 @@
   <string name="password">Wachtwoord</string>
   <string name="anonymous">Anoniem</string>
   <string name="bluetooth">Bluetooth</string>
-  <string name="extstorage">Externe opslag</string>
-  <string name="folders">Mappen</string>
+    <string name="folders">Mappen</string>
   <string name="videos">Video\'s</string>
   <string name="apks">Apk\'s</string>
   <string name="documents">Documenten</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -233,7 +233,7 @@
   <string name="password">Wachtwoord</string>
   <string name="anonymous">Anoniem</string>
   <string name="bluetooth">Bluetooth</string>
-    <string name="folders">Mappen</string>
+  <string name="folders">Mappen</string>
   <string name="videos">Video\'s</string>
   <string name="apks">Apk\'s</string>
   <string name="documents">Documenten</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -233,7 +233,7 @@
   <string name="password">Hasło</string>
   <string name="anonymous">Anonimowy</string>
   <string name="bluetooth">Bluetooth</string>
-    <string name="folders">Katalogi</string>
+  <string name="folders">Katalogi</string>
   <string name="videos">Filmy</string>
   <string name="apks">Aplikacje</string>
   <string name="documents">Dokumenty</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -233,8 +233,7 @@
   <string name="password">Hasło</string>
   <string name="anonymous">Anonimowy</string>
   <string name="bluetooth">Bluetooth</string>
-  <string name="extstorage">Pamięć zewnętrzna</string>
-  <string name="folders">Katalogi</string>
+    <string name="folders">Katalogi</string>
   <string name="videos">Filmy</string>
   <string name="apks">Aplikacje</string>
   <string name="documents">Dokumenty</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -25,7 +25,6 @@
     <string name="drawer_open">Abrir menu de navegação</string>
     <string name="drawer_close">Fechar menu de navegação</string>
     <string name="icon">ícone</string>
-    <string name="internalstorage">Armazenamento interno</string>
     <string name="apps">Gerenciador de Apps</string>
     <string name="ftp">Servidor FTP</string>
     <string name="setting">Configurações</string>
@@ -248,7 +247,6 @@
     <string name="password">Senha</string>
     <string name="anonymous">Anônimo</string>
     <string name="bluetooth">Bluetooth</string>
-    <string name="extstorage">Armazenamento externo</string>
     <string name="folders">Pastas</string>
     <string name="folderfilecount">%1$d pastas e %2$d arquivos</string>
     <string name="videos">Vídeos</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -224,8 +224,7 @@
   <string name="username">Utilizador</string>
   <string name="password">Palavra-passe</string>
   <string name="anonymous">Anónimo</string>
-  <string name="extstorage">Armazenamento externo</string>
-  <string name="folders">Pastas</string>
+    <string name="folders">Pastas</string>
   <string name="videos">Vídeos</string>
   <string name="documents">Documentos</string>
   <string name="images">Imagens</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -224,7 +224,7 @@
   <string name="username">Utilizador</string>
   <string name="password">Palavra-passe</string>
   <string name="anonymous">Anónimo</string>
-    <string name="folders">Pastas</string>
+  <string name="folders">Pastas</string>
   <string name="videos">Vídeos</string>
   <string name="documents">Documentos</string>
   <string name="images">Imagens</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -217,7 +217,6 @@
   <string name="username">Nume utilizator</string>
   <string name="password">Parolă</string>
   <string name="anonymous">Anonim</string>
-  <string name="extstorage">Stocare externă</string>
   <string name="folders">Dosare</string>
   <string name="videos">Videoclipuri</string>
   <string name="apks">Apk-uri</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -21,7 +21,6 @@
     <string name="drawer_open">Открыть меню навигации</string>
     <string name="drawer_close">Закрыть меню навигации</string>
     <string name="icon">значок</string>
-    <string name="internalstorage">Внутренняя память</string>
     <string name="apps">Менеджер приложений</string>
     <string name="ftp">FTP сервер</string>
     <string name="setting">Настройки</string>
@@ -237,7 +236,6 @@
     <string name="password">Пароль</string>
     <string name="anonymous">Анонимно</string>
     <string name="bluetooth">Bluetooth</string>
-    <string name="extstorage">Внешний накопитель</string>
     <string name="folders">Папки</string>
     <string name="videos">Видео</string>
     <string name="apks">Apk</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -237,7 +237,7 @@
   <string name="password">Heslo</string>
   <string name="anonymous">Anonymný</string>
   <string name="bluetooth">Bluetooth</string>
-    <string name="folders">Priečinky</string>
+  <string name="folders">Priečinky</string>
   <string name="videos">Videá</string>
   <string name="apks">Aplikácie</string>
   <string name="documents">Dokumenty</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -237,8 +237,7 @@
   <string name="password">Heslo</string>
   <string name="anonymous">Anonymný</string>
   <string name="bluetooth">Bluetooth</string>
-  <string name="extstorage">Externé úložisko</string>
-  <string name="folders">Priečinky</string>
+    <string name="folders">Priečinky</string>
   <string name="videos">Videá</string>
   <string name="apks">Aplikácie</string>
   <string name="documents">Dokumenty</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -207,7 +207,7 @@
   <string name="password">Geslo</string>
   <string name="anonymous">Anonimni</string>
   <string name="bluetooth">Bluetooth</string>
-    <string name="folders">Mape</string>
+  <string name="folders">Mape</string>
   <string name="videos">Video posnetki</string>
   <string name="apks">Apk-ji</string>
   <string name="documents">Dokumenti</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -207,8 +207,7 @@
   <string name="password">Geslo</string>
   <string name="anonymous">Anonimni</string>
   <string name="bluetooth">Bluetooth</string>
-  <string name="extstorage">Zunanji pomnilnik</string>
-  <string name="folders">Mape</string>
+    <string name="folders">Mape</string>
   <string name="videos">Video posnetki</string>
   <string name="apks">Apk-ji</string>
   <string name="documents">Dokumenti</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -229,7 +229,7 @@
   <string name="password">Лозинка</string>
   <string name="anonymous">Анонимно</string>
   <string name="bluetooth">Блутут</string>
-    <string name="folders">Фасцикле</string>
+  <string name="folders">Фасцикле</string>
   <string name="videos">Видео</string>
   <string name="apks">Апк</string>
   <string name="documents">Документи</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -229,8 +229,7 @@
   <string name="password">Лозинка</string>
   <string name="anonymous">Анонимно</string>
   <string name="bluetooth">Блутут</string>
-  <string name="extstorage">Спољашње складиште</string>
-  <string name="folders">Фасцикле</string>
+    <string name="folders">Фасцикле</string>
   <string name="videos">Видео</string>
   <string name="apks">Апк</string>
   <string name="documents">Документи</string>

--- a/app/src/main/res/values-sv-rSE/strings.xml
+++ b/app/src/main/res/values-sv-rSE/strings.xml
@@ -238,7 +238,6 @@
     <string name="password">Lösenord</string>
     <string name="anonymous">Anonymt</string>
     <string name="bluetooth">Blåtand</string>
-    <string name="extstorage">Extern Lagring</string>
     <string name="folders">Kataloger</string>
     <string name="videos">Filmer</string>
     <string name="apks">Apk:er</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -25,7 +25,6 @@
     <string name="drawer_open">Öppna navigationsfält</string>
     <string name="drawer_close">Stäng navigationspanel</string>
     <string name="icon">ikon</string>
-    <string name="internalstorage">Intern Lagring</string>
     <string name="apps">Apphanterare</string>
     <string name="ftp">FTP-server</string>
     <string name="setting">Inställningar</string>
@@ -248,7 +247,6 @@
     <string name="password">Lösenord</string>
     <string name="anonymous">Anonymt</string>
     <string name="bluetooth">Bluetooth</string>
-    <string name="extstorage">Extern lagring</string>
     <string name="folders">Mappar</string>
     <string name="folderfilecount">%1$d mappar och %2$d filer</string>
     <string name="videos">Videor</string>

--- a/app/src/main/res/values-ta/strings.xml
+++ b/app/src/main/res/values-ta/strings.xml
@@ -238,7 +238,6 @@
     <string name="password">கடவுச்சொல்</string>
     <string name="anonymous">பெயரில்லாத</string>
     <string name="bluetooth">ப்ளூடூத்</string>
-    <string name="extstorage">வெளி நினைவகம்</string>
     <string name="folders">கோப்புறைகள்</string>
     <string name="videos">காணொலிகள்</string>
     <string name="apks">ஏபிகேகள்</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -238,7 +238,7 @@ Devam etmek istiyor musunuz?\"</string>
   <string name="password">Şifre</string>
   <string name="anonymous">Anonim</string>
   <string name="bluetooth">Bluetooth</string>
-    <string name="folders">Klasörler</string>
+  <string name="folders">Klasörler</string>
   <string name="videos">Videolar</string>
   <string name="apks">Apk\'ler</string>
   <string name="documents">Dokümanlar</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -238,8 +238,7 @@ Devam etmek istiyor musunuz?\"</string>
   <string name="password">Şifre</string>
   <string name="anonymous">Anonim</string>
   <string name="bluetooth">Bluetooth</string>
-  <string name="extstorage">Harici Hafıza</string>
-  <string name="folders">Klasörler</string>
+    <string name="folders">Klasörler</string>
   <string name="videos">Videolar</string>
   <string name="apks">Apk\'ler</string>
   <string name="documents">Dokümanlar</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -21,7 +21,6 @@
     <string name="drawer_open">Відкрити меню навігації</string>
     <string name="drawer_close">Закрити меню навігації</string>
     <string name="icon">іконка</string>
-    <string name="internalstorage">Внутрішня пам\'ять</string>
     <string name="apps">Менеджер додатків</string>
     <string name="ftp">FTP Сервер</string>
     <string name="setting">Налаштування</string>
@@ -233,7 +232,6 @@
     <string name="password">Пароль</string>
     <string name="anonymous">Анонім</string>
     <string name="bluetooth">Bluetooth</string>
-    <string name="extstorage">Зовнішнє сховище</string>
     <string name="folders">Теки</string>
     <string name="videos">Відео</string>
     <string name="apks">Apk</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -231,7 +231,7 @@
   <string name="password">Mật khẩu</string>
   <string name="anonymous">Ẩn danh</string>
   <string name="bluetooth">Bluetooth</string>
-    <string name="folders">Thư mục</string>
+  <string name="folders">Thư mục</string>
   <string name="videos">Video</string>
   <string name="apks">Các tệp Apk</string>
   <string name="documents">Tài liệu</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -231,8 +231,7 @@
   <string name="password">Mật khẩu</string>
   <string name="anonymous">Ẩn danh</string>
   <string name="bluetooth">Bluetooth</string>
-  <string name="extstorage">Bộ nhớ ngoài</string>
-  <string name="folders">Thư mục</string>
+    <string name="folders">Thư mục</string>
   <string name="videos">Video</string>
   <string name="apks">Các tệp Apk</string>
   <string name="documents">Tài liệu</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -25,7 +25,6 @@
     <string name="drawer_open">打开导航抽屉</string>
     <string name="drawer_close">关闭导航抽屉</string>
     <string name="icon">图标</string>
-    <string name="internalstorage">Internal Storage</string>
     <string name="apps">应用管理</string>
     <string name="ftp">FTP 服务器</string>
     <string name="setting">设置</string>
@@ -246,7 +245,6 @@
     <string name="password">密码</string>
     <string name="anonymous">匿名用户</string>
     <string name="bluetooth">蓝牙</string>
-    <string name="extstorage">外置存储</string>
     <string name="folders">文件夹</string>
     <string name="folderfilecount">%1$d 个文件夹，%2$d 个文件</string>
     <string name="videos">视频</string>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -237,7 +237,7 @@
   <string name="password">密碼</string>
   <string name="anonymous">匿名</string>
   <string name="bluetooth">藍牙裝置</string>
-    <string name="folders">資料夾</string>
+  <string name="folders">資料夾</string>
   <string name="videos">影片</string>
   <string name="apks">安裝包</string>
   <string name="documents">文件</string>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -237,8 +237,7 @@
   <string name="password">密碼</string>
   <string name="anonymous">匿名</string>
   <string name="bluetooth">藍牙裝置</string>
-  <string name="extstorage">外部儲存空間</string>
-  <string name="folders">資料夾</string>
+    <string name="folders">資料夾</string>
   <string name="videos">影片</string>
   <string name="apks">安裝包</string>
   <string name="documents">文件</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -239,8 +239,7 @@
   <string name="password">密碼</string>
   <string name="anonymous">匿名</string>
   <string name="bluetooth">藍牙裝置</string>
-  <string name="extstorage">外部儲存空間</string>
-  <string name="folders">資料夾</string>
+    <string name="folders">資料夾</string>
   <string name="videos">影片</string>
   <string name="apks">Apks</string>
   <string name="documents">文件</string>
@@ -594,8 +593,7 @@
   <string name="transfer_rate">傳輸速率</string>
   <string name="time_remaining">剩餘時間</string>
   <string name="grant_apkinstall_permission">程式需要安裝程式的權限以繼續。</string>
-  <string name="internalstorage">內部儲存空間</string>
-  <string name="archive_password_prompt">請輸入壓縮檔的密碼。</string>
+    <string name="archive_password_prompt">請輸入壓縮檔的密碼。</string>
   <string name="cannot_extract_archive">不能開啟壓縮檔 \"%s\"： %s</string>
   <string name="archive_unsupported_or_corrupt">不能開啟壓縮檔 \"%s\"。可能是程式庫不支援此壓縮檔，或者壓縮檔真的壞掉了。</string>
   <string name="close">關閉</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -239,7 +239,7 @@
   <string name="password">密碼</string>
   <string name="anonymous">匿名</string>
   <string name="bluetooth">藍牙裝置</string>
-    <string name="folders">資料夾</string>
+  <string name="folders">資料夾</string>
   <string name="videos">影片</string>
   <string name="apks">Apks</string>
   <string name="documents">文件</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -652,7 +652,7 @@
 
     <!-- from https://android.googlesource.com/platform/frameworks/base/+/master/core/res/res/values/strings.xml -->
     <!-- Storage description for internal shared storage. [CHAR LIMIT=NONE] -->
-    <string name="storage_internal">Internal shared storage</string>
+    <string name="storage_internal">Internal Storage</string>
     <!-- Storage description for a generic SD card. [CHAR LIMIT=NONE] -->
     <string name="storage_sd_card">SD card</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -20,12 +20,12 @@
     -->
 
 <resources xmlns:tools="http://schemas.android.com/tools"
-    tools:ignore="MissingTranslation">
+    tools:ignore="MissingTranslation"
+    xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="app_name">Amaze File Manager</string>
     <string name="drawer_open">Open navigation drawer</string>
     <string name="drawer_close">Close navigation drawer</string>
     <string name="icon">icon</string>
-    <string name="internalstorage">Internal Storage</string>
     <string name="apps">App Manager</string>
     <string name="ftp">FTP Server</string>
     <string name="setting">Settings</string>
@@ -248,7 +248,6 @@
     <string name="password">Password</string>
     <string name="anonymous">Anonymous</string>
     <string name="bluetooth">Bluetooth</string>
-    <string name="extstorage">External Storage</string>
     <string name="folders">Folders</string>
     <string name="folderfilecount">%1$d folders and %2$d files</string>
     <string name="videos">Videos</string>
@@ -650,5 +649,11 @@
     <string name="cloud_plugin_google_play_uri" translatable="false">market://details?id=com.filemanager.amazecloud</string>
     <string name="cloud_plugin_google_play_web_uri" translatable="false">https://play.google.com/store/apps/details?id=com.filemanager.amazecloud</string>
     <string name="failed_install_apk">Failed to install</string>
+
+    <!-- from https://android.googlesource.com/platform/frameworks/base/+/master/core/res/res/values/strings.xml -->
+    <!-- Storage description for internal shared storage. [CHAR LIMIT=NONE] -->
+    <string name="storage_internal">Internal shared storage</string>
+    <!-- Storage description for a generic SD card. [CHAR LIMIT=NONE] -->
+    <string name="storage_sd_card">SD card</string>
 </resources>
 

--- a/app/src/test/java/com/amaze/filemanager/filesystem/usb/UsbOtgTest.java
+++ b/app/src/test/java/com/amaze/filemanager/filesystem/usb/UsbOtgTest.java
@@ -4,6 +4,7 @@ import android.text.TextUtils;
 
 import com.amaze.filemanager.BuildConfig;
 import com.amaze.filemanager.activities.MainActivity;
+import com.amaze.filemanager.adapters.data.StorageDirectoryParcelable;
 import com.amaze.filemanager.utils.OTGUtil;
 
 import org.junit.Test;
@@ -38,9 +39,9 @@ public class UsbOtgTest {
         activity = controller.resume().get();
 
         boolean hasOtgStorage = false;
-        ArrayList<String> storageDirectories = activity.getStorageDirectories();
-        for (String file : storageDirectories) {
-            if (file.startsWith(OTGUtil.PREFIX_OTG)) {
+        ArrayList<StorageDirectoryParcelable> storageDirectories = activity.getStorageDirectories();
+        for (StorageDirectoryParcelable storageDirectory : storageDirectories) {
+            if (storageDirectory.path.startsWith(OTGUtil.PREFIX_OTG)) {
                 hasOtgStorage = true;
                 break;
             }


### PR DESCRIPTION
Use getStorageVolumes() instead of environment variables on Android >= N

There are a few advantages:
- Better APIs
- Nicer names to every volume
- USB storage "just works", no need to fiddle with the extra classes and permissions

There are, however, a few disadvantages:
- Cannot reliably distinguish SD cards and USB devices: It relies on device name or path containing "USB" to use the USB icon
- The StorageVolume.mPath directory is a hidden API and requires reflection to be accessed (Clumsy, but works reliably)
