### PR TITLE
Fix renaming on OTG storages

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/filesystem/HybridFile.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/HybridFile.java
@@ -294,18 +294,13 @@ public class HybridFile {
     return path;
   }
 
-  /** @deprecated use {@link #getName(Context)} */
-  public String getName() {
+  public String getSimpleName() {
     String name = null;
     switch (mode) {
       case SMB:
         SmbFile smbFile = getSmbFile();
         if (smbFile != null) return smbFile.getName();
         break;
-      case FILE:
-        return getFile().getName();
-      case ROOT:
-        return getFile().getName();
       default:
         StringBuilder builder = new StringBuilder(path);
         name = builder.substring(builder.lastIndexOf("/") + 1, builder.length());
@@ -390,7 +385,7 @@ public class HybridFile {
   public String getParentName() {
     StringBuilder builder = new StringBuilder(path);
     StringBuilder parentPath =
-        new StringBuilder(builder.substring(0, builder.length() - (getName().length() + 1)));
+        new StringBuilder(builder.substring(0, builder.length() - (getSimpleName().length() + 1)));
     String parentName = parentPath.substring(parentPath.lastIndexOf("/") + 1, parentPath.length());
     return parentName;
   }

--- a/app/src/main/java/com/amaze/filemanager/filesystem/HybridFileParcelable.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/HybridFileParcelable.java
@@ -87,10 +87,9 @@ public class HybridFileParcelable extends HybridFile implements Parcelable {
         Integer.toString(FilePermission.toMask(sshFile.getAttributes().getPermissions()), 8));
   }
 
-  @Override
   public String getName() {
     if (!Utils.isNullOrEmpty(name)) return name;
-    else return super.getName();
+    else return super.getSimpleName();
   }
 
   @Override

--- a/app/src/main/java/com/amaze/filemanager/filesystem/Operations.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/Operations.java
@@ -370,8 +370,10 @@ public class Operations {
 
       @Override
       protected Void doInBackground(Void... params) {
-        // check whether file names for new file are valid or recursion occurs
-        if (!Operations.isFileNameValid(newFile.getName(context))) {
+        // check whether file names for new file are valid or recursion occurs.
+        // If rename is on OTG, we are skipping
+        if (!(oldFile.mode.equals(newFile.mode) && oldFile.mode.equals(OpenMode.OTG))
+            && !Operations.isFileNameValid(newFile.getSimpleName())) {
           errorCallBack.invalidName(newFile);
           return null;
         }
@@ -465,7 +467,7 @@ public class Operations {
             errorCallBack.exists(newFile);
             return null;
           }
-          errorCallBack.done(newFile, oldDocumentFile.renameTo(newFile.getName(context)));
+          errorCallBack.done(newFile, oldDocumentFile.renameTo(newFile.getSimpleName()));
           return null;
         } else {
 

--- a/app/src/main/java/com/amaze/filemanager/utils/MainActivityHelper.java
+++ b/app/src/main/java/com/amaze/filemanager/utils/MainActivityHelper.java
@@ -293,9 +293,11 @@ public class MainActivityHelper {
     final Toast toast =
         Toast.makeText(context, context.getString(R.string.renaming), Toast.LENGTH_SHORT);
     toast.show();
+    HybridFile oldFile = new HybridFile(mode, oldPath);
+    HybridFile newFile = new HybridFile(mode, newPath);
     Operations.rename(
-        new HybridFile(mode, oldPath),
-        new HybridFile(mode, newPath),
+        oldFile,
+        newFile,
         rootmode,
         context,
         new Operations.ErrorCallBack() {
@@ -329,7 +331,11 @@ public class MainActivityHelper {
           public void done(final HybridFile hFile, final boolean b) {
             context.runOnUiThread(
                 () -> {
-                  if (b) {
+                  /*
+                   * DocumentFile.renameTo() may return false even when rename is successful. Hence we need an extra check
+                   * instead of merely looking at the return value
+                   */
+                  if (b || newFile.exists(context)) {
                     Intent intent = new Intent(MainActivity.KEY_INTENT_LOAD_LIST);
 
                     intent.putExtra(


### PR DESCRIPTION
## PR Info

- Skip file existence test for OTG when doing rename
- Use new file existence test along with rename result to check if the rename is successful
- Changed HybridFile.getName() to HybridFile.getSimpleName() to indicate the purpose of getting filename with the mere file path

#### Issue tracker   
Fixes will automatically close the related issue

Fixes #1419 

#### Release  
Addresses release/3.5
  
#### Test cases
- [ ] Covered
  
#### Manual testing
- [x] Done  
  
If yes,  
- Device: LG Nexus 5x
- OS: AOSPExtended (9.0)

#### Build tasks success  
Successfully running following tasks on local 
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`

#### Related PR  
Related to PR #1469
