### PR TITLE
Remove redundant RoomDatabase.close() at activity.destroy()

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/activities/MainActivity.java
+++ b/app/src/main/java/com/amaze/filemanager/activities/MainActivity.java
@@ -47,9 +47,7 @@ import com.amaze.filemanager.asynchronous.management.ServiceWatcherUtil;
 import com.amaze.filemanager.asynchronous.services.CopyService;
 import com.amaze.filemanager.database.CloudContract;
 import com.amaze.filemanager.database.CloudHandler;
-import com.amaze.filemanager.database.ExplorerDatabase;
 import com.amaze.filemanager.database.TabHandler;
-import com.amaze.filemanager.database.UtilitiesDatabase;
 import com.amaze.filemanager.database.UtilsHandler;
 import com.amaze.filemanager.database.models.OperationData;
 import com.amaze.filemanager.database.models.explorer.CloudEntry;
@@ -854,10 +852,6 @@ public class MainActivity extends PermissionsActivity
 
   public void exit() {
     if (backPressedToExitOnce) {
-      UtilitiesDatabase utilitiesDatabase = AppConfig.getInstance().getUtilitiesDatabase();
-      ExplorerDatabase explorerDatabase = AppConfig.getInstance().getExplorerDatabase();
-      if (utilitiesDatabase != null && utilitiesDatabase.isOpen()) utilitiesDatabase.close();
-      if (explorerDatabase != null && explorerDatabase.isOpen()) explorerDatabase.close();
       SshConnectionPool.getInstance().expungeAllConnections();
       finish();
       if (isRootExplorer()) {

--- a/app/src/main/java/com/amaze/filemanager/activities/MainActivity.java
+++ b/app/src/main/java/com/amaze/filemanager/activities/MainActivity.java
@@ -1330,12 +1330,6 @@ public class MainActivity extends PermissionsActivity
     // TODO: 6/5/2017 Android may choose to not call this method before destruction
     // TODO: https://developer.android.com/reference/android/app/Activity.html#onDestroy%28%29
     closeInteractiveShell();
-
-    UtilitiesDatabase utilitiesDatabase = AppConfig.getInstance().getUtilitiesDatabase();
-    ExplorerDatabase explorerDatabase = AppConfig.getInstance().getExplorerDatabase();
-    if (utilitiesDatabase != null && utilitiesDatabase.isOpen()) utilitiesDatabase.close();
-    if (explorerDatabase != null && explorerDatabase.isOpen()) explorerDatabase.close();
-
     SshConnectionPool.getInstance().expungeAllConnections();
   }
 


### PR DESCRIPTION
It had been done at Activity.exit(), no need to do it here again.

## PR Info
#### Issue tracker   
Fixes will automatically close the related issue

Fixes #1924

#### Release  
Addresses `release/3.5`
  
#### Test cases
- [ ] Covered
  
#### Manual testing
- [x] Done  
  
If yes,  
- Device: Fairphone 3, OS: LineageOS 16.0 GSI (9.0)
- Device: Pixel 2 emulator, OS: Stock firmware running Android 10

#### Build tasks success  
Successfully running following tasks on local 
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`

#### Related PR  
Related to PR #

#### Additional Info
Though not marked, please see if it fixes problem in #1923 too.