### PR TITLE
Fix broken symlinks on SSH server causing incomplete file listings

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/filesystem/HybridFile.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/HybridFile.java
@@ -788,8 +788,12 @@ public class HybridFile {
                         client.ls(SshClientUtils.extractRemotePathFrom(path))) {
                       boolean isDirectory = info.isDirectory();
                       if (info.getAttributes().getType().equals(FileMode.Type.SYMLINK)) {
-                        FileAttributes symlinkAttrs = client.stat(info.getPath());
-                        isDirectory = symlinkAttrs.getType().equals(FileMode.Type.DIRECTORY);
+                        try {
+                          FileAttributes symlinkAttrs = client.stat(info.getPath());
+                          isDirectory = symlinkAttrs.getType().equals(FileMode.Type.DIRECTORY);
+                        } catch (IOException ifSymlinkIsBroken) {
+                          continue;
+                        }
                       }
                       HybridFileParcelable f =
                           new HybridFileParcelable(String.format("%s/%s", path, info.getName()));

--- a/app/src/main/java/com/amaze/filemanager/filesystem/HybridFile.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/HybridFile.java
@@ -792,6 +792,10 @@ public class HybridFile {
                           FileAttributes symlinkAttrs = client.stat(info.getPath());
                           isDirectory = symlinkAttrs.getType().equals(FileMode.Type.DIRECTORY);
                         } catch (IOException ifSymlinkIsBroken) {
+                          Log.w(
+                              TAG,
+                              String.format(
+                                  "Symbolic link %s is broken, skipping", info.getPath()));
                           continue;
                         }
                       }

--- a/app/src/test/java/com/amaze/filemanager/filesystem/ssh/ListFilesOnSshdTest.java
+++ b/app/src/test/java/com/amaze/filemanager/filesystem/ssh/ListFilesOnSshdTest.java
@@ -144,4 +144,26 @@ public class ListFilesOnSshdTest extends AbstractSftpServerTest {
             "symlink3.txt",
             "symlink4.txt"));
   }
+
+  @Test
+  public void testListDirsAndBrokenSymlinks() throws Exception {
+    File sysroot = new File(Environment.getExternalStorageDirectory(), "sysroot");
+    sysroot.mkdir();
+    Files.createSymbolicLink(
+        Paths.get(
+            new File(Environment.getExternalStorageDirectory(), "b0rken.symlink")
+                .getAbsolutePath()),
+        Paths.get(new File("/tmp/notfound.file").getAbsolutePath()));
+    for (String s : new String[] {"srv", "var", "tmp"}) {
+      File subdir = new File(sysroot, s);
+      subdir.mkdir();
+      Files.createSymbolicLink(
+          Paths.get(new File(Environment.getExternalStorageDirectory(), s).getAbsolutePath()),
+          Paths.get(subdir.getAbsolutePath()));
+    }
+    for (String s : new String[] {"bin", "lib", "usr"}) {
+      new File(Environment.getExternalStorageDirectory(), s).mkdir();
+    }
+    performVerify();
+  }
 }

--- a/app/src/test/java/com/amaze/filemanager/filesystem/ssh/ListFilesOnSshdTest.java
+++ b/app/src/test/java/com/amaze/filemanager/filesystem/ssh/ListFilesOnSshdTest.java
@@ -20,6 +20,7 @@
 
 package com.amaze.filemanager.filesystem.ssh;
 
