### PR TITLE
Feature/1896

### DIFF
--- a/.github/PR_TEMPLATE/pull_request_template.md
+++ b/.github/PR_TEMPLATE/pull_request_template.md
@@ -1,0 +1,30 @@
+## PR Info
+#### Issue tracker   
+Fixes will automatically close the related issue
+
+Fixes #  
+-or-   
+Addresses #
+
+#### Release  
+Addresses release/<input type="text" id="name" name="name"/>
+  
+#### Test cases
+- [ ] Covered
+  
+#### Manual testing
+- [ ] Done  
+  
+If yes,  
+Device - <input type="text" id="name" name="name"/>  
+OS - <input type="text" id="name" name="name"/>
+
+#### Build tasks success  
+Successfully running following tasks on local 
+- [ ] `./gradlew assembledebug`
+- [ ] `./gradlew spotlessCheck`
+
+#### Related PR  
+Related to PR #
+
+#### Additional Info

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,8 @@ android:
     - android-28
     - extra-google-m2repository
 
-script: "./gradlew assembledebug"
+script:
+  - "./gradlew assembledebug"
+  - "./gradlew spotlessJava"
+  - "./gradlew spotlessJavaCheck"
+  - "./gradlew spotlessCheck"

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,4 @@ android:
 
 script:
   - "./gradlew assembledebug"
-  - "./gradlew spotlessJava"
-  - "./gradlew spotlessJavaCheck"
   - "./gradlew spotlessCheck"

--- a/build.gradle
+++ b/build.gradle
@@ -31,8 +31,8 @@ spotless {
     java {
         licenseHeaderFile 'spotless.license-java'
         target '**/*.java'
-        googleJavaFormat('1.1').aosp()
+        googleJavaFormat('1.1')
         removeUnusedImports() // removes any unused imports
-        importOrder 'java', 'javax', 'org', 'com', ''
+        importOrder 'java', 'javax', 'org', 'com', 'android', 'androidx', ''
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,10 @@ buildscript {
     }
 }
 
+plugins {
+    id "com.diffplug.gradle.spotless" version "4.3.0"
+}
+
 allprojects {
     repositories {
         google()
@@ -23,6 +27,12 @@ allprojects {
     }
 }
 
-task clean(type: Delete) {
-    delete rootProject.buildDir
+spotless {
+    java {
+        licenseHeaderFile 'spotless.license-java'
+        target '**/*.java'
+        googleJavaFormat('1.1').aosp()
+        removeUnusedImports() // removes any unused imports
+        importOrder 'java', 'javax', 'org', 'com', ''
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ spotless {
     java {
         licenseHeaderFile 'spotless.license-java'
         target '**/*.java'
-        googleJavaFormat('1.1')
+        googleJavaFormat('1.7')
         removeUnusedImports() // removes any unused imports
         importOrder 'java', 'javax', 'org', 'com', 'android', 'androidx', ''
     }

--- a/spotless.license-java
+++ b/spotless.license-java
@@ -17,3 +17,4 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+

--- a/spotless.license-java
+++ b/spotless.license-java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) 2014-$YEAR Arpit Khurana <arpitkh96@gmail.com>, Vishal Nehra <vishalmeham2@gmail.com>,
+ * Emmanuel Messulam<emmanuelbendavid@gmail.com>, Raymond Lai <airwave209gt at gmail.com> and Contributors.
+ *
+ * This file is part of Amaze File Manager.
+ *
+ * Amaze File Manager is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */


### PR DESCRIPTION
For #1896 Adding spotless gradle support to make code neat and clean, added step in travis as well.
Things to do, before sending PR for approval, just run 
`./gradlew spotlessJavaCheck`
in local to check for formatting errors. If it finds any then run following command, it'll automatically fix
`./gradlew :spotlessApply`

This build will probably fail, so need to run `spotlessApply` on master branch, will do that in separate PR as the initial changes would be project-wide.