### PR TITLE
Make Android won't reload application on orientation changes

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -56,6 +56,7 @@
             android:label="@string/appbar_name"
             android:launchMode="singleInstance"
             android:name=".activities.MainActivity"
+            android:configChanges="orientation|screenSize"
             android:theme="@style/appCompatLight">
 
             <intent-filter android:label="@string/appbar_name">

--- a/app/src/main/java/com/amaze/filemanager/activities/superclasses/PermissionsActivity.java
+++ b/app/src/main/java/com/amaze/filemanager/activities/superclasses/PermissionsActivity.java
@@ -1,6 +1,7 @@
 package com.amaze.filemanager.activities.superclasses;
 
 import android.Manifest;
+import android.content.pm.ActivityInfo;
 import android.content.pm.PackageManager;
 import android.os.Build;
 
@@ -13,6 +14,7 @@ import com.afollestad.materialdialogs.DialogAction;
 import com.afollestad.materialdialogs.MaterialDialog;
 import com.amaze.filemanager.R;
 import com.amaze.filemanager.ui.dialogs.GeneralDialogCreation;
+import com.amaze.filemanager.utils.Utils;
 
 public class PermissionsActivity extends ThemedActivity
         implements ActivityCompat.OnRequestPermissionsResultCallback {
@@ -27,6 +29,7 @@ public class PermissionsActivity extends ThemedActivity
                                            @NonNull int[] grantResults) {
         if (requestCode == STORAGE_PERMISSION) {
             if (isGranted(grantResults)) {
+                Utils.enableScreenRotation(this);
                 permissionCallbacks[STORAGE_PERMISSION].onPermissionGranted();
                 permissionCallbacks[STORAGE_PERMISSION] = null;
             } else {
@@ -51,6 +54,7 @@ public class PermissionsActivity extends ThemedActivity
     }
 
     public void requestStoragePermission(@NonNull final OnPermissionGranted onPermissionGranted) {
+        Utils.disableScreenRotation(this);
         final MaterialDialog materialDialog = GeneralDialogCreation.showBasicDialog(this,
                 R.string.grant_storage_permission, R.string.grantper, R.string.grant, R.string.cancel);
         materialDialog.getActionButton(DialogAction.NEGATIVE).setOnClickListener(v -> finish());

--- a/app/src/main/java/com/amaze/filemanager/utils/Utils.java
+++ b/app/src/main/java/com/amaze/filemanager/utils/Utils.java
@@ -31,12 +31,6 @@ import android.content.res.Configuration;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
 import android.os.Build;
-import androidx.annotation.ColorRes;
-import androidx.annotation.NonNull;
-import androidx.core.content.ContextCompat;
-import androidx.core.content.FileProvider;
-import androidx.core.graphics.drawable.DrawableCompat;
-
 import android.os.storage.StorageVolume;
 import android.text.format.DateUtils;
 import android.util.DisplayMetrics;
@@ -44,10 +38,14 @@ import android.view.View;
 import android.widget.CheckBox;
 import android.widget.Toast;
 
+import androidx.annotation.ColorRes;
+import androidx.annotation.NonNull;
+import androidx.core.content.ContextCompat;
+import androidx.core.content.FileProvider;
+import androidx.core.graphics.drawable.DrawableCompat;
+
 import com.amaze.filemanager.R;
-import com.amaze.filemanager.activities.MainActivity;
 import com.amaze.filemanager.filesystem.HybridFileParcelable;
-import com.amaze.filemanager.utils.files.FileUtils;
 
 import java.io.File;
 import java.lang.reflect.Field;
@@ -174,14 +172,18 @@ public class Utils {
      * Force disables screen rotation. Useful when we're temporarily in activity because of external intent,
      * and don't have to really deal much with filesystem.
      */
-    public static void disableScreenRotation(MainActivity mainActivity) {
-        int screenOrientation = mainActivity.getResources().getConfiguration().orientation;
+    public static void disableScreenRotation(@NonNull Activity activity) {
+        int screenOrientation = activity.getResources().getConfiguration().orientation;
 
         if (screenOrientation == Configuration.ORIENTATION_LANDSCAPE) {
-            mainActivity.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE);
+            activity.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE);
         } else if (screenOrientation == Configuration.ORIENTATION_PORTRAIT) {
-            mainActivity.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
+            activity.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
         }
+    }
+
+    public static void enableScreenRotation(@NonNull Activity activity) {
+        activity.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED);
     }
 
     public static boolean isDeviceInLandScape(Activity activity){


### PR DESCRIPTION
Fixes #1885.

Reference: https://stackoverflow.com/a/5913370

You may want to make it into 3.4 maintenance release as well.

Tested on Oneplus 2 running AOSPExtended(7.1.2) and Fairphone 3 running LineageOS 16.0 GSI, app UI can be kept without getting black screen on screen orientation change while storage permission dialog is up.