+import static org.awaitility.Awaitility.await;
 import static org.hamcrest.Matchers.hasItems;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -28,6 +29,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.io.FileOutputStream;
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -49,11 +51,16 @@ public class ListFilesOnSshdTest extends AbstractSftpServerTest {
     for (String s : new String[] {"sysroot", "srv", "var", "tmp", "bin", "lib", "usr"}) {
       new File(Environment.getExternalStorageDirectory(), s).mkdir();
     }
-    performVerify();
+    assertTrue(performVerify());
   }
 
   @Test
   public void testListDirsAndSymlinks() throws Exception {
+    createNecessaryDirsForSymlinkRelatedTests();
+    assertTrue(performVerify());
+  }
+
+  private void createNecessaryDirsForSymlinkRelatedTests() throws IOException {
     File sysroot = new File(Environment.getExternalStorageDirectory(), "sysroot");
     sysroot.mkdir();
     for (String s : new String[] {"srv", "var", "tmp"}) {
@@ -66,41 +73,27 @@ public class ListFilesOnSshdTest extends AbstractSftpServerTest {
     for (String s : new String[] {"bin", "lib", "usr"}) {
       new File(Environment.getExternalStorageDirectory(), s).mkdir();
     }
-    performVerify();
   }
 
-  private void performVerify() throws InterruptedException {
+  private boolean performVerify() {
     List<String> result = new ArrayList<>();
     HybridFile file =
         new HybridFile(OpenMode.SFTP, "ssh://testuser:testpassword@127.0.0.1:" + serverPort);
-    CountDownLatch waiter = new CountDownLatch(7);
     file.forEachChildrenFile(
         RuntimeEnvironment.application,
         false,
         (fileFound) -> {
           assertTrue(fileFound.getPath() + " not seen as directory", fileFound.isDirectory());
           result.add(fileFound.getName());
-          waiter.countDown();
         });
-    waiter.await();
-    assertEquals(7, result.size());
+    await().until(() -> result.size() == 7);
     assertThat(result, hasItems("sysroot", "srv", "var", "tmp", "bin", "lib", "usr"));
+    return true;
   }
 
   @Test
   public void testListDirsAndFilesAndSymlinks() throws Exception {
-    File sysroot = new File(Environment.getExternalStorageDirectory(), "sysroot");
-    sysroot.mkdir();
-    for (String s : new String[] {"srv", "var", "tmp"}) {
-      File subdir = new File(sysroot, s);
-      subdir.mkdir();
-      Files.createSymbolicLink(
-          Paths.get(new File(Environment.getExternalStorageDirectory(), s).getAbsolutePath()),
-          Paths.get(subdir.getAbsolutePath()));
-    }
-    for (String s : new String[] {"bin", "lib", "usr"}) {
-      new File(Environment.getExternalStorageDirectory(), s).mkdir();
-    }
+    createNecessaryDirsForSymlinkRelatedTests();
     for (int i = 1; i <= 4; i++) {
       File f = new File(Environment.getExternalStorageDirectory(), i + ".txt");
       FileOutputStream out = new FileOutputStream(f);
@@ -147,23 +140,12 @@ public class ListFilesOnSshdTest extends AbstractSftpServerTest {
 
   @Test
   public void testListDirsAndBrokenSymlinks() throws Exception {
-    File sysroot = new File(Environment.getExternalStorageDirectory(), "sysroot");
-    sysroot.mkdir();
+    createNecessaryDirsForSymlinkRelatedTests();
     Files.createSymbolicLink(
         Paths.get(
             new File(Environment.getExternalStorageDirectory(), "b0rken.symlink")
                 .getAbsolutePath()),
         Paths.get(new File("/tmp/notfound.file").getAbsolutePath()));
-    for (String s : new String[] {"srv", "var", "tmp"}) {
-      File subdir = new File(sysroot, s);
-      subdir.mkdir();
-      Files.createSymbolicLink(
-          Paths.get(new File(Environment.getExternalStorageDirectory(), s).getAbsolutePath()),
-          Paths.get(subdir.getAbsolutePath()));
-    }
-    for (String s : new String[] {"bin", "lib", "usr"}) {
-      new File(Environment.getExternalStorageDirectory(), s).mkdir();
-    }
-    performVerify();
+    assertTrue(performVerify());
   }
 }


### PR DESCRIPTION
Fix by adding a try/catch here can keep the loop to stay at HybridFile.forEachChildrenFile() for SSH servers.

#### Release  
Addresses release/3.5
  
#### Test cases
- [x] Covered
  
#### Manual testing
- [x] Done  
  
If yes,  
- Device: Fairphone 3
- OS: Lineage OS 16.0 (9.0)

#### Build tasks success  
Successfully running following tasks on local 
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`