### PR TITLE
Migrate to stock Bouncycastle

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -88,6 +88,7 @@ ext {
     glideVersion = '4.9.0'
     sshjVersion = '0.26.0'
     fabSpeedDialVersion = '3.1.1'
+    bouncyCastleVersion = '1.65'
 }
 
 dependencies {
@@ -172,8 +173,8 @@ dependencies {
     //SFTP
     implementation "com.hierynomus:sshj:$sshjVersion"
 
-    implementation 'com.madgag.spongycastle:bcpkix-jdk15on:1.58.0.0'
-    implementation 'com.madgag.spongycastle:prov:1.58.0.0'
+    implementation "org.bouncycastle:bcpkix-jdk15on:$bouncyCastleVersion"
+    implementation "org.bouncycastle:bcprov-jdk15on:$bouncyCastleVersion"
 
     //Glide: loads icons seemlessly
     implementation "com.github.bumptech.glide:glide:$glideVersion"

--- a/app/proguard.cfg
+++ b/app/proguard.cfg
@@ -72,32 +72,6 @@
 #From here CloudRail
 -keep class com.cloudrail.** { *; }
 
-#From here SpongyCastle (https://github.com/signalapp/Signal-Android/blob/master/proguard-spongycastle.pro)
--keep class org.spongycastle.crypto.* {*;}
--keep class org.spongycastle.crypto.agreement.** {*;}
--keep class org.spongycastle.crypto.digests.* {*;}
--keep class org.spongycastle.crypto.ec.* {*;}
--keep class org.spongycastle.crypto.encodings.* {*;}
--keep class org.spongycastle.crypto.engines.* {*;}
--keep class org.spongycastle.crypto.macs.* {*;}
--keep class org.spongycastle.crypto.modes.* {*;}
--keep class org.spongycastle.crypto.paddings.* {*;}
--keep class org.spongycastle.crypto.params.* {*;}
--keep class org.spongycastle.crypto.prng.* {*;}
--keep class org.spongycastle.crypto.signers.* {*;}
-
--keep class org.spongycastle.jcajce.provider.asymmetric.* {*;}
--keep class org.spongycastle.jcajce.provider.asymmetric.util.* {*;}
--keep class org.spongycastle.jcajce.provider.asymmetric.dh.* {*;}
--keep class org.spongycastle.jcajce.provider.asymmetric.ec.* {*;}
--keep class org.spongycastle.jcajce.provider.asymmetric.rsa.* {*;}
-
--keep class org.spongycastle.jcajce.provider.digest.** {*;}
--keep class org.spongycastle.jcajce.provider.keystore.** {*;}
--keep class org.spongycastle.jcajce.provider.symmetric.** {*;}
--keep class org.spongycastle.jcajce.spec.* {*;}
--keep class org.spongycastle.jce.** {*;}
-
 #From here BouncyCastle
 -keep class org.bouncycastle.crypto.* {*;}
 -keep class org.bouncycastle.crypto.agreement.** {*;}

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/services/ftp/FtpService.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/services/ftp/FtpService.java
@@ -199,7 +199,7 @@ public class FtpService extends Service implements Runnable {
         if (preferences.getBoolean(KEY_PREFERENCE_SECURE, DEFAULT_SECURE)) {
 
             try {
-                KeyStore keyStore = KeyStore.getInstance("BKS", "BC");
+                KeyStore keyStore = KeyStore.getInstance("BKS");
                 keyStore.load(getResources().openRawResource(R.raw.key), KEYSTORE_PASSWORD);
 
                 KeyManagerFactory keyManagerFactory = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());

--- a/app/src/main/java/com/amaze/filemanager/filesystem/ssh/CustomSshJConfig.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/ssh/CustomSshJConfig.java
@@ -43,10 +43,8 @@ public class CustomSshJConfig extends DefaultConfig
     // BouncyCastle before registering SpongyCastle's provider
     public static void init() {
         Security.removeProvider("BC");
-        Security.insertProviderAt(new org.spongycastle.jce.provider.BouncyCastleProvider(),
-                Security.getProviders().length+1);
         Security.insertProviderAt(new org.bouncycastle.jce.provider.BouncyCastleProvider(),
-                Security.getProviders().length+1);
+                0);
     }
 
     // don't add ECDSA

--- a/app/src/main/java/com/amaze/filemanager/utils/files/CryptUtil.java
+++ b/app/src/main/java/com/amaze/filemanager/utils/files/CryptUtil.java
@@ -384,7 +384,7 @@ public class CryptUtil {
     private void rsaEncrypt(Context context, BufferedInputStream inputStream, BufferedOutputStream outputStream)
             throws GeneralSecurityException, IOException {
 
-        Cipher cipher = Cipher.getInstance(ALGO_AES, "BC");
+        Cipher cipher = Cipher.getInstance(ALGO_AES);
         RSAKeygen keygen = new RSAKeygen(context);
 
         IvParameterSpec ivParameterSpec = new IvParameterSpec(IV.getBytes());
@@ -414,7 +414,7 @@ public class CryptUtil {
     private void rsaDecrypt(Context context, BufferedInputStream inputStream,
                                    BufferedOutputStream outputStream) throws GeneralSecurityException, IOException {
 
-        Cipher cipher = Cipher.getInstance(ALGO_AES, "BC");
+        Cipher cipher = Cipher.getInstance(ALGO_AES);
         RSAKeygen keygen = new RSAKeygen(context);
 
         IvParameterSpec ivParameterSpec = new IvParameterSpec(IV.getBytes());
@@ -443,7 +443,7 @@ public class CryptUtil {
     @RequiresApi(api = Build.VERSION_CODES.JELLY_BEAN_MR2)
     private static String rsaEncryptPassword(Context context, String password) throws GeneralSecurityException, IOException {
 
-        Cipher cipher = Cipher.getInstance(ALGO_AES, "BC");
+        Cipher cipher = Cipher.getInstance(ALGO_AES);
         RSAKeygen keygen = new RSAKeygen(context);
 
         IvParameterSpec ivParameterSpec = new IvParameterSpec(IV.getBytes());
@@ -455,7 +455,7 @@ public class CryptUtil {
     @RequiresApi(api = Build.VERSION_CODES.JELLY_BEAN_MR2)
     private static String rsaDecryptPassword(Context context, String cipherText) throws GeneralSecurityException, IOException {
 
-        Cipher cipher = Cipher.getInstance(ALGO_AES, "BC");
+        Cipher cipher = Cipher.getInstance(ALGO_AES);
         RSAKeygen keygen = new RSAKeygen(context);
         IvParameterSpec ivParameterSpec = new IvParameterSpec(IV.getBytes());
         cipher.init(Cipher.DECRYPT_MODE, keygen.getSecretKey(), ivParameterSpec);
@@ -498,7 +498,7 @@ public class CryptUtil {
             GCMParameterSpec gcmParameterSpec = new GCMParameterSpec(128, IV.getBytes());
             cipher.init(Cipher.ENCRYPT_MODE, getSecretKey(), gcmParameterSpec);
         } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
-            cipher = Cipher.getInstance(ALGO_AES, "BC");
+            cipher = Cipher.getInstance(ALGO_AES);
             RSAKeygen keygen = new RSAKeygen(context);
 
             cipher.init(Cipher.ENCRYPT_MODE, keygen.getSecretKey());

--- a/app/src/test/java/com/amaze/filemanager/filesystem/ssh/test/TestKeyProvider.java
+++ b/app/src/test/java/com/amaze/filemanager/filesystem/ssh/test/TestKeyProvider.java
@@ -12,7 +12,7 @@ public class TestKeyProvider implements KeyPairProvider {
     private KeyPair keyPair;
 
     public TestKeyProvider() throws Exception {
-        KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("RSA", "BC");
+        KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("RSA");
         keyPairGenerator.initialize(1024, new SecureRandom());
         keyPair = keyPairGenerator.generateKeyPair();
     }

--- a/app/src/test/java/com/amaze/filemanager/test/ShadowCryptUtil.java
+++ b/app/src/test/java/com/amaze/filemanager/test/ShadowCryptUtil.java
@@ -26,7 +26,7 @@ public class ShadowCryptUtil {
 
     static {
         try {
-            KeyGenerator keyGen = KeyGenerator.getInstance("AES", "BC");
+            KeyGenerator keyGen = KeyGenerator.getInstance("AES");
             keyGen.init(128);
             secretKey = keyGen.generateKey();
         } catch (GeneralSecurityException e) {
@@ -56,7 +56,7 @@ public class ShadowCryptUtil {
     private static String aesEncryptPassword(String plainTextPassword)
             throws GeneralSecurityException {
 
-        Cipher cipher = Cipher.getInstance(ALGO_AES, "BC");
+        Cipher cipher = Cipher.getInstance(ALGO_AES);
         GCMParameterSpec gcmParameterSpec = new GCMParameterSpec(128, IV.getBytes());
         cipher.init(Cipher.ENCRYPT_MODE, secretKey, gcmParameterSpec);
         byte[] encodedBytes = cipher.doFinal(plainTextPassword.getBytes());
@@ -69,7 +69,7 @@ public class ShadowCryptUtil {
      */
     private static String aesDecryptPassword(String cipherPassword) throws GeneralSecurityException {
 
-        Cipher cipher = Cipher.getInstance(ALGO_AES, "BC");
+        Cipher cipher = Cipher.getInstance(ALGO_AES);
         GCMParameterSpec gcmParameterSpec = new GCMParameterSpec(128, IV.getBytes());
         cipher.init(Cipher.DECRYPT_MODE, secretKey, gcmParameterSpec);
         byte[] decryptedBytes = cipher.doFinal(Base64.decode(cipherPassword, Base64.DEFAULT));

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,6 +11,10 @@
 # The setting is particularly useful for tweaking memory settings.
 android.enableJetifier=true
 android.useAndroidX=true
+# Workaround for Android Gradle Plugin before 3.6.0.
+# See https://github.com/robolectric/robolectric/issues/5299#issuecomment-543125381
+# and https://issuetracker.google.com/issues/142580430
+android.jetifier.blacklist=.*bcprov.*
 org.gradle.jvmargs=-Xmx4608M
 
 # When configured, Gradle will run in incubating parallel mode.


### PR DESCRIPTION
Fixes #1870.

Per @Neustradamus suggested and [rtyley/spongycastle#34](https://github.com/rtyley/spongycastle/issues/34) we should deprecate Spongycastle and use Bouncycastle directly without worrying about package name/class loading collisions.

Changes:

- Remove stock Bouncycastle provider bundled with Android
- Register updated Bouncycastle provider as first crypto provider available
- Remove proguard config related to Spongycastle
- Update code to obtain crypto provider directly without prefix

Related robolectric tests passed, Espresso tests were passed on Android emulators running 4.4, 6.0, 8.0, Oneplus 2 running AOSPExtended (7.1.2) and Fairphone 3 running LineageOS 16 GSI (9.0). Also tested on Fairphone 3 with production build (proguard enabled) on encrypting/decrypting files and establishing SSH connections.