### PR TITLE
Implement support for SMBv1 without server-side IPC signature check

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/MoveFiles.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/MoveFiles.java
@@ -21,7 +21,6 @@
 package com.amaze.filemanager.asynchronous.asynctasks;
 
 import java.io.File;
-import java.net.MalformedURLException;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -51,9 +50,6 @@ import android.content.Intent;
 import android.os.AsyncTask;
 import android.util.Log;
 import android.widget.Toast;
-
-import jcifs.smb.SmbException;
-import jcifs.smb.SmbFile;
 
 /**
  * AsyncTask that moves files from source to destination by trying to rename files first, if they're
@@ -97,6 +93,8 @@ public class MoveFiles extends AsyncTask<ArrayList<String>, String, Boolean> {
     for (int i = 0; i < paths.size(); i++) {
       for (HybridFileParcelable baseFile : files.get(i)) {
         String destPath = paths.get(i) + "/" + baseFile.getName(context);
+        if (baseFile.getPath().indexOf('?') > 0)
+          destPath += baseFile.getPath().substring(baseFile.getPath().indexOf('?'));
         if (!isMoveOperationValid(baseFile, new HybridFile(mode, paths.get(i)))) {
           // TODO: 30/06/20 Replace runtime exception with generic exception
           Log.w(
@@ -105,19 +103,6 @@ public class MoveFiles extends AsyncTask<ArrayList<String>, String, Boolean> {
           continue;
         }
         switch (mode) {
-          case SMB:
-            try {
-              SmbFile source = new SmbFile(baseFile.getPath());
-              SmbFile dest = new SmbFile(destPath);
-              source.renameTo(dest);
-            } catch (MalformedURLException e) {
-              e.printStackTrace();
-              return false;
-            } catch (SmbException e) {
-              e.printStackTrace();
-              return false;
-            }
-            break;
           case FILE:
             File dest = new File(destPath);
             File source = new File(baseFile.getPath());

--- a/app/src/main/java/com/amaze/filemanager/database/UtilsHandler.java
+++ b/app/src/main/java/com/amaze/filemanager/database/UtilsHandler.java
@@ -379,12 +379,18 @@ public class UtilsHandler {
   private void removeSmbPath(String name, String path) {
     if ("".equals(path))
       utilitiesDatabase.smbEntryDao().deleteByName(name).subscribeOn(Schedulers.io()).subscribe();
-    else
+    else {
+      try {
+        path = SmbUtil.getSmbEncryptedPath(context, path);
+      } catch (GeneralSecurityException | IOException e) {
+        Log.e(TAG, "Error encrypting path", e);
+      }
       utilitiesDatabase
           .smbEntryDao()
           .deleteByNameAndPath(name, path)
           .subscribeOn(Schedulers.io())
           .subscribe();
+    }
   }
 
   private void removeSftpPath(String name, String path) {

--- a/app/src/main/java/com/amaze/filemanager/filesystem/FileUtil.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/FileUtil.java
@@ -32,7 +32,6 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.net.MalformedURLException;
 import java.nio.channels.FileChannel;
 import java.util.ArrayList;
 import java.util.List;
@@ -52,6 +51,7 @@ import com.amaze.filemanager.utils.AppConstants;
 import com.amaze.filemanager.utils.DataUtils;
 import com.amaze.filemanager.utils.OTGUtil;
 import com.amaze.filemanager.utils.OpenMode;
+import com.amaze.filemanager.utils.SmbUtil;
 import com.cloudrail.si.interfaces.CloudStorage;
 
 import android.annotation.TargetApi;
@@ -279,7 +279,7 @@ public abstract class FileUtil {
                           retval.add(targetFile.getPath());
                           break;
                         case SMB:
-                          SmbFile targetSmbFile = new SmbFile(finalFilePath);
+                          SmbFile targetSmbFile = SmbUtil.create(finalFilePath);
                           if (targetSmbFile.exists()) {
                             AppConfig.toast(
                                 mainActivity, mainActivity.getString(R.string.cannot_overwrite));
@@ -577,11 +577,8 @@ public abstract class FileUtil {
     switch (file.mode) {
       case SMB:
         try {
-          SmbFile smbFile = new SmbFile(file.getPath());
+          SmbFile smbFile = file.getSmbFile();
           smbFile.mkdirs();
-        } catch (MalformedURLException e) {
-          e.printStackTrace();
-          isSuccessful = false;
         } catch (SmbException e) {
           e.printStackTrace();
           isSuccessful = false;

--- a/app/src/main/java/com/amaze/filemanager/filesystem/FileUtil.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/FileUtil.java
@@ -20,6 +20,9 @@
 
 package com.amaze.filemanager.filesystem;
 
+import static com.amaze.filemanager.filesystem.smb.CifsContextFactory.SMB_URI_PREFIX;
+import static com.amaze.filemanager.filesystem.ssh.SshConnectionPool.SSH_URI_PREFIX;
+
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.File;
@@ -287,7 +290,8 @@ public abstract class FileUtil {
                           } else {
                             OutputStream outputStream = targetSmbFile.getOutputStream();
                             bufferedOutputStream = new BufferedOutputStream(outputStream);
-                            retval.add(HybridFile.parseSmbPath(targetSmbFile.getPath()));
+                            retval.add(
+                                HybridFile.parseAndFormatUriForDisplay(targetSmbFile.getPath()));
                           }
                           break;
                         case SFTP:
@@ -1016,8 +1020,8 @@ public abstract class FileUtil {
    */
   public static int checkFolder(final String f, Context context) {
     if (f == null) return 0;
-    if (f.startsWith("smb://")
-        || f.startsWith("ssh://")
+    if (f.startsWith(SMB_URI_PREFIX)
+        || f.startsWith(SSH_URI_PREFIX)
         || f.startsWith(OTGUtil.PREFIX_OTG)
         || f.startsWith(CloudHandler.CLOUD_PREFIX_BOX)
         || f.startsWith(CloudHandler.CLOUD_PREFIX_GOOGLE_DRIVE)

--- a/app/src/main/java/com/amaze/filemanager/filesystem/Operations.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/Operations.java
@@ -25,6 +25,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.MalformedURLException;
+import java.net.URL;
 
 import com.amaze.filemanager.exceptions.ShellNotRunningException;
 import com.amaze.filemanager.filesystem.cloud.CloudUtil;
@@ -386,17 +387,15 @@ public class Operations {
 
         if (oldFile.isSmb()) {
           try {
-            SmbFile smbFile = new SmbFile(oldFile.getPath());
-            SmbFile smbFile1 = new SmbFile(newFile.getPath());
+            SmbFile smbFile = oldFile.getSmbFile();
+            SmbFile smbFile1 = new SmbFile(new URL(newFile.getPath()), smbFile.getContext());
             if (smbFile1.exists()) {
               errorCallBack.exists(newFile);
               return null;
             }
             smbFile.renameTo(smbFile1);
             if (!smbFile.exists() && smbFile1.exists()) errorCallBack.done(newFile, true);
-          } catch (MalformedURLException e) {
-            e.printStackTrace();
-          } catch (SmbException e) {
+          } catch (SmbException | MalformedURLException e) {
             e.printStackTrace();
           }
           return null;

--- a/app/src/main/java/com/amaze/filemanager/filesystem/cloud/CloudUtil.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/cloud/CloudUtil.java
@@ -58,7 +58,6 @@ import android.widget.Toast;
 
 import androidx.documentfile.provider.DocumentFile;
 
-import jcifs.smb.SmbFile;
 import net.schmizz.sshj.sftp.RemoteFile;
 import net.schmizz.sshj.sftp.SFTPClient;
 
@@ -320,7 +319,7 @@ public class CloudUtil {
         break;
       case SMB:
         try {
-          inputStream = new SmbFile(hybridFile.getPath()).getInputStream();
+          inputStream = hybridFile.getSmbFile().getInputStream();
         } catch (IOException e) {
           inputStream = null;
           e.printStackTrace();

--- a/app/src/main/java/com/amaze/filemanager/filesystem/smb/CifsContextFactory.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/smb/CifsContextFactory.java
@@ -36,6 +36,8 @@ import jcifs.context.SingletonContext;
 
 public abstract class CifsContextFactory {
 
+  public static final String SMB_URI_PREFIX = "smb://";
+
   private static final String TAG = CifsContextFactory.class.getSimpleName();
 
   private static final Properties defaultProperties;

--- a/app/src/main/java/com/amaze/filemanager/filesystem/smb/CifsContextFactory.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/smb/CifsContextFactory.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2014-2020 Arpit Khurana <arpitkh96@gmail.com>, Vishal Nehra <vishalmeham2@gmail.com>,
+ * Emmanuel Messulam<emmanuelbendavid@gmail.com>, Raymond Lai <airwave209gt at gmail.com> and Contributors.
+ *
+ * This file is part of Amaze File Manager.
+ *
+ * Amaze File Manager is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.amaze.filemanager.filesystem.smb;
+
+import java.util.Properties;
+
+import android.util.Log;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import io.reactivex.Single;
+import io.reactivex.schedulers.Schedulers;
+import jcifs.CIFSException;
+import jcifs.config.PropertyConfiguration;
+import jcifs.context.BaseContext;
+import jcifs.context.SingletonContext;
+
+public abstract class CifsContextFactory {
+
+  private static final String TAG = CifsContextFactory.class.getSimpleName();
+
+  private static final Properties defaultProperties;
+
+  static {
+    defaultProperties = new Properties();
+    defaultProperties.setProperty("jcifs.resolveOrder", "BCAST");
+    defaultProperties.setProperty("jcifs.smb.client.responseTimeout", "30000");
+    defaultProperties.setProperty("jcifs.netbios.retryTimeout", "5000");
+    defaultProperties.setProperty("jcifs.netbios.cachePolicy", "-1");
+  }
+
+  public static final @NonNull BaseContext createWithDisableIpcSigningCheck(
+      boolean disableIpcSigningCheck) {
+    if (disableIpcSigningCheck) {
+      Properties extraProperties = new Properties();
+      extraProperties.put("jcifs.smb.client.ipcSigningEnforced", "false");
+      return create(extraProperties);
+    } else {
+      return create(null);
+    }
+  }
+
+  public static final @NonNull BaseContext create(@Nullable final Properties extraProperties) {
+    return Single.fromCallable(
+            () -> {
+              try {
+                Properties p = new Properties(defaultProperties);
+                if (extraProperties != null) p.putAll(extraProperties);
+                return new BaseContext(new PropertyConfiguration(p));
+              } catch (CIFSException e) {
+                Log.e(TAG, "Error initialize jcifs BaseContext, returning default", e);
+                return SingletonContext.getInstance();
+              }
+            })
+        .subscribeOn(Schedulers.io())
+        .blockingGet();
+  }
+}

--- a/app/src/main/java/com/amaze/filemanager/ui/dialogs/RenameBookmark.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/dialogs/RenameBookmark.java
@@ -20,6 +20,8 @@
 
 package com.amaze.filemanager.ui.dialogs;
 
+import static com.amaze.filemanager.filesystem.smb.CifsContextFactory.SMB_URI_PREFIX;
+
 import java.net.URL;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
@@ -112,7 +114,7 @@ public class RenameBookmark extends DialogFragment {
           });
       final AppCompatEditText ip = v2.findViewById(R.id.editText);
       if (studiomode != 0) {
-        if (path.startsWith("smb:/")) {
+        if (path.startsWith(SMB_URI_PREFIX)) {
           try {
             URL a = new URL(path);
             String userinfo = a.getUserInfo();
@@ -121,7 +123,7 @@ public class RenameBookmark extends DialogFragment {
               user = inf.substring(0, inf.indexOf(":"));
               pass = inf.substring(inf.indexOf(":") + 1, inf.length());
               String ipp = a.getHost();
-              pa = "smb://" + ipp + a.getPath();
+              pa = SMB_URI_PREFIX + ipp + a.getPath();
             }
           } catch (Exception e) {
             e.printStackTrace();
@@ -146,13 +148,13 @@ public class RenameBookmark extends DialogFragment {
               v -> {
                 String t = ip.getText().toString();
                 String name = conName.getText().toString();
-                if (studiomode != 0 && t.startsWith("smb://")) {
+                if (studiomode != 0 && t.startsWith(SMB_URI_PREFIX)) {
                   try {
                     URL a = new URL(t);
                     String userinfo = a.getUserInfo();
                     if (userinfo == null && user.length() > 0) {
                       t =
-                          "smb://"
+                          SMB_URI_PREFIX
                               + ((URLEncoder.encode(user, "UTF-8")
                                   + ":"
                                   + URLEncoder.encode(pass, "UTF-8")

--- a/app/src/main/java/com/amaze/filemanager/ui/dialogs/SmbConnectDialog.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/dialogs/SmbConnectDialog.java
@@ -20,6 +20,7 @@
 
 package com.amaze.filemanager.ui.dialogs;
 
+import static com.amaze.filemanager.filesystem.smb.CifsContextFactory.SMB_URI_PREFIX;
 import static com.amaze.filemanager.utils.SmbUtil.PARAM_DISABLE_IPC_SIGNING_CHECK;
 
 import java.io.IOException;
@@ -340,7 +341,7 @@ public class SmbConnectDialog extends DialogFragment {
     try {
       String yourPeerIP = auth[0], domain = auth[3];
 
-      StringBuilder sb = new StringBuilder("smb://");
+      StringBuilder sb = new StringBuilder(SMB_URI_PREFIX);
       if (!android.text.TextUtils.isEmpty(domain))
         sb.append(URLEncoder.encode(domain + ";", "UTF-8"));
       if (!anonymous)

--- a/app/src/main/java/com/amaze/filemanager/ui/fragments/MainFragment.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/fragments/MainFragment.java
@@ -20,6 +20,7 @@
 
 package com.amaze.filemanager.ui.fragments;
 
+import static com.amaze.filemanager.filesystem.ssh.SshConnectionPool.SSH_URI_PREFIX;
 import static com.amaze.filemanager.ui.fragments.preference_fragments.PreferencesConstants.PREFERENCE_DIRECTORY_SORT_MODE;
 import static com.amaze.filemanager.ui.fragments.preference_fragments.PreferencesConstants.PREFERENCE_GRID_COLUMNS;
 import static com.amaze.filemanager.ui.fragments.preference_fragments.PreferencesConstants.PREFERENCE_SHOW_DIVIDERS;
@@ -1249,7 +1250,7 @@ public class MainFragment extends Fragment implements BottomBarButtonPath {
               loadlist(path.toString().replace("%3D", "="), true, openMode);
             } else loadlist(home, false, OpenMode.FILE);
           } else if (OpenMode.SFTP.equals(openMode)) {
-            if (!CURRENT_PATH.substring("ssh://".length()).contains("/"))
+            if (!CURRENT_PATH.substring(SSH_URI_PREFIX.length()).contains("/"))
               loadlist(home, false, OpenMode.FILE);
             else loadlist(currentFile.getParent(getContext()), true, openMode);
           } else if (CURRENT_PATH.equals("/")

--- a/app/src/main/java/com/amaze/filemanager/ui/views/appbar/BottomBar.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/views/appbar/BottomBar.java
@@ -346,10 +346,8 @@ public class BottomBar implements View.OnTouchListener {
 
     switch (openmode) {
       case SFTP:
-        newPath = HybridFile.parseSftpPath(news);
-        break;
       case SMB:
-        newPath = HybridFile.parseSmbPath(news);
+        newPath = HybridFile.parseAndFormatUriForDisplay(news);
         break;
       case OTG:
         newPath = mainActivityHelper.parseOTGPath(news);

--- a/app/src/main/java/com/amaze/filemanager/utils/MainActivityHelper.java
+++ b/app/src/main/java/com/amaze/filemanager/utils/MainActivityHelper.java
@@ -52,6 +52,7 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
+import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Build;
 import android.os.Bundle;
@@ -140,7 +141,15 @@ public class MainActivityHelper {
         "",
         (dialog, which) -> {
           EditText textfield = dialog.getCustomView().findViewById(R.id.singleedittext_input);
-          mkDir(new HybridFile(openMode, path + "/" + textfield.getText().toString()), ma);
+          mkDir(
+              new HybridFile(
+                  openMode,
+                  Uri.parse(path)
+                      .buildUpon()
+                      .appendPath(textfield.getText().toString())
+                      .build()
+                      .toString()),
+              ma);
           dialog.dismiss();
         },
         (text) -> {
@@ -170,7 +179,15 @@ public class MainActivityHelper {
         AppConstants.NEW_FILE_DELIMITER.concat(AppConstants.NEW_FILE_EXTENSION_TXT),
         (dialog, which) -> {
           EditText textfield = dialog.getCustomView().findViewById(R.id.singleedittext_input);
-          mkFile(new HybridFile(openMode, path + "/" + textfield.getText().toString()), ma);
+          mkFile(
+              new HybridFile(
+                  openMode,
+                  Uri.parse(path)
+                      .buildUpon()
+                      .appendPath(textfield.getText().toString())
+                      .build()
+                      .toString()),
+              ma);
           dialog.dismiss();
         },
         (text) -> {

--- a/app/src/main/java/com/amaze/filemanager/utils/SubnetScanner.java
+++ b/app/src/main/java/com/amaze/filemanager/utils/SubnetScanner.java
@@ -21,6 +21,8 @@
 package com.amaze.filemanager.utils;
 
 /** Created by arpitkh996 on 16-01-2016. */
+import static com.amaze.filemanager.filesystem.smb.CifsContextFactory.SMB_URI_PREFIX;
+
 import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.List;
@@ -179,7 +181,7 @@ public class SubnetScanner extends AsyncTask<Void, ComputerParcelable, Void> {
           public void run() {
             for (int i = 0; i < SubnetScanner.RETRY_COUNT; i++) {
               try {
-                SmbFile smbFile = SmbUtil.create("smb://");
+                SmbFile smbFile = SmbUtil.create(SMB_URI_PREFIX);
                 smbFile.setConnectTimeout(5000);
                 SmbFile[] listFiles = smbFile.listFiles();
                 for (SmbFile smbFile2 : listFiles) {

--- a/app/src/main/java/com/amaze/filemanager/utils/SubnetScanner.java
+++ b/app/src/main/java/com/amaze/filemanager/utils/SubnetScanner.java
@@ -179,7 +179,7 @@ public class SubnetScanner extends AsyncTask<Void, ComputerParcelable, Void> {
           public void run() {
             for (int i = 0; i < SubnetScanner.RETRY_COUNT; i++) {
               try {
-                SmbFile smbFile = new SmbFile("smb://");
+                SmbFile smbFile = SmbUtil.create("smb://");
                 smbFile.setConnectTimeout(5000);
                 SmbFile[] listFiles = smbFile.listFiles();
                 for (SmbFile smbFile2 : listFiles) {

--- a/app/src/main/res/layout/smb_dialog.xml
+++ b/app/src/main/res/layout/smb_dialog.xml
@@ -76,12 +76,18 @@
             android:id="@+id/passwordET"
             android:layout_gravity="center_horizontal" />
     </com.google.android.material.textfield.TextInputLayout>
+
     <androidx.appcompat.widget.AppCompatCheckBox
-        android:layout_width="match_parent"
+        android:id="@+id/chkSmbAnonymous"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="@string/anonymous"
-        android:id="@+id/checkBox2"
-        android:layout_gravity="center_horizontal" />
+        android:text="@string/anonymous" />
+    <androidx.appcompat.widget.AppCompatCheckBox
+        android:id="@+id/chkSmbDisableIpcSignature"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/disableIpcSignature" />
+
     <TextView
         android:layout_width="wrap_content"
         android:id="@+id/wanthelp"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -665,5 +665,6 @@
     <string name="move">Move</string>
     <string name="select_save_location">Select location to save</string>
     <string name="scp_default_path">Default Path (Optional)</string>
+    <string name="disableIpcSignature">Disable IPC signing check (For legacy SMBv1 servers - UNSAFE!)</string>
 </resources>
 

--- a/app/src/test/java/com/amaze/filemanager/filesystem/smb/CifsContextFactoryTest.java
+++ b/app/src/test/java/com/amaze/filemanager/filesystem/smb/CifsContextFactoryTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2014-2020 Arpit Khurana <arpitkh96@gmail.com>, Vishal Nehra <vishalmeham2@gmail.com>,
+ * Emmanuel Messulam<emmanuelbendavid@gmail.com>, Raymond Lai <airwave209gt at gmail.com> and Contributors.
+ *
+ * This file is part of Amaze File Manager.
+ *
+ * Amaze File Manager is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.amaze.filemanager.filesystem.smb;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Properties;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import androidx.annotation.NonNull;
+
+import jcifs.Config;
+import jcifs.ResolverType;
+import jcifs.context.BaseContext;
+
+public class CifsContextFactoryTest {
+
+  @BeforeClass
+  public static void bootstrap() {
+    Config.registerSmbURLHandler();
+  }
+
+  @Test
+  public void testCreateUsingEmptyPropeties() {
+    BaseContext ctx = CifsContextFactory.create(new Properties());
+    verifyCommonProperties(ctx);
+  }
+
+  @Test
+  public void testCreateWithNull() {
+    BaseContext ctx = CifsContextFactory.create(null);
+    verifyCommonProperties(ctx);
+  }
+
+  @Test
+  public void testCreateUsingCustomProperties() {
+    Properties p = new Properties();
+    p.setProperty("jcifs.smb.client.ipcSigningEnforced", "false");
+    BaseContext ctx = CifsContextFactory.create(p);
+    verifyCommonProperties(ctx);
+    assertFalse(ctx.getConfig().isIpcSigningEnforced());
+  }
+
+  @Test
+  public void testRepeatedCreateWithCustomProperties() {
+    Properties p = new Properties();
+    p.setProperty("jcifs.smb.client.ipcSigningEnforced", "false");
+    BaseContext ctx = CifsContextFactory.create(p);
+    verifyCommonProperties(ctx);
+    assertFalse(ctx.getConfig().isIpcSigningEnforced());
+
+    p = new Properties();
+    p.setProperty("jcifs.smb.client.ipcSigningEnforced", "true");
+    ctx = CifsContextFactory.create(p);
+    verifyCommonProperties(ctx);
+    assertTrue(ctx.getConfig().isIpcSigningEnforced());
+  }
+
+  private void verifyCommonProperties(@NonNull BaseContext ctx) {
+    assertNotNull(ctx);
+    assertEquals(ResolverType.RESOLVER_BCAST, ctx.getConfig().getResolveOrder().get(0));
+    assertEquals(-1 * 60, ctx.getConfig().getNetbiosCachePolicy());
+    assertEquals(30000, ctx.getConfig().getResponseTimeout());
+    assertEquals(5000, ctx.getConfig().getNetbiosRetryTimeout());
+  }
+}

--- a/app/src/test/java/com/amaze/filemanager/filesystem/ssh/test/TestUtils.java
+++ b/app/src/test/java/com/amaze/filemanager/filesystem/ssh/test/TestUtils.java
@@ -20,6 +20,8 @@
 
 package com.amaze.filemanager.filesystem.ssh.test;
 
+import static com.amaze.filemanager.filesystem.ssh.SshConnectionPool.SSH_URI_PREFIX;
+
 import java.io.IOException;
 import java.io.StringWriter;
 import java.security.KeyPair;
@@ -77,7 +79,7 @@ public abstract class TestUtils {
       privateKeyContents = writer.toString();
     }
 
-    StringBuilder fullUri = new StringBuilder().append("ssh://").append(validUsername);
+    StringBuilder fullUri = new StringBuilder().append(SSH_URI_PREFIX).append(validUsername);
 
     if (validPassword != null) fullUri.append(':').append(validPassword);
 


### PR DESCRIPTION
After switching to [jcifs-ng](https://github.com/AgNO3/jcifs-ng), some users reported they cannot access their SMBv1 servers with new versions of Amaze. It is possibly due to jcifs-ng enforces IPC signing check as described in [CVE-2016-2115](https://nvd.nist.gov/vuln/detail/CVE-2016-2115). This PR add support back, but on per-connection basis, i.e. only SMB connections explicitly disabled IPC signing check will be affected.

- Add `CifsContextFactory` to create `BaseContext` instances for `SmbFile`, allow adding custom properties
- Implement adding `jcifs.smb.client.ipcSigningEnforced` flag in creating `BaseContext`, for legacy SMBv1 compatibility
- `HybridFile` centralized `SmbFile` creation to `getSmbFile()`
- `SmbConnectDialog`, add checkbox for enable legacy SMBv1 support (= Disable IPC signing check)
- Added routines to handle SMB URLs with query string, for propagating the `disableIpcSigningCheck` flag when manipulating files/folders on SMB server
- Removed SMB specific routines in MoveFiles, as they are actually for moving files on the remote

## PR Info
#### Issue tracker   
Fixes will automatically close the related issue

Fixes #2061 

#### Release  
Addresses release/3.5
  
#### Test cases
- [ ] Covered
  
#### Manual testing
- [x] Done  
  
If yes,  
- Device: Pixel 2 emulator
- OS: Android 10

#### Build tasks success  
Successfully running following tasks on local 
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`

#### Additional Info