### PR TITLE
Update Android SDK

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -267,6 +267,7 @@ jacoco {
 
 tasks.withType(Test) {
     jacoco.includeNoLocationClasses = true
+    jacoco.excludes = ['jdk.internal.*']
 }
 
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,9 +1,9 @@
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
-apply plugin: 'jacoco-android'
+apply plugin: 'com.hiya.jacoco-android'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 30
 
     dexOptions {
         jumboMode = true
@@ -24,7 +24,7 @@ android {
     defaultConfig {
         applicationId "com.amaze.filemanager"
         minSdkVersion 14
-        targetSdkVersion 28
+        targetSdkVersion 30
         versionCode 90
         versionName "3.5.1"
         multiDexEnabled true
@@ -95,7 +95,8 @@ ext {
     roomVersion = '2.2.5'
     bouncyCastleVersion = '1.65'
     awaitilityVersion = "3.1.6"
-    androidXTestVersion = "1.2.0"
+    androidXTestVersion = "1.3.0"
+    androidXTestExtVersion = "1.1.2"
     junitVersion = "4.13"
     slf4jVersion = "1.7.25"
     mockitoVersion = "3.4.4"
@@ -126,7 +127,7 @@ dependencies {
     testImplementation "androidx.test:core:$androidXTestVersion"
     testImplementation "androidx.test:runner:$androidXTestVersion"
     testImplementation "androidx.test:rules:$androidXTestVersion"
-    testImplementation 'androidx.test.ext:junit:1.1.1'
+    testImplementation "androidx.test.ext:junit:$androidXTestExtVersion"
     //testImplementation 'androidx.test.uiautomator:uiautomator:2.2.0'
     testImplementation "org.mockito:mockito-core:$mockitoVersion"
     testImplementation "org.apache.sshd:sshd-core:1.7.0"
@@ -139,7 +140,7 @@ dependencies {
     androidTestImplementation "androidx.test:core:$androidXTestVersion"
     androidTestImplementation "androidx.test:runner:$androidXTestVersion"
     androidTestImplementation "androidx.test:rules:$androidXTestVersion"
-    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
+    androidTestImplementation "androidx.test.ext:junit:$androidXTestExtVersion"
     androidTestImplementation 'commons-net:commons-net:3.6'
     androidTestImplementation "org.awaitility:awaitility:$awaitilityVersion"
 
@@ -266,6 +267,7 @@ jacoco {
 
 tasks.withType(Test) {
     jacoco.includeNoLocationClasses = true
+    jacoco.excludes = ['jdk.internal.*']
 }
 
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'kotlin-android'
 apply plugin: 'com.hiya.jacoco-android'
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 29
 
     dexOptions {
         jumboMode = true
@@ -24,7 +24,7 @@ android {
     defaultConfig {
         applicationId "com.amaze.filemanager"
         minSdkVersion 14
-        targetSdkVersion 30
+        targetSdkVersion 29
         versionCode 90
         versionName "3.5.1"
         multiDexEnabled true
@@ -267,6 +267,7 @@ jacoco {
 
 tasks.withType(Test) {
     jacoco.includeNoLocationClasses = true
+    jacoco.excludes = ['jdk.internal.*']
 }
 
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -267,7 +267,6 @@ jacoco {
 
 tasks.withType(Test) {
     jacoco.includeNoLocationClasses = true
-    jacoco.excludes = ['jdk.internal.*']
 }
 
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -50,6 +50,7 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         tools:replace="android:label"
         android:label="@string/appbar_name"
+        android:requestLegacyExternalStorage="true"
         android:banner="@drawable/about_header">
 
         <activity

--- a/app/src/test/java/com/amaze/filemanager/application/AppConfigTest.java
+++ b/app/src/test/java/com/amaze/filemanager/application/AppConfigTest.java
@@ -20,11 +20,13 @@
 
 package com.amaze.filemanager.application;
 
+import static android.os.Looper.getMainLooper;
 import static org.awaitility.Awaitility.await;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.mock;
+import static org.robolectric.Shadows.shadowOf;
 
 import java.lang.reflect.Field;
 import java.util.concurrent.TimeUnit;
@@ -68,6 +70,7 @@ public class AppConfigTest {
   @Test
   public void testToastWithStringRes() {
     AppConfig.toast(ApplicationProvider.getApplicationContext(), R.string.ok);
+    shadowOf(getMainLooper()).idle();
     await().atMost(5, TimeUnit.SECONDS).until(() -> ShadowToast.getLatestToast() != null);
     assertEquals(
         ApplicationProvider.getApplicationContext().getString(R.string.ok),
@@ -77,6 +80,7 @@ public class AppConfigTest {
   @Test
   public void testToastWithString() {
     AppConfig.toast(ApplicationProvider.getApplicationContext(), "Hello world");
+    shadowOf(getMainLooper()).idle();
     await().atMost(5, TimeUnit.SECONDS).until(() -> ShadowToast.getLatestToast() != null);
     assertEquals("Hello world", ShadowToast.getTextOfLatestToast());
   }

--- a/app/src/test/java/com/amaze/filemanager/asynchronous/asynctasks/DbViewerTaskTest.java
+++ b/app/src/test/java/com/amaze/filemanager/asynchronous/asynctasks/DbViewerTaskTest.java
@@ -20,12 +20,14 @@
 
 package com.amaze.filemanager.asynchronous.asynctasks;
 
+import static android.os.Looper.getMainLooper;
 import static android.view.View.VISIBLE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.robolectric.Shadows.shadowOf;
 
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
@@ -111,6 +113,8 @@ public class DbViewerTaskTest {
 
     DbViewerTask task = new DbViewerTask(schemaCursor, contentCursor, webView, mock);
     task.doInBackground();
+
+    shadowOf(getMainLooper()).idle();
 
     assertNotNull(task.schemaList);
     assertNotNull(task.contentList);

--- a/app/src/test/java/com/amaze/filemanager/filesystem/ssh/test/TestUtils.java
+++ b/app/src/test/java/com/amaze/filemanager/filesystem/ssh/test/TestUtils.java
@@ -22,6 +22,8 @@ package com.amaze.filemanager.filesystem.ssh.test;
 
 import static com.amaze.filemanager.filesystem.ssh.SshConnectionPool.SSH_URI_PREFIX;
 
+import static org.robolectric.Shadows.shadowOf;
+
 import java.io.IOException;
 import java.io.StringWriter;
 import java.security.KeyPair;
@@ -36,6 +38,8 @@ import com.amaze.filemanager.database.UtilitiesDatabase;
 import com.amaze.filemanager.database.UtilsHandler;
 import com.amaze.filemanager.database.models.OperationData;
 import com.amaze.filemanager.filesystem.ssh.SshClientUtils;
+
+import android.os.Looper;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -103,5 +107,7 @@ public abstract class TestUtils {
               SecurityUtils.getFingerprint(hostKeyPair.getPublic()),
               "id_rsa",
               privateKeyContents));
+
+    shadowOf(Looper.getMainLooper()).idle();
   }
 }

--- a/app/src/test/java/com/amaze/filemanager/filesystem/ssh/test/TestUtils.java
+++ b/app/src/test/java/com/amaze/filemanager/filesystem/ssh/test/TestUtils.java
@@ -24,10 +24,6 @@ import static com.amaze.filemanager.filesystem.ssh.SshConnectionPool.SSH_URI_PRE
 
 import static org.robolectric.Shadows.shadowOf;
 
-import static com.amaze.filemanager.filesystem.ssh.SshConnectionPool.SSH_URI_PREFIX;
-
-import static org.robolectric.Shadows.shadowOf;
-
 import java.io.IOException;
 import java.io.StringWriter;
 import java.security.KeyPair;

--- a/app/src/test/java/com/amaze/filemanager/filesystem/ssh/test/TestUtils.java
+++ b/app/src/test/java/com/amaze/filemanager/filesystem/ssh/test/TestUtils.java
@@ -21,7 +21,6 @@
 package com.amaze.filemanager.filesystem.ssh.test;
 
 import static com.amaze.filemanager.filesystem.ssh.SshConnectionPool.SSH_URI_PREFIX;
-
 import static org.robolectric.Shadows.shadowOf;
 
 import java.io.IOException;

--- a/app/src/test/java/com/amaze/filemanager/filesystem/ssh/test/TestUtils.java
+++ b/app/src/test/java/com/amaze/filemanager/filesystem/ssh/test/TestUtils.java
@@ -24,6 +24,8 @@ import static com.amaze.filemanager.filesystem.ssh.SshConnectionPool.SSH_URI_PRE
 
 import static org.robolectric.Shadows.shadowOf;
 
+import static com.amaze.filemanager.filesystem.ssh.SshConnectionPool.SSH_URI_PREFIX;
+
 import java.io.IOException;
 import java.io.StringWriter;
 import java.security.KeyPair;

--- a/app/src/test/java/com/amaze/filemanager/filesystem/ssh/test/TestUtils.java
+++ b/app/src/test/java/com/amaze/filemanager/filesystem/ssh/test/TestUtils.java
@@ -26,6 +26,8 @@ import static org.robolectric.Shadows.shadowOf;
 
 import static com.amaze.filemanager.filesystem.ssh.SshConnectionPool.SSH_URI_PREFIX;
 
+import static org.robolectric.Shadows.shadowOf;
+
 import java.io.IOException;
 import java.io.StringWriter;
 import java.security.KeyPair;

--- a/build.gradle
+++ b/build.gradle
@@ -5,12 +5,14 @@ buildscript {
     repositories {
         google()
         jcenter()
+        maven {
+            url "https://plugins.gradle.org/m2/"
+        }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.4'
-        classpath 'com.dicedmelon.gradle:jacoco-android:0.1.4'
+        classpath 'com.android.tools.build:gradle:4.1.0'
+        classpath 'com.hiya:jacoco-android:0.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sun Jul 19 11:09:24 HKT 2020
+#Sun Nov 08 11:35:54 HKT 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip


### PR DESCRIPTION
Fixes #2057. Everybody hate this because of its "privacy-oriented" storage lockdowns, but it needs to happen anyway.

- Update to SDK 30
- Enable requestLegacyExternalStorage flag in manifest
- Update test libraries
- Fixes to AppConfigTest and DbViewerTaskTest for new ShadowLooper behaviour (default=PAUSED) in Robolectric 4.4

I'm marking this 3.5 milestone since now updates on Google Play will require at least SDK 29. When we need to update to 3.5.1 this PR will become necessary.

Update to Robolectric was postponed to separate PR because some tests will need refactoring to adapt to its default behaviour that [Looper is always PAUSED](https://github.com/robolectric/robolectric/releases/tag/robolectric-4.4).

Very little quick tests done... on Fairphone 3 running LineageOS 16.0 (9.0), Android data directory is still accessible, and copy from SD card to internal storage still works. Will do more tests on wide variety of devices later.

Please also test on Android 10 or 11 devices to see how you'd be affected.