### PR TITLE
Fix OTG not loading file lists on Android >= N + refactoring

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -80,6 +80,7 @@ android {
     testOptions {
         unitTests {
             includeAndroidResources = true
+            returnDefaultValues = true
         }
     }
 }
@@ -93,6 +94,7 @@ ext {
     roomVersion = '2.2.5'
     bouncyCastleVersion = '1.65'
     awaitilityVersion = "3.1.6"
+    mockitoVersion = "3.4.4"
 }
 
 dependencies {
@@ -115,7 +117,7 @@ dependencies {
     testImplementation 'junit:junit:4.12'//tests the app logic
     testImplementation "org.robolectric:robolectric:$robolectricVersion"//tests android interaction
     testImplementation "org.robolectric:shadows-httpclient:$robolectricVersion"//tests android interaction
-
+    testImplementation "org.mockito:mockito-core:$mockitoVersion"
     testImplementation "org.apache.sshd:sshd-core:1.7.0"
     testImplementation "org.awaitility:awaitility:$awaitilityVersion"
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -113,8 +113,8 @@ dependencies {
     annotationProcessor 'androidx.annotation:annotation:1.1.0'
 
     //For tests
-    androidTestImplementation 'junit:junit:4.12'//tests the app logic
-    testImplementation 'junit:junit:4.12'//tests the app logic
+    androidTestImplementation 'junit:junit:4.13'//tests the app logic
+    testImplementation 'junit:junit:4.13'//tests the app logic
     testImplementation "org.robolectric:robolectric:$robolectricVersion"//tests android interaction
     testImplementation "org.robolectric:shadows-httpclient:$robolectricVersion"//tests android interaction
     testImplementation "org.mockito:mockito-core:$mockitoVersion"

--- a/app/src/main/java/com/amaze/filemanager/adapters/data/StorageDirectoryParcelable.java
+++ b/app/src/main/java/com/amaze/filemanager/adapters/data/StorageDirectoryParcelable.java
@@ -28,17 +28,17 @@ import androidx.annotation.NonNull;
 
 /** Identifies a mounted volume */
 public class StorageDirectoryParcelable implements Parcelable {
-  public final String path;
-  public final String name;
+  @NonNull public final String path;
+  @NonNull public final String name;
   public final @DrawableRes int iconRes;
 
-  public StorageDirectoryParcelable(String path, String name, int iconRes) {
+  public StorageDirectoryParcelable(@NonNull String path, @NonNull String name, int iconRes) {
     this.path = path;
     this.name = name;
     this.iconRes = iconRes;
   }
 
-  public StorageDirectoryParcelable(Parcel im) {
+  public StorageDirectoryParcelable(@NonNull Parcel im) {
     path = im.readString();
     name = im.readString();
     iconRes = im.readInt();

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/LoadFilesListTask.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/LoadFilesListTask.java
@@ -55,6 +55,8 @@ import android.os.AsyncTask;
 import android.provider.MediaStore;
 import android.text.format.Formatter;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.core.util.Pair;
 
 import jcifs.smb.SmbAuthException;
@@ -299,72 +301,42 @@ public class LoadFilesListTask
   }
 
   private ArrayList<LayoutElementParcelable> listImages() {
-    ArrayList<LayoutElementParcelable> images = new ArrayList<>();
     final String[] projection = {MediaStore.Images.Media.DATA};
-    final Cursor cursor =
-        context
-            .getContentResolver()
-            .query(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, projection, null, null, null);
-    if (cursor == null) return images;
-    else if (cursor.getCount() > 0 && cursor.moveToFirst()) {
-      do {
-        String path = cursor.getString(cursor.getColumnIndex(MediaStore.Files.FileColumns.DATA));
-        HybridFileParcelable strings = RootHelper.generateBaseFile(new File(path), showHiddenFiles);
-        if (strings != null) {
-          LayoutElementParcelable parcelable = createListParcelables(strings);
-          if (parcelable != null) images.add(parcelable);
-        }
-      } while (cursor.moveToNext());
-    }
-    cursor.close();
-    return images;
+    return listMediaCommon(projection, null);
   }
 
   private ArrayList<LayoutElementParcelable> listVideos() {
-    ArrayList<LayoutElementParcelable> videos = new ArrayList<>();
-    final String[] projection = {MediaStore.Images.Media.DATA};
-    final Cursor cursor =
-        context
-            .getContentResolver()
-            .query(MediaStore.Video.Media.EXTERNAL_CONTENT_URI, projection, null, null, null);
-    if (cursor == null) return videos;
-    else if (cursor.getCount() > 0 && cursor.moveToFirst()) {
-      do {
-        String path = cursor.getString(cursor.getColumnIndex(MediaStore.Files.FileColumns.DATA));
-        HybridFileParcelable strings = RootHelper.generateBaseFile(new File(path), showHiddenFiles);
-        if (strings != null) {
-          LayoutElementParcelable parcelable = createListParcelables(strings);
-          if (parcelable != null) videos.add(parcelable);
-        }
-      } while (cursor.moveToNext());
-    }
-    cursor.close();
-    return videos;
+    final String[] projection = {MediaStore.Video.Media.DATA};
+    return listMediaCommon(projection, null);
   }
 
   private ArrayList<LayoutElementParcelable> listaudio() {
     String selection = MediaStore.Audio.Media.IS_MUSIC + " != 0";
     String[] projection = {MediaStore.Audio.Media.DATA};
+    return listMediaCommon(projection, selection);
+  }
 
+  private @NonNull ArrayList<LayoutElementParcelable> listMediaCommon(
+      @NonNull String[] projection, @Nullable String selection) {
     Cursor cursor =
         context
             .getContentResolver()
             .query(MediaStore.Audio.Media.EXTERNAL_CONTENT_URI, projection, selection, null, null);
 
-    ArrayList<LayoutElementParcelable> songs = new ArrayList<>();
-    if (cursor == null) return songs;
+    ArrayList<LayoutElementParcelable> retval = new ArrayList<>();
+    if (cursor == null) return retval;
     else if (cursor.getCount() > 0 && cursor.moveToFirst()) {
       do {
         String path = cursor.getString(cursor.getColumnIndex(MediaStore.Files.FileColumns.DATA));
         HybridFileParcelable strings = RootHelper.generateBaseFile(new File(path), showHiddenFiles);
         if (strings != null) {
           LayoutElementParcelable parcelable = createListParcelables(strings);
-          if (parcelable != null) songs.add(parcelable);
+          if (parcelable != null) retval.add(parcelable);
         }
       } while (cursor.moveToNext());
     }
     cursor.close();
-    return songs;
+    return retval;
   }
 
   private ArrayList<LayoutElementParcelable> listDocs() {

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/PrepareCopyTask.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/PrepareCopyTask.java
@@ -239,7 +239,7 @@ public class PrepareCopyTask
 
     final MaterialDialog dialog = dialogBuilder.build();
     dialog.show();
-    if (filesToCopy.get(0).getParent().equals(path)) {
+    if (filesToCopy.get(0).getParent(context).equals(path)) {
       View negative = dialog.getActionButton(DialogAction.NEGATIVE);
       negative.setEnabled(false);
     }

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/services/CopyService.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/services/CopyService.java
@@ -535,7 +535,7 @@ public class CopyService extends AbstractProgressiveService {
       return RootHelper.fileExists(hFile2.getPath());
     } else {
       ArrayList<HybridFileParcelable> baseFiles =
-          RootHelper.getFilesList(hFile1.getParent(), true, true, null);
+          RootHelper.getFilesList(hFile1.getParent(c), true, true, null);
       int i = -1;
       int index = -1;
       for (HybridFileParcelable b : baseFiles) {
@@ -546,7 +546,7 @@ public class CopyService extends AbstractProgressiveService {
         }
       }
       ArrayList<HybridFileParcelable> baseFiles1 =
-          RootHelper.getFilesList(hFile1.getParent(), true, true, null);
+          RootHelper.getFilesList(hFile1.getParent(c), true, true, null);
       int i1 = -1;
       int index1 = -1;
       for (HybridFileParcelable b : baseFiles1) {

--- a/app/src/main/java/com/amaze/filemanager/database/UtilsHandler.java
+++ b/app/src/main/java/com/amaze/filemanager/database/UtilsHandler.java
@@ -155,15 +155,15 @@ public class UtilsHandler {
   }
 
   public void addCommonBookmarks() {
-    String sd = Environment.getExternalStorageDirectory() + "/";
+    File sd = Environment.getExternalStorageDirectory();
 
     String[] dirs =
         new String[] {
-          sd + Environment.DIRECTORY_DCIM,
-          sd + Environment.DIRECTORY_DOWNLOADS,
-          sd + Environment.DIRECTORY_MOVIES,
-          sd + Environment.DIRECTORY_MUSIC,
-          sd + Environment.DIRECTORY_PICTURES
+          new File(sd, Environment.DIRECTORY_DCIM).getAbsolutePath(),
+          new File(sd, Environment.DIRECTORY_DOWNLOADS).getAbsolutePath(),
+          new File(sd, Environment.DIRECTORY_MOVIES).getAbsolutePath(),
+          new File(sd, Environment.DIRECTORY_MUSIC).getAbsolutePath(),
+          new File(sd, Environment.DIRECTORY_PICTURES).getAbsolutePath()
         };
 
     for (String dir : dirs) {

--- a/app/src/main/java/com/amaze/filemanager/filesystem/FileUtil.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/FileUtil.java
@@ -1170,7 +1170,7 @@ public abstract class FileUtil {
     }
 
     private File installTemporaryTrack() throws IOException {
-      File externalFilesDir = getExternalFilesDir(context);
+      File externalFilesDir = context.getExternalFilesDir(null);
       if (externalFilesDir == null) {
         return null;
       }

--- a/app/src/main/java/com/amaze/filemanager/filesystem/FileUtil.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/FileUtil.java
@@ -278,8 +278,7 @@ public abstract class FileUtil {
                     } else {
                       OutputStream outputStream = targetSmbFile.getOutputStream();
                       bufferedOutputStream = new BufferedOutputStream(outputStream);
-                      retval.add(
-                          mainActivity.mainActivityHelper.parseSmbPath(targetSmbFile.getPath()));
+                      retval.add(HybridFile.parseSmbPath(targetSmbFile.getPath()));
                     }
                     break;
                   case SFTP:

--- a/app/src/main/java/com/amaze/filemanager/filesystem/HybridFile.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/HybridFile.java
@@ -723,7 +723,13 @@ public class HybridFile {
                   try {
                     for (RemoteResourceInfo info :
                         client.ls(SshClientUtils.extractRemotePathFrom(path))) {
-                      boolean isDirectory = SshClientUtils.isDirectory(client, info);
+                      boolean isDirectory = false;
+                      try {
+                        isDirectory = SshClientUtils.isDirectory(client, info);
+                      } catch (IOException ifBrokenSymlink) {
+                        Log.w(TAG, "IOException checking isDirectory(): " + info.getPath());
+                        continue;
+                      }
                       HybridFileParcelable f = new HybridFileParcelable(path, isDirectory, info);
                       onFileFound.onFileFound(f);
                     }
@@ -786,7 +792,13 @@ public class HybridFile {
                       try {
                         for (RemoteResourceInfo info :
                             client.ls(SshClientUtils.extractRemotePathFrom(path))) {
-                          boolean isDirectory = SshClientUtils.isDirectory(client, info);
+                          boolean isDirectory = false;
+                          try {
+                            isDirectory = SshClientUtils.isDirectory(client, info);
+                          } catch (IOException ifBrokenSymlink) {
+                            Log.w(TAG, "IOException checking isDirectory(): " + info.getPath());
+                            continue;
+                          }
                           HybridFileParcelable f =
                               new HybridFileParcelable(path, isDirectory, info);
                           retval.add(f);

--- a/app/src/main/java/com/amaze/filemanager/filesystem/HybridFile.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/HybridFile.java
@@ -818,12 +818,7 @@ public class HybridFile {
         try {
           SmbFile smbFile = new SmbFile(path);
           for (SmbFile smbFile1 : smbFile.listFiles()) {
-            HybridFileParcelable baseFile = new HybridFileParcelable(smbFile1.getPath());
-            baseFile.setName(smbFile1.getName());
-            baseFile.setMode(OpenMode.SMB);
-            baseFile.setDirectory(smbFile1.isDirectory());
-            baseFile.setDate(smbFile1.lastModified());
-            baseFile.setSize(baseFile.isDirectory() ? 0 : smbFile1.length());
+            HybridFileParcelable baseFile = new HybridFileParcelable(smbFile1);
             arrayList.add(baseFile);
           }
         } catch (MalformedURLException e) {
@@ -861,12 +856,12 @@ public class HybridFile {
     return path;
   }
 
-  String parseSftpPath(String a) {
+  public static String parseSftpPath(String a) {
     if (a.contains("@")) return "ssh://" + a.substring(a.indexOf("@") + 1, a.length());
     else return a;
   }
 
-  String parseSmbPath(String a) {
+  public static String parseSmbPath(String a) {
     if (a.contains("@")) return "smb://" + a.substring(a.indexOf("@") + 1, a.length());
     else return a;
   }

--- a/app/src/main/java/com/amaze/filemanager/filesystem/HybridFile.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/HybridFile.java
@@ -57,19 +57,18 @@ import android.preference.PreferenceManager;
 import android.util.Log;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.documentfile.provider.DocumentFile;
 
 import jcifs.smb.SmbException;
 import jcifs.smb.SmbFile;
 import net.schmizz.sshj.SSHClient;
 import net.schmizz.sshj.common.Buffer;
-import net.schmizz.sshj.sftp.FileAttributes;
 import net.schmizz.sshj.sftp.FileMode;
 import net.schmizz.sshj.sftp.RemoteFile;
 import net.schmizz.sshj.sftp.RemoteResourceInfo;
 import net.schmizz.sshj.sftp.SFTPClient;
 import net.schmizz.sshj.sftp.SFTPException;
-import net.schmizz.sshj.xfer.FilePermission;
 
 /** Created by Arpit on 07-07-2015. */
 // Hybrid file for handeling all types of files
@@ -194,6 +193,7 @@ public class HybridFile {
     return mode == OpenMode.GDRIVE;
   }
 
+  @Nullable
   public File getFile() {
     return new File(path);
   }
@@ -210,21 +210,19 @@ public class HybridFile {
   public long lastModified() throws SmbException {
     switch (mode) {
       case SFTP:
-        SshClientUtils.execute(
+        return SshClientUtils.<Long>execute(
             new SFtpClientTemplate(path) {
               @Override
-              public Long execute(SFTPClient client) throws IOException {
+              public Long execute(@NonNull SFTPClient client) throws IOException {
                 return client.mtime(SshClientUtils.extractRemotePathFrom(path));
               }
             });
-        break;
       case SMB:
         SmbFile smbFile = getSmbFile();
         if (smbFile != null) return smbFile.lastModified();
         break;
       case FILE:
-        new File(path).lastModified();
-        break;
+        return getFile().lastModified();
       case ROOT:
         HybridFileParcelable baseFile = generateBaseFileFromParent();
         if (baseFile != null) return baseFile.getDate();
@@ -232,40 +230,8 @@ public class HybridFile {
     return new File("/").lastModified();
   }
 
-  /** @deprecated use {@link #length(Context)} to handle content resolvers */
-  public long length() {
-    long s = 0L;
-    switch (mode) {
-      case SFTP:
-        return SshClientUtils.execute(
-            new SFtpClientTemplate(path) {
-              @Override
-              public Long execute(SFTPClient client) throws IOException {
-                return client.size(SshClientUtils.extractRemotePathFrom(path));
-              }
-            });
-      case SMB:
-        SmbFile smbFile = getSmbFile();
-        if (smbFile != null)
-          try {
-            s = smbFile.length();
-          } catch (SmbException e) {
-          }
-        return s;
-      case FILE:
-        s = new File(path).length();
-        return s;
-      case ROOT:
-        HybridFileParcelable baseFile = generateBaseFileFromParent();
-        if (baseFile != null) return baseFile.getSize();
-        break;
-    }
-    return s;
-  }
-
   /** Helper method to find length */
   public long length(Context context) {
-
     long s = 0l;
     switch (mode) {
       case SFTP:
@@ -279,7 +245,7 @@ public class HybridFile {
           }
         return s;
       case FILE:
-        s = new File(path).length();
+        s = getFile().length();
         return s;
       case ROOT:
         HybridFileParcelable baseFile = generateBaseFileFromParent();
@@ -335,9 +301,9 @@ public class HybridFile {
         if (smbFile != null) return smbFile.getName();
         break;
       case FILE:
-        return new File(path).getName();
+        return getFile().getName();
       case ROOT:
-        return new File(path).getName();
+        return getFile().getName();
       default:
         StringBuilder builder = new StringBuilder(path);
         name = builder.substring(builder.lastIndexOf("/") + 1, builder.length());
@@ -353,14 +319,12 @@ public class HybridFile {
         if (smbFile != null) return smbFile.getName();
         break;
       case FILE:
-        return new File(path).getName();
       case ROOT:
-        return new File(path).getName();
+        return getFile().getName();
       case OTG:
         return OTGUtil.getDocumentFile(path, context, false).getName();
       default:
-        StringBuilder builder = new StringBuilder(path);
-        name = builder.substring(builder.lastIndexOf("/") + 1, builder.length());
+        name = path.substring(path.lastIndexOf('/'));
     }
     return name;
   }
@@ -393,33 +357,6 @@ public class HybridFile {
         || path.equals("6");
   }
 
-  /**
-   * Returns a path to parent for various {@link #mode}
-   *
-   * @deprecated use {@link #getParent(Context)} to handle content resolvers
-   */
-  public String getParent() {
-    String parentPath = "";
-    switch (mode) {
-      case SMB:
-        try {
-          parentPath = new SmbFile(path).getParent();
-        } catch (MalformedURLException e) {
-          parentPath = "";
-          e.printStackTrace();
-        }
-        break;
-      case FILE:
-      case ROOT:
-        parentPath = new File(path).getParent();
-        break;
-      default:
-        StringBuilder builder = new StringBuilder(path);
-        return builder.substring(0, builder.length() - (getName().length() + 1));
-    }
-    return parentPath;
-  }
-
   /** Helper method to get parent path */
   public String getParent(Context context) {
 
@@ -435,7 +372,7 @@ public class HybridFile {
         break;
       case FILE:
       case ROOT:
-        parentPath = new File(path).getParent();
+        parentPath = getFile().getParent();
         break;
       case OTG:
       default:
@@ -478,7 +415,7 @@ public class HybridFile {
         }
         break;
       case FILE:
-        isDirectory = new File(path).isDirectory();
+        isDirectory = getFile().isDirectory();
         break;
       case ROOT:
         try {
@@ -494,7 +431,7 @@ public class HybridFile {
         isDirectory = false;
         break;
       default:
-        isDirectory = new File(path).isDirectory();
+        isDirectory = getFile().isDirectory();
         break;
     }
     return isDirectory;
@@ -531,7 +468,7 @@ public class HybridFile {
         }
         break;
       case FILE:
-        isDirectory = new File(path).isDirectory();
+        isDirectory = getFile().isDirectory();
         break;
       case ROOT:
         try {
@@ -573,7 +510,7 @@ public class HybridFile {
                 .getFolder();
         break;
       default:
-        isDirectory = new File(path).isDirectory();
+        isDirectory = getFile().isDirectory();
         break;
     }
     return isDirectory;
@@ -595,7 +532,7 @@ public class HybridFile {
         }
         break;
       case FILE:
-        size = FileUtils.folderSize(new File(path), null);
+        size = FileUtils.folderSize(getFile(), null);
         break;
       case ROOT:
         HybridFileParcelable baseFile = generateBaseFileFromParent();
@@ -630,7 +567,7 @@ public class HybridFile {
         }
         break;
       case FILE:
-        size = FileUtils.folderSize(new File(path), null);
+        size = FileUtils.folderSize(getFile(), null);
         break;
       case ROOT:
         HybridFileParcelable baseFile = generateBaseFileFromParent();
@@ -670,7 +607,7 @@ public class HybridFile {
         break;
       case FILE:
       case ROOT:
-        size = new File(path).getUsableSpace();
+        size = getFile().getUsableSpace();
         break;
       case DROPBOX:
       case BOX:
@@ -729,7 +666,7 @@ public class HybridFile {
         break;
       case FILE:
       case ROOT:
-        size = new File(path).getTotalSpace();
+        size = getFile().getTotalSpace();
         break;
       case DROPBOX:
       case BOX:
@@ -786,29 +723,8 @@ public class HybridFile {
                   try {
                     for (RemoteResourceInfo info :
                         client.ls(SshClientUtils.extractRemotePathFrom(path))) {
-                      boolean isDirectory = info.isDirectory();
-                      if (info.getAttributes().getType().equals(FileMode.Type.SYMLINK)) {
-                        try {
-                          FileAttributes symlinkAttrs = client.stat(info.getPath());
-                          isDirectory = symlinkAttrs.getType().equals(FileMode.Type.DIRECTORY);
-                        } catch (IOException ifSymlinkIsBroken) {
-                          Log.w(
-                              TAG,
-                              String.format(
-                                  "Symbolic link %s is broken, skipping", info.getPath()));
-                          continue;
-                        }
-                      }
-                      HybridFileParcelable f =
-                          new HybridFileParcelable(String.format("%s/%s", path, info.getName()));
-                      f.setName(info.getName());
-                      f.setMode(OpenMode.SFTP);
-                      f.setDirectory(isDirectory);
-                      f.setDate(info.getAttributes().getMtime() * 1000);
-                      f.setSize(isDirectory ? 0 : info.getAttributes().getSize());
-                      f.setPermission(
-                          Integer.toString(
-                              FilePermission.toMask(info.getAttributes().getPermissions()), 8));
+                      boolean isDirectory = SshClientUtils.isDirectory(client, info);
+                      HybridFileParcelable f = new HybridFileParcelable(path, isDirectory, info);
                       onFileFound.onFileFound(f);
                     }
                   } catch (IOException e) {
@@ -825,12 +741,7 @@ public class HybridFile {
         try {
           SmbFile smbFile = new SmbFile(path);
           for (SmbFile smbFile1 : smbFile.listFiles()) {
-            HybridFileParcelable baseFile = new HybridFileParcelable(smbFile1.getPath());
-            baseFile.setName(smbFile1.getName());
-            baseFile.setMode(OpenMode.SMB);
-            baseFile.setDirectory(smbFile1.isDirectory());
-            baseFile.setDate(smbFile1.lastModified());
-            baseFile.setSize(baseFile.isDirectory() ? 0 : smbFile1.length());
+            HybridFileParcelable baseFile = new HybridFileParcelable(smbFile1);
             onFileFound.onFileFound(baseFile);
           }
         } catch (MalformedURLException | SmbException e) {
@@ -875,17 +786,9 @@ public class HybridFile {
                       try {
                         for (RemoteResourceInfo info :
                             client.ls(SshClientUtils.extractRemotePathFrom(path))) {
+                          boolean isDirectory = SshClientUtils.isDirectory(client, info);
                           HybridFileParcelable f =
-                              new HybridFileParcelable(
-                                  String.format("%s/%s", path, info.getName()));
-                          f.setName(info.getName());
-                          f.setMode(OpenMode.SFTP);
-                          f.setDirectory(info.isDirectory());
-                          f.setDate(info.getAttributes().getMtime() * 1000);
-                          f.setSize(f.isDirectory() ? 0 : info.getAttributes().getSize());
-                          f.setPermission(
-                              Integer.toString(
-                                  FilePermission.toMask(info.getAttributes().getPermissions()), 8));
+                              new HybridFileParcelable(path, isDirectory, info);
                           retval.add(f);
                         }
                       } catch (IOException e) {
@@ -912,10 +815,10 @@ public class HybridFile {
             arrayList.add(baseFile);
           }
         } catch (MalformedURLException e) {
-          if (arrayList != null) arrayList.clear();
+          arrayList.clear();
           e.printStackTrace();
         } catch (SmbException e) {
-          if (arrayList != null) arrayList.clear();
+          arrayList.clear();
           e.printStackTrace();
         }
         break;
@@ -1119,7 +1022,7 @@ public class HybridFile {
         break;
       default:
         try {
-          outputStream = FileUtil.getOutputStream(new File(path), context);
+          outputStream = FileUtil.getOutputStream(getFile(), context);
         } catch (Exception e) {
           outputStream = null;
           e.printStackTrace();
@@ -1163,7 +1066,7 @@ public class HybridFile {
       CloudStorage cloudStorageOneDrive = dataUtils.getAccount(OpenMode.ONEDRIVE);
       exists = cloudStorageOneDrive.exists(CloudUtil.stripPath(OpenMode.ONEDRIVE, path));
     } else if (isLocal()) {
-      exists = new File(path).exists();
+      exists = getFile().exists();
     } else if (isRoot()) {
       return RootHelper.fileExists(path);
     }
@@ -1189,7 +1092,7 @@ public class HybridFile {
         && !isOtgFile()
         && !isCustomPath()
         && !android.util.Patterns.EMAIL_ADDRESS.matcher(path).matches()
-        && !new File(path).isDirectory()
+        && (getFile() != null && !getFile().isDirectory())
         && !isOneDriveFile()
         && !isGoogleDriveFile()
         && !isDropBoxFile()
@@ -1208,7 +1111,7 @@ public class HybridFile {
         return false;
       }
     }
-    File f = new File(path);
+    File f = getFile();
     return f.setLastModified(date);
   }
 
@@ -1267,7 +1170,7 @@ public class HybridFile {
       } catch (Exception e) {
         e.printStackTrace();
       }
-    } else FileUtil.mkdir(new File(path), context);
+    } else FileUtil.mkdir(getFile(), context);
   }
 
   public boolean delete(Context context, boolean rootmode) throws ShellNotRunningException {
@@ -1294,7 +1197,7 @@ public class HybridFile {
         setMode(OpenMode.ROOT);
         RootUtils.delete(getPath());
       } else {
-        FileUtil.deleteFile(new File(path), context);
+        FileUtil.deleteFile(getFile(), context);
       }
     }
     return !exists();
@@ -1320,7 +1223,7 @@ public class HybridFile {
     switch (mode) {
       case FILE:
       case ROOT:
-        File file = new File(path);
+        File file = getFile();
         LayoutElementParcelable layoutElement;
         if (isDirectory()) {
 

--- a/app/src/main/java/com/amaze/filemanager/filesystem/HybridFileParcelable.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/HybridFileParcelable.java
@@ -56,6 +56,12 @@ public class HybridFileParcelable extends HybridFile implements Parcelable {
     this.permission = permission;
   }
 
+  /**
+   * Constructor for jcifs {@link SmbFile}.
+   *
+   * @param smbFile
+   * @throws SmbException
+   */
   public HybridFileParcelable(SmbFile smbFile) throws SmbException {
     super(OpenMode.SMB, smbFile.getPath());
     setName(smbFile.getName());
@@ -64,6 +70,13 @@ public class HybridFileParcelable extends HybridFile implements Parcelable {
     setSize(smbFile.isDirectory() ? 0 : smbFile.length());
   }
 
+  /**
+   * Constructor for sshj {@link RemoteResourceInfo}.
+   *
+   * @param path
+   * @param isDirectory
+   * @param sshFile
+   */
   public HybridFileParcelable(String path, boolean isDirectory, RemoteResourceInfo sshFile) {
     super(OpenMode.SFTP, String.format("%s/%s", path, sshFile.getName()));
     setName(sshFile.getName());

--- a/app/src/main/java/com/amaze/filemanager/filesystem/Operations.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/Operations.java
@@ -133,7 +133,8 @@ public class Operations {
           DocumentFile directoryToCreate = OTGUtil.getDocumentFile(file.getPath(), context, false);
           if (directoryToCreate != null) errorCallBack.exists(file);
 
-          DocumentFile parentDirectory = OTGUtil.getDocumentFile(file.getParent(), context, false);
+          DocumentFile parentDirectory =
+              OTGUtil.getDocumentFile(file.getParent(context), context, false);
           if (parentDirectory.isDirectory()) {
             parentDirectory.createDirectory(file.getName(context));
             errorCallBack.done(file, true);
@@ -178,7 +179,7 @@ public class Operations {
           }
         } else {
           if (file.isLocal() || file.isRoot()) {
-            int mode = checkFolder(new File(file.getParent()), context);
+            int mode = checkFolder(new File(file.getParent(context)), context);
             if (mode == 2) {
               errorCallBack.launchSAF(file);
               return null;
@@ -317,7 +318,8 @@ public class Operations {
           DocumentFile fileToCreate = OTGUtil.getDocumentFile(file.getPath(), context, false);
           if (fileToCreate != null) errorCallBack.exists(file);
 
-          DocumentFile parentDirectory = OTGUtil.getDocumentFile(file.getParent(), context, false);
+          DocumentFile parentDirectory =
+              OTGUtil.getDocumentFile(file.getParent(context), context, false);
           if (parentDirectory.isDirectory()) {
             parentDirectory.createFile(
                 file.getName(context).substring(file.getName(context).lastIndexOf(".")),
@@ -327,7 +329,7 @@ public class Operations {
           return null;
         } else {
           if (file.isLocal() || file.isRoot()) {
-            int mode = checkFolder(new File(file.getParent()), context);
+            int mode = checkFolder(new File(file.getParent(context)), context);
             if (mode == 2) {
               errorCallBack.launchSAF(file);
               return null;

--- a/app/src/main/java/com/amaze/filemanager/filesystem/files/FileUtils.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/files/FileUtils.java
@@ -800,7 +800,9 @@ public class FileUtils {
 
   public static boolean isRoot(
       String dir) { // TODO: 5/5/2017 hardcoding root might lead to problems down the line
-    return !dir.contains(OTGUtil.PREFIX_OTG) && !dir.startsWith("/storage");
+    return !dir.contains(OTGUtil.PREFIX_OTG)
+        && !dir.startsWith(OTGUtil.PREFIX_MEDIA_REMOVABLE)
+        && !dir.startsWith("/storage");
   }
 
   /** Converts ArrayList of HybridFileParcelable to ArrayList of File */

--- a/app/src/main/java/com/amaze/filemanager/filesystem/ssh/SshClientUtils.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/ssh/SshClientUtils.java
@@ -287,7 +287,8 @@ public abstract class SshClientUtils {
         : String.format("ssh://%s:%s@%s:%d", username, password, hostname, port);
   }
 
-  public static boolean isDirectory(@NonNull SFTPClient client, @NonNull RemoteResourceInfo info) {
+  public static boolean isDirectory(@NonNull SFTPClient client, @NonNull RemoteResourceInfo info)
+      throws IOException {
     boolean isDirectory = info.isDirectory();
     if (info.getAttributes().getType().equals(FileMode.Type.SYMLINK)) {
       try {
@@ -295,6 +296,7 @@ public abstract class SshClientUtils {
         isDirectory = symlinkAttrs.getType().equals(FileMode.Type.DIRECTORY);
       } catch (IOException ifSymlinkIsBroken) {
         Log.w(TAG, String.format("Symbolic link %s is broken, skipping", info.getPath()));
+        throw ifSymlinkIsBroken;
       }
     }
     return isDirectory;

--- a/app/src/main/java/com/amaze/filemanager/filesystem/ssh/SshClientUtils.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/ssh/SshClientUtils.java
@@ -49,6 +49,9 @@ import androidx.annotation.NonNull;
 
 import net.schmizz.sshj.SSHClient;
 import net.schmizz.sshj.connection.channel.direct.Session;
+import net.schmizz.sshj.sftp.FileAttributes;
+import net.schmizz.sshj.sftp.FileMode;
+import net.schmizz.sshj.sftp.RemoteResourceInfo;
 import net.schmizz.sshj.sftp.SFTPClient;
 
 public abstract class SshClientUtils {
@@ -282,5 +285,18 @@ public abstract class SshClientUtils {
     return (selectedParsedKeyPair != null || password == null)
         ? String.format("ssh://%s@%s:%d", username, hostname, port)
         : String.format("ssh://%s:%s@%s:%d", username, password, hostname, port);
+  }
+
+  public static boolean isDirectory(@NonNull SFTPClient client, @NonNull RemoteResourceInfo info) {
+    boolean isDirectory = info.isDirectory();
+    if (info.getAttributes().getType().equals(FileMode.Type.SYMLINK)) {
+      try {
+        FileAttributes symlinkAttrs = client.stat(info.getPath());
+        isDirectory = symlinkAttrs.getType().equals(FileMode.Type.DIRECTORY);
+      } catch (IOException ifSymlinkIsBroken) {
+        Log.w(TAG, String.format("Symbolic link %s is broken, skipping", info.getPath()));
+      }
+    }
+    return isDirectory;
   }
 }

--- a/app/src/main/java/com/amaze/filemanager/ui/activities/MainActivity.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/activities/MainActivity.java
@@ -1213,7 +1213,7 @@ public class MainActivity extends PermissionsActivity
     registerReceiver(mainActivityHelper.mNotificationReceiver, newFilter);
     registerReceiver(receiver2, new IntentFilter(TAG_INTENT_FILTER_GENERAL));
 
-    if (SDK_INT >= Build.VERSION_CODES.KITKAT && SDK_INT < Build.VERSION_CODES.N) {
+    if (SDK_INT >= Build.VERSION_CODES.KITKAT) {
       updateUsbInformation();
     }
   }
@@ -1484,10 +1484,9 @@ public class MainActivity extends PermissionsActivity
     } else if (requestCode == REQUEST_CODE_SAF) {
       if (responseCode == Activity.RESULT_OK && intent.getData() != null) {
         // otg access
-        Uri usbOtgRoot = Uri.parse(intent.getData().toString());
+        Uri usbOtgRoot = intent.getData();
         SingletonUsbOtg.getInstance().setUsbOtgRoot(usbOtgRoot);
         getCurrentMainFragment().loadlist(OTGUtil.PREFIX_OTG, false, OpenMode.OTG);
-
         drawer.closeIfNotLocked();
         if (drawer.isLocked()) drawer.onDrawerClosed();
       } else {

--- a/app/src/main/java/com/amaze/filemanager/ui/views/appbar/BottomBar.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/views/appbar/BottomBar.java
@@ -25,6 +25,7 @@ import static com.amaze.filemanager.ui.fragments.preference_fragments.Preference
 import java.util.ArrayList;
 
 import com.amaze.filemanager.R;
+import com.amaze.filemanager.filesystem.HybridFile;
 import com.amaze.filemanager.filesystem.files.FileUtils;
 import com.amaze.filemanager.ui.activities.MainActivity;
 import com.amaze.filemanager.ui.dialogs.GeneralDialogCreation;
@@ -341,10 +342,10 @@ public class BottomBar implements View.OnTouchListener {
 
     switch (openmode) {
       case SFTP:
-        newPath = mainActivityHelper.parseSftpPath(news);
+        newPath = HybridFile.parseSftpPath(news);
         break;
       case SMB:
-        newPath = mainActivityHelper.parseSmbPath(news);
+        newPath = HybridFile.parseSmbPath(news);
         break;
       case OTG:
         newPath = mainActivityHelper.parseOTGPath(news);

--- a/app/src/main/java/com/amaze/filemanager/ui/views/drawer/Drawer.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/views/drawer/Drawer.java
@@ -263,7 +263,7 @@ public class Drawer implements NavigationView.OnNavigationItemSelectedListener {
 
       storageDirectoryPaths.add(file);
 
-      if (file.contains(OTGUtil.PREFIX_OTG)) {
+      if (file.contains(OTGUtil.PREFIX_OTG) || file.startsWith(OTGUtil.PREFIX_MEDIA_REMOVABLE)) {
         addNewItem(
             menu,
             STORAGES_GROUP,
@@ -694,7 +694,8 @@ public class Drawer implements NavigationView.OnNavigationItemSelectedListener {
         }
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP
-            && meta.path.contains(OTGUtil.PREFIX_OTG)
+            && (meta.path.contains(OTGUtil.PREFIX_OTG)
+                || meta.path.startsWith(OTGUtil.PREFIX_MEDIA_REMOVABLE))
             && SingletonUsbOtg.getInstance().getUsbOtgRoot() == null) {
           MaterialDialog dialog = GeneralDialogCreation.showOtgSafExplanationDialog(mainActivity);
           dialog
@@ -705,6 +706,7 @@ public class Drawer implements NavigationView.OnNavigationItemSelectedListener {
                     mainActivity.startActivityForResult(safIntent, MainActivity.REQUEST_CODE_SAF);
                     dialog.dismiss();
                   });
+          dialog.show();
         } else {
           pendingPath = meta.path;
           closeIfNotLocked();

--- a/app/src/main/java/com/amaze/filemanager/utils/MainActivityHelper.java
+++ b/app/src/main/java/com/amaze/filemanager/utils/MainActivityHelper.java
@@ -453,7 +453,10 @@ public class MainActivityHelper {
                           .show();
                       if (ma != null && ma.getActivity() != null) {
                         // retry with dialog prompted again
-                        mkfile(file.getMode(), file.getParent(), ma);
+                        mkfile(
+                            file.getMode(),
+                            file.getParent(mainActivity.getApplicationContext()),
+                            ma);
                       }
                     });
           }
@@ -531,7 +534,10 @@ public class MainActivityHelper {
                           .show();
                       if (ma != null && ma.getActivity() != null) {
                         // retry with dialog prompted again
-                        mkdir(file.getMode(), file.getParent(), ma);
+                        mkdir(
+                            file.getMode(),
+                            file.getParent(mainActivity.getApplicationContext()),
+                            ma);
                       }
                     });
           }

--- a/app/src/main/java/com/amaze/filemanager/utils/MainActivityHelper.java
+++ b/app/src/main/java/com/amaze/filemanager/utils/MainActivityHelper.java
@@ -617,20 +617,10 @@ public class MainActivityHelper {
     } else Toast.makeText(mainActivity, R.string.not_allowed, Toast.LENGTH_SHORT).show();
   }
 
-  public String parseSftpPath(String a) {
-    if (a.contains("@")) return "ssh://" + a.substring(a.lastIndexOf("@") + 1, a.length());
-    else return a;
-  }
-
-  public String parseSmbPath(String a) {
-    if (a.contains("@")) return "smb://" + a.substring(a.indexOf("@") + 1, a.length());
-    else return a;
-  }
-
   /** Retrieve a path with {@link OTGUtil#PREFIX_OTG} as prefix */
   public String parseOTGPath(String path) {
     if (path.contains(OTGUtil.PREFIX_OTG)) return path;
-    else return OTGUtil.PREFIX_OTG + path.substring(path.indexOf(":") + 1, path.length());
+    else return OTGUtil.PREFIX_OTG + path.substring(path.indexOf(":") + 1);
   }
 
   public String parseCloudPath(OpenMode serviceType, String path) {

--- a/app/src/main/java/com/amaze/filemanager/utils/OTGUtil.java
+++ b/app/src/main/java/com/amaze/filemanager/utils/OTGUtil.java
@@ -51,6 +51,8 @@ public class OTGUtil {
 
   public static final String PREFIX_OTG = "otg:/";
 
+  public static final String PREFIX_MEDIA_REMOVABLE = "/mnt/media_rw";
+
   /**
    * Returns an array of list of files at a specific path in OTG
    *

--- a/app/src/test/java/com/amaze/filemanager/filesystem/ssh/SshClientUtilTest.java
+++ b/app/src/test/java/com/amaze/filemanager/filesystem/ssh/SshClientUtilTest.java
@@ -21,6 +21,7 @@
 package com.amaze.filemanager.filesystem.ssh;
 
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -37,7 +38,7 @@ import net.schmizz.sshj.sftp.SFTPClient;
 public class SshClientUtilTest {
 
   @Test
-  public void testIsDirectoryNormal() {
+  public void testIsDirectoryNormal() throws IOException {
     RemoteResourceInfo mock = mock(RemoteResourceInfo.class);
     when(mock.isDirectory()).thenReturn(true);
     FileAttributes mockAttributes =
@@ -48,7 +49,7 @@ public class SshClientUtilTest {
   }
 
   @Test
-  public void testIsDirectoryWithFile() {
+  public void testIsDirectoryWithFile() throws IOException {
     RemoteResourceInfo mock = mock(RemoteResourceInfo.class);
     when(mock.isDirectory()).thenReturn(false);
     FileAttributes mockAttributes =
@@ -87,7 +88,7 @@ public class SshClientUtilTest {
     mockAttributes = new FileAttributes.Builder().withType(FileMode.Type.DIRECTORY).build();
     when(mockClient.stat("/sysroot/etc")).thenThrow(new IOException());
 
-    assertTrue(SshClientUtils.isDirectory(mockClient, mock));
+    assertThrows(IOException.class, () -> SshClientUtils.isDirectory(mockClient, mock));
   }
 
   @Test
@@ -103,6 +104,6 @@ public class SshClientUtilTest {
     mockAttributes = new FileAttributes.Builder().withType(FileMode.Type.DIRECTORY).build();
     when(mockClient.stat("/sysroot/etc")).thenThrow(new IOException());
 
-    assertFalse(SshClientUtils.isDirectory(mockClient, mock));
+    assertThrows(IOException.class, () -> SshClientUtils.isDirectory(mockClient, mock));
   }
 }

--- a/app/src/test/java/com/amaze/filemanager/filesystem/ssh/SshClientUtilTest.java
+++ b/app/src/test/java/com/amaze/filemanager/filesystem/ssh/SshClientUtilTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (C) 2014-2020 Arpit Khurana <arpitkh96@gmail.com>, Vishal Nehra <vishalmeham2@gmail.com>,
+ * Emmanuel Messulam<emmanuelbendavid@gmail.com>, Raymond Lai <airwave209gt at gmail.com> and Contributors.
+ *
+ * This file is part of Amaze File Manager.
+ *
+ * Amaze File Manager is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.amaze.filemanager.filesystem.ssh;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+
+import org.junit.Test;
+
+import net.schmizz.sshj.sftp.FileAttributes;
+import net.schmizz.sshj.sftp.FileMode;
+import net.schmizz.sshj.sftp.RemoteResourceInfo;
+import net.schmizz.sshj.sftp.SFTPClient;
+
+public class SshClientUtilTest {
+
+  @Test
+  public void testIsDirectoryNormal() {
+    RemoteResourceInfo mock = mock(RemoteResourceInfo.class);
+    when(mock.isDirectory()).thenReturn(true);
+    FileAttributes mockAttributes =
+        new FileAttributes.Builder().withType(FileMode.Type.DIRECTORY).build();
+    when(mock.getAttributes()).thenReturn(mockAttributes);
+    SFTPClient mockClient = mock(SFTPClient.class);
+    assertTrue(SshClientUtils.isDirectory(mockClient, mock));
+  }
+
+  @Test
+  public void testIsDirectoryWithFile() {
+    RemoteResourceInfo mock = mock(RemoteResourceInfo.class);
+    when(mock.isDirectory()).thenReturn(false);
+    FileAttributes mockAttributes =
+        new FileAttributes.Builder().withType(FileMode.Type.REGULAR).build();
+    when(mock.getAttributes()).thenReturn(mockAttributes);
+    SFTPClient mockClient = mock(SFTPClient.class);
+    assertFalse(SshClientUtils.isDirectory(mockClient, mock));
+  }
+
+  @Test
+  public void testIsDirectorySymlinkNormal() throws IOException {
+    RemoteResourceInfo mock = mock(RemoteResourceInfo.class);
+    when(mock.getPath()).thenReturn("/sysroot/etc");
+    when(mock.isDirectory()).thenReturn(true);
+    FileAttributes mockAttributes =
+        new FileAttributes.Builder().withType(FileMode.Type.SYMLINK).build();
+    when(mock.getAttributes()).thenReturn(mockAttributes);
+
+    SFTPClient mockClient = mock(SFTPClient.class);
+    mockAttributes = new FileAttributes.Builder().withType(FileMode.Type.DIRECTORY).build();
+    when(mockClient.stat("/sysroot/etc")).thenReturn(mockAttributes);
+
+    assertTrue(SshClientUtils.isDirectory(mockClient, mock));
+  }
+
+  @Test
+  public void testIsDirectorySymlinkBrokenDirectory() throws IOException {
+    RemoteResourceInfo mock = mock(RemoteResourceInfo.class);
+    when(mock.getPath()).thenReturn("/sysroot/etc");
+    when(mock.isDirectory()).thenReturn(true);
+    FileAttributes mockAttributes =
+        new FileAttributes.Builder().withType(FileMode.Type.SYMLINK).build();
+    when(mock.getAttributes()).thenReturn(mockAttributes);
+
+    SFTPClient mockClient = mock(SFTPClient.class);
+    mockAttributes = new FileAttributes.Builder().withType(FileMode.Type.DIRECTORY).build();
+    when(mockClient.stat("/sysroot/etc")).thenThrow(new IOException());
+
+    assertTrue(SshClientUtils.isDirectory(mockClient, mock));
+  }
+
+  @Test
+  public void testIsDirectorySymlinkBrokenFile() throws IOException {
+    RemoteResourceInfo mock = mock(RemoteResourceInfo.class);
+    when(mock.getPath()).thenReturn("/sysroot/etc");
+    when(mock.isDirectory()).thenReturn(false);
+    FileAttributes mockAttributes =
+        new FileAttributes.Builder().withType(FileMode.Type.SYMLINK).build();
+    when(mock.getAttributes()).thenReturn(mockAttributes);
+
+    SFTPClient mockClient = mock(SFTPClient.class);
+    mockAttributes = new FileAttributes.Builder().withType(FileMode.Type.DIRECTORY).build();
+    when(mockClient.stat("/sysroot/etc")).thenThrow(new IOException());
+
+    assertFalse(SshClientUtils.isDirectory(mockClient, mock));
+  }
+}


### PR DESCRIPTION
## PR Info
#### Issue tracker   
Addresses #1951 

#### Release  
Addresses release/3.5
  
#### Test cases
- [ ] Covered
  
#### Manual testing
- [x] Done  
  
If yes,  
- Device: Fairphone 3
- OS: LineageOS 16.0 (9.0)

#### Build tasks success  
Successfully running following tasks on local 
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`

#### Additional Info

Changes:
- Allow USB device detection on Android >= N
- Add back missing dialog.show() in Drawer when asking user to open USB device root at Android DocumentsUI
- Moved SSH isDirectory() symlink checks to SshClientUtil
- combined MediaStore image/video query methods together + fix arguments

Known issue:
Amaze cannot detect USB device inserted while running. Debug mode saw Amaze did able to detect USB and put item drawer, but not at normal run.