### PR TITLE
Add declaration of cache folder for FileProvider

### DIFF
--- a/app/src/main/res/xml/provider_paths.xml
+++ b/app/src/main/res/xml/provider_paths.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <paths>
-    <external-path path="Android/data/com.amaze.filemanager/" name="package_root" />
+    <external-path path="Android/data/${applicationId}/" name="package_root" />
+    <cache-path path="Android/data/${applicationId}/" name="cache" />
     <!--
     root-path is suggested in https://stackoverflow.com/q/42516126
     as a workaround to access files only accessible via root


### PR DESCRIPTION
## PR Info
#### Issue tracker   
Fixes will automatically close the related issue

Fixes #1908
-or-   
Addresses #1911

#### Release  
Addresses release/3.5
  
#### Test cases
- [ ] Covered
  
#### Manual testing
- [x] Done  
  
If yes,  
- Device: Fairphone 3
- OS: LineageOS 16.0 GSI (9.0)

#### Build tasks success  
Successfully running following tasks on local 
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`

#### Related PR  
Related to PR #

#### Additional Info
'm using another approach to (hopefully) keep the app communicate with other apps using content:// URI. Also changed path from hard-coding app ID to dynamic ${applicationId} so dev builds won't mess up with production builds for developers.