### PR TITLE
Fix RecyclerPreloadModelProvider crashing while searching #1862

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/adapters/glide/RecyclerPreloadModelProvider.java
+++ b/app/src/main/java/com/amaze/filemanager/adapters/glide/RecyclerPreloadModelProvider.java
@@ -33,7 +33,7 @@ public class RecyclerPreloadModelProvider implements ListPreloader.PreloadModelP
     @Override
     @NonNull
     public List<IconDataParcelable> getPreloadItems(int position) {
-        IconDataParcelable iconData = urisToLoad.get(position);
+        IconDataParcelable iconData = position < urisToLoad.size() ? urisToLoad.get(position) : null;
         if (iconData == null) return Collections.emptyList();
         return Collections.singletonList(iconData);
     }


### PR DESCRIPTION
Looks like a problem with RecyclerPreloadModelProvider.
It's difficult to debug since when you use debugger it works like a charm. Maybe kind of a race condition or something. It can be fixed by disabling RecyclerPreloadModuleProvider or with simple if-else clause.

The issue is not only related to the "android" keyword. I was able to reproduce it when there is more than one search result but it's hard to reproduce for me when I used debugger. I tried to synchronize methods but my knowledge is too little to be able to do it.

Idk maybe it is a more elegant way.

Fixes #1837