### PR TITLE
Add support for writing Amaze's content URIs requiring root access

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/ReadFileTask.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/ReadFileTask.java
@@ -39,11 +39,14 @@ import com.amaze.filemanager.utils.RootUtils;
 
 import android.content.ContentResolver;
 import android.os.AsyncTask;
+import android.util.Log;
 
 import androidx.documentfile.provider.DocumentFile;
 
 /** @author Emmanuel Messulam <emmanuelbendavid@gmail.com> on 16/1/2018, at 18:05. */
 public class ReadFileTask extends AsyncTask<Void, Void, ReadFileTask.ReturnedValues> {
+
+  private static final String TAG = ReadFileTask.class.getSimpleName();
 
   public static final int NORMAL = 0;
   public static final int EXCEPTION_STREAM_NOT_FOUND = -1;
@@ -85,7 +88,7 @@ public class ReadFileTask extends AsyncTask<Void, Void, ReadFileTask.ReturnedVal
           if (fileAbstraction.uri.getAuthority().equals(AppConfig.getInstance().getPackageName())) {
             DocumentFile documentFile =
                 DocumentFile.fromSingleUri(AppConfig.getInstance(), fileAbstraction.uri);
-            if (documentFile != null && documentFile.exists() && documentFile.canRead())
+            if (documentFile != null && documentFile.exists() && documentFile.canWrite())
               inputStream = contentResolver.openInputStream(documentFile.getUri());
             else inputStream = loadFile(FileUtils.fromContentUri(fileAbstraction.uri));
           } else {
@@ -157,6 +160,7 @@ public class ReadFileTask extends AsyncTask<Void, Void, ReadFileTask.ReturnedVal
       try {
         inputStream = new FileInputStream(file.getAbsolutePath());
       } catch (FileNotFoundException e) {
+        Log.e(TAG, "Unable to open file [" + file.getAbsolutePath() + "] for reading", e);
         inputStream = null;
       }
     }

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/ReadFileTask.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/ReadFileTask.java
@@ -82,11 +82,15 @@ public class ReadFileTask extends AsyncTask<Void, Void, ReadFileTask.ReturnedVal
           if (fileAbstraction.uri == null)
             throw new NullPointerException("Something went really wrong!");
 
-          DocumentFile documentFile =
-              DocumentFile.fromSingleUri(AppConfig.getInstance(), fileAbstraction.uri);
-          if (documentFile != null && documentFile.exists() && documentFile.canRead())
-            inputStream = contentResolver.openInputStream(documentFile.getUri());
-          else inputStream = loadFile(FileUtils.fromContentUri(fileAbstraction.uri));
+          if (fileAbstraction.uri.getAuthority().equals(AppConfig.getInstance().getPackageName())) {
+            DocumentFile documentFile =
+                DocumentFile.fromSingleUri(AppConfig.getInstance(), fileAbstraction.uri);
+            if (documentFile != null && documentFile.exists() && documentFile.canRead())
+              inputStream = contentResolver.openInputStream(documentFile.getUri());
+            else inputStream = loadFile(FileUtils.fromContentUri(fileAbstraction.uri));
+          } else {
+            inputStream = contentResolver.openInputStream(fileAbstraction.uri);
+          }
           break;
         case FILE:
           final HybridFileParcelable hybridFileParcelable = fileAbstraction.hybridFileParcelable;

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/WriteFileAbstraction.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/WriteFileAbstraction.java
@@ -27,17 +27,23 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.lang.ref.WeakReference;
 
+import com.amaze.filemanager.application.AppConfig;
 import com.amaze.filemanager.exceptions.ShellNotRunningException;
 import com.amaze.filemanager.exceptions.StreamNotFoundException;
 import com.amaze.filemanager.filesystem.EditableFileAbstraction;
 import com.amaze.filemanager.filesystem.FileUtil;
 import com.amaze.filemanager.filesystem.HybridFileParcelable;
+import com.amaze.filemanager.filesystem.files.FileUtils;
 import com.amaze.filemanager.utils.OnAsyncTaskFinished;
 import com.amaze.filemanager.utils.RootUtils;
 
 import android.content.ContentResolver;
 import android.content.Context;
 import android.os.AsyncTask;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.documentfile.provider.DocumentFile;
 
 /** @author Emmanuel Messulam <emmanuelbendavid@gmail.com> on 16/1/2018, at 18:36. */
 public class WriteFileAbstraction extends AsyncTask<Void, String, Integer> {
@@ -77,6 +83,7 @@ public class WriteFileAbstraction extends AsyncTask<Void, String, Integer> {
   protected Integer doInBackground(Void... voids) {
     try {
       OutputStream outputStream;
+      File destFile = null;
 
       switch (fileAbstraction.scheme) {
         case CONTENT:
@@ -84,11 +91,17 @@ public class WriteFileAbstraction extends AsyncTask<Void, String, Integer> {
             throw new NullPointerException("Something went really wrong!");
 
           try {
-            outputStream = contentResolver.openOutputStream(fileAbstraction.uri);
+            DocumentFile documentFile =
+                DocumentFile.fromSingleUri(AppConfig.getInstance(), fileAbstraction.uri);
+            if (documentFile != null && documentFile.exists() && documentFile.canWrite())
+              outputStream = contentResolver.openOutputStream(fileAbstraction.uri);
+            else {
+              destFile = FileUtils.fromContentUri(fileAbstraction.uri);
+              outputStream = openFile(destFile, context.get());
+            }
           } catch (RuntimeException e) {
             throw new StreamNotFoundException(e);
           }
-
           break;
         case FILE:
           final HybridFileParcelable hybridFileParcelable = fileAbstraction.hybridFileParcelable;
@@ -100,19 +113,8 @@ public class WriteFileAbstraction extends AsyncTask<Void, String, Integer> {
             cancel(true);
             return null;
           }
-          outputStream = FileUtil.getOutputStream(hybridFileParcelable.getFile(), context);
-
-          if (isRootExplorer && outputStream == null) {
-            // try loading stream associated using root
-            try {
-              if (cachedFile != null && cachedFile.exists()) {
-                outputStream = new FileOutputStream(cachedFile);
-              }
-            } catch (FileNotFoundException e) {
-              e.printStackTrace();
-              outputStream = null;
-            }
-          }
+          outputStream = openFile(hybridFileParcelable.getFile(), context);
+          destFile = fileAbstraction.hybridFileParcelable.getFile();
           break;
         default:
           throw new IllegalArgumentException(
@@ -124,10 +126,9 @@ public class WriteFileAbstraction extends AsyncTask<Void, String, Integer> {
       outputStream.write(dataToSave.getBytes());
       outputStream.close();
 
-      if (cachedFile != null && cachedFile.exists()) {
+      if (cachedFile != null && cachedFile.exists() && destFile != null) {
         // cat cache content to original file and delete cache file
-        RootUtils.cat(cachedFile.getPath(), fileAbstraction.hybridFileParcelable.getPath());
-
+        RootUtils.cat(cachedFile.getPath(), destFile.getPath());
         cachedFile.delete();
       }
 
@@ -150,5 +151,26 @@ public class WriteFileAbstraction extends AsyncTask<Void, String, Integer> {
     super.onPostExecute(integer);
 
     onAsyncTaskFinished.onAsyncTaskFinished(integer);
+  }
+
+  private OutputStream openFile(@Nullable File file, @NonNull Context context)
+      throws FileNotFoundException {
+    if (file == null) throw new IllegalArgumentException("File cannot be null");
+
+    OutputStream outputStream = FileUtil.getOutputStream(file, context);
+
+    if (isRootExplorer && outputStream == null) {
+      // try loading stream associated using root
+      try {
+        if (cachedFile != null && cachedFile.exists()) {
+          outputStream = new FileOutputStream(cachedFile);
+        }
+      } catch (FileNotFoundException e) {
+        e.printStackTrace();
+        outputStream = null;
+      }
+    }
+
+    return outputStream;
   }
 }

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/WriteFileAbstraction.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/WriteFileAbstraction.java
@@ -91,13 +91,17 @@ public class WriteFileAbstraction extends AsyncTask<Void, String, Integer> {
             throw new NullPointerException("Something went really wrong!");
 
           try {
-            DocumentFile documentFile =
-                DocumentFile.fromSingleUri(AppConfig.getInstance(), fileAbstraction.uri);
-            if (documentFile != null && documentFile.exists() && documentFile.canWrite())
+            if (fileAbstraction.uri.getAuthority().equals(context.get().getPackageName())) {
+              DocumentFile documentFile =
+                  DocumentFile.fromSingleUri(AppConfig.getInstance(), fileAbstraction.uri);
+              if (documentFile != null && documentFile.exists() && documentFile.canWrite())
+                outputStream = contentResolver.openOutputStream(fileAbstraction.uri);
+              else {
+                destFile = FileUtils.fromContentUri(fileAbstraction.uri);
+                outputStream = openFile(destFile, context.get());
+              }
+            } else {
               outputStream = contentResolver.openOutputStream(fileAbstraction.uri);
-            else {
-              destFile = FileUtils.fromContentUri(fileAbstraction.uri);
-              outputStream = openFile(destFile, context.get());
             }
           } catch (RuntimeException e) {
             throw new StreamNotFoundException(e);

--- a/app/src/main/java/com/amaze/filemanager/filesystem/files/FileUtils.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/files/FileUtils.java
@@ -20,6 +20,8 @@
 
 package com.amaze.filemanager.filesystem.files;
 
+import static com.amaze.filemanager.filesystem.EditableFileAbstraction.Scheme.CONTENT;
+
 import java.io.File;
 import java.text.ParsePosition;
 import java.text.SimpleDateFormat;
@@ -840,6 +842,15 @@ public class FileUtils {
             @Override
             public void invalidName(HybridFile file) {}
           });
+    }
+  }
+
+  public static File fromContentUri(@NonNull Uri uri) {
+    if (!CONTENT.name().equalsIgnoreCase(uri.getScheme())) {
+      throw new IllegalArgumentException(
+          "URI must start with content://. URI was [" + uri.toString() + "]");
+    } else {
+      return new File(uri.getPath().substring(FILE_PROVIDER_PREFIX.length() + 1));
     }
   }
 }

--- a/app/src/main/java/com/amaze/filemanager/ui/activities/TextEditorActivity.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/activities/TextEditorActivity.java
@@ -20,6 +20,7 @@
 
 package com.amaze.filemanager.ui.activities;
 
+import static com.amaze.filemanager.filesystem.EditableFileAbstraction.Scheme.CONTENT;
 import static com.amaze.filemanager.filesystem.EditableFileAbstraction.Scheme.FILE;
 import static com.amaze.filemanager.ui.fragments.preference_fragments.PreferencesConstants.PREFERENCE_COLORED_NAVIGATION;
 import static com.amaze.filemanager.ui.fragments.preference_fragments.PreferencesConstants.PREFERENCE_TEXTEDITOR_NEWSTACK;
@@ -36,12 +37,14 @@ import com.amaze.filemanager.asynchronous.asynctasks.ReadFileTask;
 import com.amaze.filemanager.asynchronous.asynctasks.SearchTextTask;
 import com.amaze.filemanager.asynchronous.asynctasks.WriteFileAbstraction;
 import com.amaze.filemanager.filesystem.EditableFileAbstraction;
+import com.amaze.filemanager.filesystem.HybridFileParcelable;
 import com.amaze.filemanager.filesystem.files.FileUtils;
 import com.amaze.filemanager.ui.activities.superclasses.ThemedActivity;
 import com.amaze.filemanager.ui.colors.ColorPreferenceHelper;
 import com.amaze.filemanager.ui.dialogs.GeneralDialogCreation;
 import com.amaze.filemanager.ui.theme.AppTheme;
 import com.amaze.filemanager.utils.MapEntry;
+import com.amaze.filemanager.utils.OpenMode;
 import com.amaze.filemanager.utils.PreferenceUtils;
 import com.amaze.filemanager.utils.Utils;
 import com.google.android.material.snackbar.Snackbar;
@@ -407,6 +410,13 @@ public class TextEditorActivity extends ThemedActivity
         if (mFile.scheme.equals(FILE) && mFile.hybridFileParcelable.getFile().exists()) {
           GeneralDialogCreation.showPropertiesDialogWithoutPermissions(
               mFile.hybridFileParcelable, this, getAppTheme());
+        } else if (mFile.scheme.equals(CONTENT)) {
+          if (getApplicationContext().getPackageName().equals(mFile.uri.getAuthority())) {
+            File file = FileUtils.fromContentUri(mFile.uri);
+            HybridFileParcelable p = new HybridFileParcelable(file.getAbsolutePath());
+            if (isRootExplorer()) p.setMode(OpenMode.ROOT);
+            GeneralDialogCreation.showPropertiesDialogWithoutPermissions(p, this, getAppTheme());
+          }
         } else {
           Toast.makeText(this, R.string.no_obtainable_info, Toast.LENGTH_SHORT).show();
         }


### PR DESCRIPTION
Fixes #1966.

Attempt to resolve content:// URIs used by Amaze as files that will need root access.

- added FileUtils.fromContentUri() to resolve path to root files by simply cut off the prefixes
- Modified WriteFileAbstraction and ReadFileTask to switch to root read/write mode as necessary

## PR Info
#### Issue tracker   
Fixes will automatically close the related issue

Fixes #1966

#### Release  
Addresses release/3.5
  
#### Test cases
- [ ] Covered
  
#### Manual testing
- [x] Done  
  
If yes,  
- Device: Fairphone 3 running LineageOS 16.0 (9.0), Samsung Galaxy S2 running SlimLP (5.1.1)

#### Build tasks success  
Successfully running following tasks on local 
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`