### PR TITLE
Lifting tweaks in CustomSshJConfig to enable advanced crypto features

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/filesystem/ssh/CustomSshJConfig.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/ssh/CustomSshJConfig.java
@@ -23,10 +23,6 @@ package com.amaze.filemanager.filesystem.ssh;
 import java.security.Security;
 
 import net.schmizz.sshj.DefaultConfig;
-import net.schmizz.sshj.signature.SignatureDSA;
-import net.schmizz.sshj.signature.SignatureRSA;
-import net.schmizz.sshj.transport.random.JCERandom;
-import net.schmizz.sshj.transport.random.SingletonRandomFactory;
 
 /**
  * sshj {@link net.schmizz.sshj.Config} for our own use.
@@ -43,15 +39,5 @@ public class CustomSshJConfig extends DefaultConfig {
   public static void init() {
     Security.removeProvider("BC");
     Security.insertProviderAt(new org.bouncycastle.jce.provider.BouncyCastleProvider(), 0);
-  }
-
-  // don't add ECDSA
-  protected void initSignatureFactories() {
-    setSignatureFactories(new SignatureRSA.Factory(), new SignatureDSA.Factory());
-  }
-
-  @Override
-  protected void initRandomFactory(boolean ignored) {
-    setRandomFactory(new SingletonRandomFactory(new JCERandom.Factory()));
   }
 }


### PR DESCRIPTION
Previously due to preventing conflict with stock BouncyCastle on Android devices some tweaks were added to CustomSshJConfig. But with full adaptation of BouncyCastle over the stock one it should be safe to remove the tweaks and use stock features as much as possible.

Tested on Fairphone 3 running LineageOS 16.0 (9.0), using ED25519 private key to authenticate against OpenSSH server 8.2p1 on Ubuntu 20.04.

## PR Info
#### Issue tracker   
Addresses #1961

#### Release  
Addresses release/3.5
  
#### Test cases
- [ ] Covered
  
#### Manual testing
- [x] Done  
  
If yes,  
- Device: Fairphone 3
- OS: LineageOS 16.0 (9.0)

#### Build tasks success  
Successfully running following tasks on local 
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`