### PR TITLE
#1937 Fix Crash on display of properties dialog in landscape

### DIFF
--- a/app/src/main/res/layout-w500dp/properties_dialog.xml
+++ b/app/src/main/res/layout-w500dp/properties_dialog.xml
@@ -156,6 +156,21 @@
                 android:text="@string/calculating"
                 android:textSize="@dimen/material_generic_title_summary"/>
         </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingStart="-7dp"
+            android:paddingLeft="-7dp"
+            android:paddingRight="-7dp">
+            <CheckBox
+                android:id="@+id/nomediacheckbox"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:fontFamily="sans-serif-medium"
+                android:text="@string/hide_media"
+                android:visibility="gone"/>
+        </LinearLayout>
     </LinearLayout>
 
     <com.github.mikephil.charting.charts.PieChart


### PR DESCRIPTION
## PR Info
#### Issue tracker   
Fixes will automatically close the related issue

Fixes #1937 
-or-   
Addresses #

#### Release  
Addresses release/3.5
  
#### Test cases
- [ ] Covered
  
#### Manual testing
- [x] Done  
  
If yes,  
- Device: Realme 3 Pro
- OS: Android 10

#### Build tasks success  
Successfully running following tasks on local 
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`

#### Related PR  
Related to PR #

#### Additional Info