### PR TITLE
Remove "SpongyCastle"

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/filesystem/ssh/CustomSshJConfig.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/ssh/CustomSshJConfig.java
@@ -32,7 +32,7 @@ import java.security.Security;
 /**
  * sshj {@link net.schmizz.sshj.Config} for our own use.
  *
- * Borrowed from original AndroidConfig, but also use SpongyCastle from the start altogether.
+ * Borrowed from original AndroidConfig, but also use vanilla BouncyCastle from the start altogether.
  *
  * @see net.schmizz.sshj.Config
  * @see net.schmizz.sshj.AndroidConfig
@@ -40,7 +40,7 @@ import java.security.Security;
 public class CustomSshJConfig extends DefaultConfig
 {
     // This is where we different from the original AndroidConfig. Found it only work if we remove
-    // BouncyCastle before registering SpongyCastle's provider
+    // BouncyCastle bundled with Android before registering our BouncyCastle provider
     public static void init() {
         Security.removeProvider("BC");
         Security.insertProviderAt(new org.bouncycastle.jce.provider.BouncyCastleProvider(),


### PR DESCRIPTION
A continuation of #1870, fixes #1881, by removing any other SpongyCastle references in code comments.

This only affects code comments, so it should be good to go after 1 approval.