### PR TITLE
Fix opening searched directory

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/fragments/MainFragment.java
+++ b/app/src/main/java/com/amaze/filemanager/fragments/MainFragment.java
@@ -1504,7 +1504,7 @@ public class MainFragment extends Fragment implements BottomBarButtonPath {
                 size = "";
                 LayoutElementParcelable layoutElement = new LayoutElementParcelable(getContext(), f.getPath(), mFile.getPermission(),
                         mFile.getLink(), size, 0, true,
-                        mFile.getDate() + "", false,
+                        mFile.getDate() + "", true,
                         getBoolean(PREFERENCE_SHOW_THUMB), mFile.getMode());
 
                 LIST_ELEMENTS.add(layoutElement);


### PR DESCRIPTION
Looks like somebody make a typo. If we check if it is a directory we should set boolean **isDirectory** to true.

Fixes #1872 