### PR TITLE
SSH move/back navigation fixes

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/MoveFiles.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/MoveFiles.java
@@ -124,7 +124,7 @@ public class MoveFiles extends AsyncTask<ArrayList<String>, String, Boolean> {
             if (!source.renameTo(dest)) {
 
               // check if we have root
-              if (mainFrag.getMainActivity().isRootExplorer()) {
+              if (mainFrag != null && mainFrag.getMainActivity().isRootExplorer()) {
                 try {
                   if (!RootUtils.rename(baseFile.getPath(), destPath)) return false;
                 } catch (ShellNotRunningException e) {


### PR DESCRIPTION
## PR Info
- Fix SFTP routine template in `HybridFile.forEachChildrenFile()` to return `true` instead of `null`, to workaround RxJava's restriction that callable passed in must not return null, prevent app crash when moving file from device to SSH server
- Wrap exception that may throw when closing remote outputstream on SSH server into `Log.w()` to prevent exception thrown that might crash the app
- Fix grepping path for SFTP to fix back button navigation on server, that previously user cannot go to parent folder on SSH server when pressing back button

#### Release  
Addresses release/3.5
  
#### Test cases
- [x] Covered
  
#### Manual testing
- [x] Done  
  
If yes,  
- Device: Fairphone 3
- OS: Lineage OS 16.0 (9.0)

#### Build tasks success  
Successfully running following tasks on local 
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`

