### PR TITLE
Fixes for editing SMB connections

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/application/AppConfig.java
+++ b/app/src/main/java/com/amaze/filemanager/application/AppConfig.java
@@ -87,11 +87,10 @@ public class AppConfig extends GlideApplication {
     utilsProvider = new UtilitiesProvider(this);
     utilsHandler = new UtilsHandler(this, utilitiesDatabase);
 
-    // FIXME: in unit tests when AppConfig is rapidly created/destroyed this call will cause
-    // IllegalThreadStateException.
-    // Until this gets fixed only one test case can be run in a time. - Raymond, 24/4/2018
     backgroundHandlerThread.start();
     backgroundHandler = new Handler(backgroundHandlerThread.getLooper());
+
+    runInBackground(jcifs.Config::registerSmbURLHandler);
 
     // disabling file exposure method check for api n+
     StrictMode.VmPolicy.Builder builder = new StrictMode.VmPolicy.Builder();

--- a/app/src/main/java/com/amaze/filemanager/database/UtilsHandler.java
+++ b/app/src/main/java/com/amaze/filemanager/database/UtilsHandler.java
@@ -58,6 +58,8 @@ import androidx.annotation.NonNull;
  */
 public class UtilsHandler {
 
+  private static final String TAG = UtilsHandler.class.getSimpleName();
+
   private final Context context;
 
   private final UtilitiesDatabase utilitiesDatabase;
@@ -313,6 +315,13 @@ public class UtilsHandler {
   }
 
   public void renameSMB(String oldName, String oldPath, String newName, String newPath) {
+    try {
+      oldPath = SmbUtil.getSmbEncryptedPath(AppConfig.getInstance(), oldPath);
+      newPath = SmbUtil.getSmbEncryptedPath(AppConfig.getInstance(), newPath);
+    } catch (GeneralSecurityException | IOException e) {
+      Log.e(TAG, "Error encrypting SMB path", e);
+    }
+
     SmbEntry smbEntry = utilitiesDatabase.smbEntryDao().findByNameAndPath(oldName, oldPath);
     smbEntry.name = newName;
     smbEntry.path = newPath;

--- a/app/src/main/java/com/amaze/filemanager/ui/dialogs/SmbConnectDialog.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/dialogs/SmbConnectDialog.java
@@ -207,7 +207,6 @@ public class SmbConnectDialog extends DialogFragment {
       String userp = "", passp = "", ipp = "", domainp = "";
       conName.setText(name);
       try {
-        jcifs.Config.registerSmbURLHandler();
         URL a = new URL(path);
         String userinfo = a.getUserInfo();
         if (userinfo != null) {


### PR DESCRIPTION
## PR Info

Fixes for crashes when trying to edit existing SMB connections.

- moved jcifs.Config.registerSmbURLHandler() from SmbConnectDialog to AppConfig.runInBackground()
- encrypt path parameters in UtilsHandler.renameSMB() as it was stored encrypted in database

#### Release  
Addresses release/3.5
  
#### Test cases
- [ ] Covered
  
#### Manual testing
- [x] Done  
  
Devices:
- LG Nexus 5x running AOSPExtended (9.0)
- Oneplus 2 running AOSPExtended (7.1.2)
- Fairphone 3 running LineageOS 16.0 (9.0)

#### Build tasks success  
Successfully running following tasks on local 
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`