### PR TITLE
Improve feedbacks on read-only remote filesystems

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -130,6 +130,7 @@ dependencies {
     testImplementation "androidx.test.ext:junit:$androidXTestExtVersion"
     //testImplementation 'androidx.test.uiautomator:uiautomator:2.2.0'
     testImplementation "org.mockito:mockito-core:$mockitoVersion"
+    testImplementation "org.mockito:mockito-inline:$mockitoVersion"
     testImplementation "org.apache.sshd:sshd-core:1.7.0"
     testImplementation "org.awaitility:awaitility:$awaitilityVersion"
     testImplementation 'org.jsoup:jsoup:1.11.2'

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -666,5 +666,9 @@
     <string name="select_save_location">Select location to save</string>
     <string name="scp_default_path">Default Path (Optional)</string>
     <string name="disableIpcSignature">Disable IPC signing check (For legacy SMBv1 servers - UNSAFE!)</string>
+    <string name="cannot_delete_file">Cannot delete file </string>
+    <string name="cannot_delete_file_with_reason">Cannot delete file - %s </string>
+    <string name="cannot_rename_file">Cannot rename file %s - %s</string>
+    <string name="cannot_read_directory">Cannot read directory %s - %s</string>
 </resources>
 

--- a/app/src/test/java/com/amaze/filemanager/application/AppConfigTest.java
+++ b/app/src/test/java/com/amaze/filemanager/application/AppConfigTest.java
@@ -20,6 +20,9 @@
 
 package com.amaze.filemanager.application;
 
+import static android.os.Build.VERSION_CODES.JELLY_BEAN;
+import static android.os.Build.VERSION_CODES.KITKAT;
+import static android.os.Build.VERSION_CODES.P;
 import static android.os.Looper.getMainLooper;
 import static org.awaitility.Awaitility.await;
 import static org.junit.Assert.assertEquals;
@@ -34,6 +37,7 @@ import java.util.concurrent.TimeUnit;
 import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.annotation.Config;
 import org.robolectric.shadows.ShadowToast;
 
 import com.amaze.filemanager.R;
@@ -47,6 +51,7 @@ import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 @RunWith(AndroidJUnit4.class)
+@Config(sdk = {JELLY_BEAN, KITKAT, P})
 public class AppConfigTest {
 
   @After

--- a/app/src/test/java/com/amaze/filemanager/asynchronous/asynctasks/AbstractDeleteTaskTestBase.kt
+++ b/app/src/test/java/com/amaze/filemanager/asynchronous/asynctasks/AbstractDeleteTaskTestBase.kt
@@ -49,6 +49,9 @@ abstract class AbstractDeleteTaskTestBase {
     private var ctx: Context? = null
 
     companion object {
+        /**
+         * Custom bootstrap function to turn RxJava to fit better in Robolectric tests.
+         */
         @BeforeClass
         fun bootstrap() {
             RxJavaPlugins.reset()
@@ -56,6 +59,11 @@ abstract class AbstractDeleteTaskTestBase {
         }
     }
 
+    /**
+     * Test case setup.
+     *
+     * TODO: some even more generic test case base to prevent copy-and-paste?
+     */
     @Before
     fun setUp() {
         ctx = ApplicationProvider.getApplicationContext()

--- a/app/src/test/java/com/amaze/filemanager/asynchronous/asynctasks/AbstractDeleteTaskTestBase.kt
+++ b/app/src/test/java/com/amaze/filemanager/asynchronous/asynctasks/AbstractDeleteTaskTestBase.kt
@@ -106,7 +106,8 @@ abstract class AbstractDeleteTaskTestBase {
                 }!!.apply {
                     assertEquals(MainActivity.TAG_INTENT_FILTER_GENERAL, action)
                     getParcelableArrayListExtra<HybridFileParcelable>(
-                        MainActivity.TAG_INTENT_FILTER_FAILED_OPS)
+                        MainActivity.TAG_INTENT_FILTER_FAILED_OPS
+                    )
                         .run {
                             assertTrue(size > 0)
                             assertEquals(file.path, this[0].path)
@@ -116,7 +117,7 @@ abstract class AbstractDeleteTaskTestBase {
         }.moveToState(Lifecycle.State.DESTROYED).close().run {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N)
                 shadowOf(ctx?.getSystemService(StorageManager::class.java))
-                        .resetStorageVolumeList()
+                    .resetStorageVolumeList()
         }
     }
 }

--- a/app/src/test/java/com/amaze/filemanager/asynchronous/asynctasks/AbstractDeleteTaskTestBase.kt
+++ b/app/src/test/java/com/amaze/filemanager/asynchronous/asynctasks/AbstractDeleteTaskTestBase.kt
@@ -1,0 +1,114 @@
+/*
+ * Copyright (C) 2014-2020 Arpit Khurana <arpitkh96@gmail.com>, Vishal Nehra <vishalmeham2@gmail.com>,
+ * Emmanuel Messulam<emmanuelbendavid@gmail.com>, Raymond Lai <airwave209gt at gmail.com> and Contributors.
+ *
+ * This file is part of Amaze File Manager.
+ *
+ * Amaze File Manager is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.amaze.filemanager.asynchronous.asynctasks
+
+import android.content.Context
+import android.os.Build
+import android.os.Looper
+import android.os.storage.StorageManager
+import androidx.lifecycle.Lifecycle
+import androidx.test.core.app.ActivityScenario
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.amaze.filemanager.R
+import com.amaze.filemanager.filesystem.HybridFileParcelable
+import com.amaze.filemanager.test.TestUtils
+import com.amaze.filemanager.ui.activities.MainActivity
+import io.reactivex.plugins.RxJavaPlugins
+import io.reactivex.schedulers.Schedulers
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.BeforeClass
+import org.junit.runner.RunWith
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.LooperMode
+import org.robolectric.shadows.ShadowToast
+
+@RunWith(AndroidJUnit4::class)
+@LooperMode(LooperMode.Mode.PAUSED)
+abstract class AbstractDeleteTaskTestBase {
+
+    private var ctx: Context? = null
+
+    companion object {
+        @BeforeClass
+        fun bootstrap() {
+            RxJavaPlugins.reset()
+            RxJavaPlugins.setIoSchedulerHandler { Schedulers.trampoline() }
+        }
+    }
+
+    @Before
+    fun setUp() {
+        ctx = ApplicationProvider.getApplicationContext()
+    }
+
+    protected fun doTestDeleteFileOk(file: HybridFileParcelable) {
+        val task = DeleteTask(ctx!!)
+        val result = task.doInBackground(ArrayList(listOf(file)))
+        assertTrue(result.result)
+        assertNull(result.exception)
+
+        task.onPostExecute(result)
+        shadowOf(Looper.getMainLooper()).idle()
+        assertNotNull(ShadowToast.getLatestToast())
+        assertEquals(ctx?.getString(R.string.done), ShadowToast.getTextOfLatestToast())
+    }
+
+    protected fun doTestDeleteFileAccessDenied(file: HybridFileParcelable) {
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) TestUtils.initializeInternalStorage()
+
+        ActivityScenario.launch(MainActivity::class.java).also {
+            shadowOf(Looper.getMainLooper()).idle()
+        }.moveToState(Lifecycle.State.STARTED).onActivity { activity ->
+
+            val task = DeleteTask(ctx!!)
+            val result = task.doInBackground(ArrayList(listOf(file)))
+            if (result.result != null) {
+                assertFalse(result.result)
+            } else {
+                assertNotNull(result.exception)
+            }
+            task.onPostExecute(result)
+            shadowOf(Looper.getMainLooper()).idle()
+
+            shadowOf(activity).broadcastIntents.run {
+                assertTrue(size > 0)
+                find {
+                    MainActivity.TAG_INTENT_FILTER_GENERAL.equals(it.action)
+                }!!.apply {
+                    assertEquals(MainActivity.TAG_INTENT_FILTER_GENERAL, action)
+                    getParcelableArrayListExtra<HybridFileParcelable>(
+                        MainActivity.TAG_INTENT_FILTER_FAILED_OPS)
+                        .run {
+                            assertTrue(size > 0)
+                            assertEquals(file.path, this[0].path)
+                        }
+                }
+            }
+        }.moveToState(Lifecycle.State.DESTROYED).close().run {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N)
+                shadowOf(ctx?.getSystemService(StorageManager::class.java))
+                        .resetStorageVolumeList()
+        }
+    }
+}

--- a/app/src/test/java/com/amaze/filemanager/asynchronous/asynctasks/DbViewerTaskTest.java
+++ b/app/src/test/java/com/amaze/filemanager/asynchronous/asynctasks/DbViewerTaskTest.java
@@ -20,6 +20,9 @@
 
 package com.amaze.filemanager.asynchronous.asynctasks;
 
+import static android.os.Build.VERSION_CODES.JELLY_BEAN;
+import static android.os.Build.VERSION_CODES.KITKAT;
+import static android.os.Build.VERSION_CODES.P;
 import static android.os.Looper.getMainLooper;
 import static android.view.View.VISIBLE;
 import static org.junit.Assert.assertEquals;
@@ -53,7 +56,9 @@ import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 @RunWith(AndroidJUnit4.class)
-@Config(shadows = {ShadowMultiDex.class})
+@Config(
+    shadows = {ShadowMultiDex.class},
+    sdk = {JELLY_BEAN, KITKAT, P})
 public class DbViewerTaskTest {
 
   private WebView webView;

--- a/app/src/test/java/com/amaze/filemanager/asynchronous/asynctasks/SmbDeleteTaskTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/asynchronous/asynctasks/SmbDeleteTaskTest.kt
@@ -20,6 +20,7 @@
 
 package com.amaze.filemanager.asynchronous.asynctasks
 
+import android.os.Build.VERSION_CODES.*
 import com.amaze.filemanager.filesystem.HybridFileParcelable
 import com.amaze.filemanager.shadows.ShadowMultiDex
 import com.amaze.filemanager.shadows.ShadowSmbUtil
@@ -28,7 +29,7 @@ import com.amaze.filemanager.utils.SmbUtil
 import org.junit.Test
 import org.robolectric.annotation.Config
 
-@Config(shadows = [ShadowMultiDex::class, ShadowSmbUtil::class])
+@Config(shadows = [ShadowMultiDex::class, ShadowSmbUtil::class], sdk = [JELLY_BEAN, KITKAT, P])
 class SmbDeleteTaskTest : AbstractDeleteTaskTestBase() {
 
     /**
@@ -39,7 +40,8 @@ class SmbDeleteTaskTest : AbstractDeleteTaskTestBase() {
     @Test
     fun testDeleteSmbFileOk() {
         doTestDeleteFileOk(
-                HybridFileParcelable(SmbUtil.create("smb://user:password@1.2.3.4/just/a/file.txt")))
+            HybridFileParcelable(SmbUtil.create("smb://user:password@1.2.3.4/just/a/file.txt"))
+        )
     }
 
     /**

--- a/app/src/test/java/com/amaze/filemanager/asynchronous/asynctasks/SmbDeleteTaskTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/asynchronous/asynctasks/SmbDeleteTaskTest.kt
@@ -31,12 +31,22 @@ import org.robolectric.annotation.Config
 @Config(shadows = [ShadowMultiDex::class, ShadowSmbUtil::class])
 class SmbDeleteTaskTest : AbstractDeleteTaskTestBase() {
 
+    /**
+     * Test case to verify delete SMB file success scenario.
+     *
+     * @see AbstractDeleteTaskTestBase.doTestDeleteFileOk
+     */
     @Test
     fun testDeleteSmbFileOk() {
         doTestDeleteFileOk(
                 HybridFileParcelable(SmbUtil.create("smb://user:password@1.2.3.4/just/a/file.txt")))
     }
 
+    /**
+     * Test case to verify delete SSH file failure scenario.
+     *
+     * @see AbstractDeleteTaskTestBase.doTestDeleteFileAccessDenied
+     */
     @Test
     fun testDeleteSmbFileAccessDenied() {
         doTestDeleteFileAccessDenied(HybridFileParcelable(SmbUtil.create(PATH_CANNOT_DELETE_FILE)))

--- a/app/src/test/java/com/amaze/filemanager/asynchronous/asynctasks/SmbDeleteTaskTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/asynchronous/asynctasks/SmbDeleteTaskTest.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2014-2020 Arpit Khurana <arpitkh96@gmail.com>, Vishal Nehra <vishalmeham2@gmail.com>,
+ * Emmanuel Messulam<emmanuelbendavid@gmail.com>, Raymond Lai <airwave209gt at gmail.com> and Contributors.
+ *
+ * This file is part of Amaze File Manager.
+ *
+ * Amaze File Manager is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.amaze.filemanager.asynchronous.asynctasks
+
+import com.amaze.filemanager.filesystem.HybridFileParcelable
+import com.amaze.filemanager.shadows.ShadowMultiDex
+import com.amaze.filemanager.shadows.ShadowSmbUtil
+import com.amaze.filemanager.shadows.ShadowSmbUtil.Companion.PATH_CANNOT_DELETE_FILE
+import com.amaze.filemanager.utils.SmbUtil
+import org.junit.Test
+import org.robolectric.annotation.Config
+
+@Config(shadows = [ShadowMultiDex::class, ShadowSmbUtil::class])
+class SmbDeleteTaskTest : AbstractDeleteTaskTestBase() {
+
+    @Test
+    fun testDeleteSmbFileOk() {
+        doTestDeleteFileOk(
+                HybridFileParcelable(SmbUtil.create("smb://user:password@1.2.3.4/just/a/file.txt")))
+    }
+
+    @Test
+    fun testDeleteSmbFileAccessDenied() {
+        doTestDeleteFileAccessDenied(HybridFileParcelable(SmbUtil.create(PATH_CANNOT_DELETE_FILE)))
+    }
+}

--- a/app/src/test/java/com/amaze/filemanager/asynchronous/asynctasks/SshDeleteTaskTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/asynchronous/asynctasks/SshDeleteTaskTest.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2014-2020 Arpit Khurana <arpitkh96@gmail.com>, Vishal Nehra <vishalmeham2@gmail.com>,
+ * Emmanuel Messulam<emmanuelbendavid@gmail.com>, Raymond Lai <airwave209gt at gmail.com> and Contributors.
+ *
+ * This file is part of Amaze File Manager.
+ *
+ * Amaze File Manager is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.amaze.filemanager.asynchronous.asynctasks
+
+import com.amaze.filemanager.filesystem.HybridFileParcelable
+import com.amaze.filemanager.filesystem.ssh.test.MockSshConnectionPools
+import com.amaze.filemanager.shadows.ShadowMultiDex
+import com.amaze.filemanager.test.ShadowCryptUtil
+import net.schmizz.sshj.sftp.FileAttributes
+import net.schmizz.sshj.sftp.RemoteResourceInfo
+import net.schmizz.sshj.xfer.FilePermission
+import org.junit.Test
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.mock
+import org.robolectric.annotation.Config
+
+@Config(shadows = [ShadowMultiDex::class, ShadowCryptUtil::class])
+class SshDeleteTaskTest : AbstractDeleteTaskTestBase() {
+
+    @Test
+    fun testDeleteSshFileOk() {
+        MockSshConnectionPools.prepareCanDeleteScenario()
+        doTestDeleteFileOk(createSshHybridFileParcelable())
+    }
+
+    @Test
+    fun testDeleteSshFileAccessDenied() {
+        MockSshConnectionPools.prepareCannotDeleteScenario()
+        doTestDeleteFileAccessDenied(createSshHybridFileParcelable())
+    }
+
+    private fun createSshHybridFileParcelable(): HybridFileParcelable {
+        val ri = mock(RemoteResourceInfo::class.java).apply {
+            val fa = mock(FileAttributes::class.java).apply {
+                `when`(mtime).thenReturn(System.currentTimeMillis() / 1000)
+                `when`(size).thenReturn(16384)
+                `when`(permissions).thenReturn(
+                    setOf(FilePermission.USR_RWX,
+                        FilePermission.GRP_RWX,
+                        FilePermission.OTH_RWX))
+            }
+            `when`(name).thenReturn("test.file")
+            `when`(attributes).thenReturn(fa)
+        }
+
+        return HybridFileParcelable("ssh://user:password@127.0.0.1:22222",
+                false, ri)
+    }
+}

--- a/app/src/test/java/com/amaze/filemanager/asynchronous/asynctasks/SshDeleteTaskTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/asynchronous/asynctasks/SshDeleteTaskTest.kt
@@ -35,12 +35,22 @@ import org.robolectric.annotation.Config
 @Config(shadows = [ShadowMultiDex::class, ShadowCryptUtil::class])
 class SshDeleteTaskTest : AbstractDeleteTaskTestBase() {
 
+    /**
+     * Test case to verify delete SSH file success scenario.
+     *
+     * @see AbstractDeleteTaskTestBase.doTestDeleteFileOk
+     */
     @Test
     fun testDeleteSshFileOk() {
         MockSshConnectionPools.prepareCanDeleteScenario()
         doTestDeleteFileOk(createSshHybridFileParcelable())
     }
 
+    /**
+     * Test case to verify delete SSH file failure scenario.
+     *
+     * @see AbstractDeleteTaskTestBase.doTestDeleteFileAccessDenied
+     */
     @Test
     fun testDeleteSshFileAccessDenied() {
         MockSshConnectionPools.prepareCannotDeleteScenario()

--- a/app/src/test/java/com/amaze/filemanager/asynchronous/asynctasks/SshDeleteTaskTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/asynchronous/asynctasks/SshDeleteTaskTest.kt
@@ -20,6 +20,7 @@
 
 package com.amaze.filemanager.asynchronous.asynctasks
 
+import android.os.Build.VERSION_CODES.*
 import com.amaze.filemanager.filesystem.HybridFileParcelable
 import com.amaze.filemanager.filesystem.ssh.test.MockSshConnectionPools
 import com.amaze.filemanager.shadows.ShadowMultiDex
@@ -32,7 +33,10 @@ import org.mockito.Mockito.`when`
 import org.mockito.Mockito.mock
 import org.robolectric.annotation.Config
 
-@Config(shadows = [ShadowMultiDex::class, ShadowCryptUtil::class])
+@Config(
+    shadows = [ShadowMultiDex::class, ShadowCryptUtil::class],
+    sdk = [JELLY_BEAN, KITKAT, P]
+)
 class SshDeleteTaskTest : AbstractDeleteTaskTestBase() {
 
     /**
@@ -63,15 +67,20 @@ class SshDeleteTaskTest : AbstractDeleteTaskTestBase() {
                 `when`(mtime).thenReturn(System.currentTimeMillis() / 1000)
                 `when`(size).thenReturn(16384)
                 `when`(permissions).thenReturn(
-                    setOf(FilePermission.USR_RWX,
+                    setOf(
+                        FilePermission.USR_RWX,
                         FilePermission.GRP_RWX,
-                        FilePermission.OTH_RWX))
+                        FilePermission.OTH_RWX
+                    )
+                )
             }
             `when`(name).thenReturn("test.file")
             `when`(attributes).thenReturn(fa)
         }
 
-        return HybridFileParcelable("ssh://user:password@127.0.0.1:22222",
-                false, ri)
+        return HybridFileParcelable(
+            "ssh://user:password@127.0.0.1:22222",
+            false, ri
+        )
     }
 }

--- a/app/src/test/java/com/amaze/filemanager/asynchronous/asynctasks/WriteFileAbstractionTest.java
+++ b/app/src/test/java/com/amaze/filemanager/asynchronous/asynctasks/WriteFileAbstractionTest.java
@@ -20,6 +20,9 @@
 
 package com.amaze.filemanager.asynchronous.asynctasks;
 
+import static android.os.Build.VERSION_CODES.JELLY_BEAN;
+import static android.os.Build.VERSION_CODES.KITKAT;
+import static android.os.Build.VERSION_CODES.P;
 import static com.amaze.filemanager.asynchronous.asynctasks.WriteFileAbstraction.EXCEPTION_SHELL_NOT_RUNNING;
 import static com.amaze.filemanager.asynchronous.asynctasks.WriteFileAbstraction.EXCEPTION_STREAM_NOT_FOUND;
 import static com.amaze.filemanager.asynchronous.asynctasks.WriteFileAbstraction.NORMAL;
@@ -59,7 +62,9 @@ import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 @RunWith(AndroidJUnit4.class)
-@Config(shadows = {ShadowMultiDex.class})
+@Config(
+    shadows = {ShadowMultiDex.class},
+    sdk = {JELLY_BEAN, KITKAT, P})
 public class WriteFileAbstractionTest {
 
   private static final String contents = "This is modified data";

--- a/app/src/test/java/com/amaze/filemanager/asynchronous/asynctasks/compress/AbstractCompressedHelperTaskTest.java
+++ b/app/src/test/java/com/amaze/filemanager/asynchronous/asynctasks/compress/AbstractCompressedHelperTaskTest.java
@@ -20,6 +20,9 @@
 
 package com.amaze.filemanager.asynchronous.asynctasks.compress;
 
+import static android.os.Build.VERSION_CODES.JELLY_BEAN;
+import static android.os.Build.VERSION_CODES.KITKAT;
+import static android.os.Build.VERSION_CODES.P;
 import static org.junit.Assert.assertEquals;
 
 import java.io.File;
@@ -44,7 +47,9 @@ import android.os.Environment;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 @RunWith(AndroidJUnit4.class)
-@Config(shadows = {ShadowMultiDex.class})
+@Config(
+    shadows = {ShadowMultiDex.class},
+    sdk = {JELLY_BEAN, KITKAT, P})
 public abstract class AbstractCompressedHelperTaskTest {
 
   @Before

--- a/app/src/test/java/com/amaze/filemanager/asynchronous/services/ExtractServiceTest.java
+++ b/app/src/test/java/com/amaze/filemanager/asynchronous/services/ExtractServiceTest.java
@@ -20,6 +20,9 @@
 
 package com.amaze.filemanager.asynchronous.services;
 
+import static android.os.Build.VERSION_CODES.JELLY_BEAN;
+import static android.os.Build.VERSION_CODES.KITKAT;
+import static android.os.Build.VERSION_CODES.P;
 import static android.os.Looper.getMainLooper;
 import static org.awaitility.Awaitility.await;
 import static org.junit.Assert.assertEquals;
@@ -56,7 +59,9 @@ import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 @RunWith(AndroidJUnit4.class)
-@Config(shadows = {ShadowMultiDex.class})
+@Config(
+    shadows = {ShadowMultiDex.class},
+    sdk = {JELLY_BEAN, KITKAT, P})
 public class ExtractServiceTest {
 
   private File zipfile1 = new File(Environment.getExternalStorageDirectory(), "zip-slip.zip");

--- a/app/src/test/java/com/amaze/filemanager/filesystem/AbstractOperationsTestBase.kt
+++ b/app/src/test/java/com/amaze/filemanager/filesystem/AbstractOperationsTestBase.kt
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2014-2020 Arpit Khurana <arpitkh96@gmail.com>, Vishal Nehra <vishalmeham2@gmail.com>,
+ * Emmanuel Messulam<emmanuelbendavid@gmail.com>, Raymond Lai <airwave209gt at gmail.com> and Contributors.
+ *
+ * This file is part of Amaze File Manager.
+ *
+ * Amaze File Manager is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.amaze.filemanager.filesystem
+
+import android.content.Context
+import android.os.Build
+import android.os.Looper
+import android.os.storage.StorageManager
+import androidx.lifecycle.Lifecycle
+import androidx.test.core.app.ActivityScenario
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.amaze.filemanager.test.TestUtils
+import com.amaze.filemanager.ui.activities.MainActivity
+import com.amaze.filemanager.utils.OpenMode
+import org.junit.Assert
+import org.junit.Before
+import org.junit.runner.RunWith
+import org.robolectric.Shadows
+import org.robolectric.android.util.concurrent.InlineExecutorService
+import org.robolectric.annotation.LooperMode
+import org.robolectric.shadows.ShadowPausedAsyncTask
+
+@RunWith(AndroidJUnit4::class)
+@LooperMode(LooperMode.Mode.PAUSED)
+abstract class AbstractOperationsTestBase {
+
+    protected var ctx: Context? = null
+
+    protected val blankCallback = object : Operations.ErrorCallBack {
+        override fun exists(file: HybridFile?) = Unit
+        override fun launchSAF(file: HybridFile?) = Unit
+        override fun launchSAF(file: HybridFile?, file1: HybridFile?) = Unit
+        override fun done(hFile: HybridFile?, b: Boolean) = Unit
+        override fun invalidName(file: HybridFile?) = Unit
+    }
+
+    @Before
+    fun setUp() {
+        ctx = ApplicationProvider.getApplicationContext()
+        ShadowPausedAsyncTask.overrideExecutor(InlineExecutorService())
+    }
+
+    protected fun testRenameFileAccessDenied(
+        fileMode: OpenMode,
+        oldFilePath: String,
+        newFilePath: String
+    ) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) TestUtils.initializeInternalStorage()
+
+        ActivityScenario.launch(MainActivity::class.java).also {
+            Shadows.shadowOf(Looper.getMainLooper()).idle()
+        }.moveToState(Lifecycle.State.STARTED).onActivity { activity ->
+
+            val oldFile = HybridFile(fileMode, oldFilePath)
+            val newFile = HybridFile(fileMode, newFilePath)
+            Operations.rename(oldFile, newFile, false, activity, blankCallback)
+            Shadows.shadowOf(Looper.getMainLooper()).idle()
+
+            Shadows.shadowOf(activity).broadcastIntents.run {
+                Assert.assertNotNull(this)
+                Assert.assertTrue(this.size > 0)
+                this[0].apply {
+                    Assert.assertEquals(MainActivity.TAG_INTENT_FILTER_GENERAL, this.action)
+                    this
+                    .getParcelableArrayListExtra<HybridFileParcelable>(
+                            MainActivity.TAG_INTENT_FILTER_FAILED_OPS)
+                    .run {
+                        Assert.assertTrue(this.size > 0)
+                        Assert.assertEquals(oldFilePath, this[0].path)
+                    }
+                }
+            }
+        }.moveToState(Lifecycle.State.DESTROYED).close().run {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N)
+                Shadows.shadowOf(ctx?.getSystemService(StorageManager::class.java))
+                        .resetStorageVolumeList()
+        }
+    }
+}

--- a/app/src/test/java/com/amaze/filemanager/filesystem/AbstractOperationsTestBase.kt
+++ b/app/src/test/java/com/amaze/filemanager/filesystem/AbstractOperationsTestBase.kt
@@ -53,6 +53,11 @@ abstract class AbstractOperationsTestBase {
         override fun invalidName(file: HybridFile?) = Unit
     }
 
+    /**
+     * Test case setup.
+     *
+     * TODO: some even more generic test case base to prevent copy-and-paste?
+     */
     @Before
     fun setUp() {
         ctx = ApplicationProvider.getApplicationContext()

--- a/app/src/test/java/com/amaze/filemanager/filesystem/AbstractOperationsTestBase.kt
+++ b/app/src/test/java/com/amaze/filemanager/filesystem/AbstractOperationsTestBase.kt
@@ -86,18 +86,19 @@ abstract class AbstractOperationsTestBase {
                 this[0].apply {
                     Assert.assertEquals(MainActivity.TAG_INTENT_FILTER_GENERAL, this.action)
                     this
-                    .getParcelableArrayListExtra<HybridFileParcelable>(
-                            MainActivity.TAG_INTENT_FILTER_FAILED_OPS)
-                    .run {
-                        Assert.assertTrue(this.size > 0)
-                        Assert.assertEquals(oldFilePath, this[0].path)
-                    }
+                        .getParcelableArrayListExtra<HybridFileParcelable>(
+                            MainActivity.TAG_INTENT_FILTER_FAILED_OPS
+                        )
+                        .run {
+                            Assert.assertTrue(this.size > 0)
+                            Assert.assertEquals(oldFilePath, this[0].path)
+                        }
                 }
             }
         }.moveToState(Lifecycle.State.DESTROYED).close().run {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N)
                 Shadows.shadowOf(ctx?.getSystemService(StorageManager::class.java))
-                        .resetStorageVolumeList()
+                    .resetStorageVolumeList()
         }
     }
 }

--- a/app/src/test/java/com/amaze/filemanager/filesystem/EditableFileAbstractionTest.java
+++ b/app/src/test/java/com/amaze/filemanager/filesystem/EditableFileAbstractionTest.java
@@ -20,6 +20,9 @@
 
 package com.amaze.filemanager.filesystem;
 
+import static android.os.Build.VERSION_CODES.JELLY_BEAN;
+import static android.os.Build.VERSION_CODES.KITKAT;
+import static android.os.Build.VERSION_CODES.P;
 import static com.amaze.filemanager.filesystem.EditableFileAbstraction.Scheme.CONTENT;
 import static com.amaze.filemanager.filesystem.EditableFileAbstraction.Scheme.FILE;
 import static org.junit.Assert.assertEquals;
@@ -44,7 +47,9 @@ import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 @RunWith(AndroidJUnit4.class)
-@Config(shadows = {ShadowMultiDex.class})
+@Config(
+    shadows = {ShadowMultiDex.class},
+    sdk = {JELLY_BEAN, KITKAT, P})
 public class EditableFileAbstractionTest {
 
   @Test(expected = IllegalArgumentException.class)

--- a/app/src/test/java/com/amaze/filemanager/filesystem/OperationsTest.java
+++ b/app/src/test/java/com/amaze/filemanager/filesystem/OperationsTest.java
@@ -20,6 +20,9 @@
 
 package com.amaze.filemanager.filesystem;
 
+import static android.os.Build.VERSION_CODES.JELLY_BEAN;
+import static android.os.Build.VERSION_CODES.KITKAT;
+import static android.os.Build.VERSION_CODES.P;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -40,7 +43,9 @@ import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 @RunWith(AndroidJUnit4.class)
-@Config(shadows = {ShadowMultiDex.class})
+@Config(
+    shadows = {ShadowMultiDex.class},
+    sdk = {JELLY_BEAN, KITKAT, P})
 public class OperationsTest {
 
   private File storageRoot = Environment.getExternalStorageDirectory();

--- a/app/src/test/java/com/amaze/filemanager/filesystem/RootHelperTest.java
+++ b/app/src/test/java/com/amaze/filemanager/filesystem/RootHelperTest.java
@@ -20,6 +20,9 @@
 
 package com.amaze.filemanager.filesystem;
 
+import static android.os.Build.VERSION_CODES.JELLY_BEAN;
+import static android.os.Build.VERSION_CODES.KITKAT;
+import static android.os.Build.VERSION_CODES.P;
 import static org.junit.Assert.fail;
 
 import java.io.File;
@@ -50,7 +53,9 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 import eu.chainfire.libsuperuser.Shell;
 
 @RunWith(AndroidJUnit4.class)
-@Config(shadows = {ShadowMultiDex.class, ShadowShellInteractive.class})
+@Config(
+    shadows = {ShadowMultiDex.class, ShadowShellInteractive.class},
+    sdk = {JELLY_BEAN, KITKAT, P})
 public class RootHelperTest {
 
   private static final File sysroot =

--- a/app/src/test/java/com/amaze/filemanager/filesystem/SmbOperationsTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/filesystem/SmbOperationsTest.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2014-2020 Arpit Khurana <arpitkh96@gmail.com>, Vishal Nehra <vishalmeham2@gmail.com>,
+ * Emmanuel Messulam<emmanuelbendavid@gmail.com>, Raymond Lai <airwave209gt at gmail.com> and Contributors.
+ *
+ * This file is part of Amaze File Manager.
+ *
+ * Amaze File Manager is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.amaze.filemanager.filesystem
+
+import com.amaze.filemanager.shadows.ShadowMultiDex
+import com.amaze.filemanager.shadows.ShadowSmbUtil
+import com.amaze.filemanager.shadows.ShadowSmbUtil.Companion.PATH_CANNOT_RENAME_OLDFILE
+import com.amaze.filemanager.utils.OpenMode.SMB
+import org.junit.Test
+import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowAsyncTask
+
+@Config(shadows = [ShadowSmbUtil::class, ShadowMultiDex::class, ShadowAsyncTask::class])
+class SmbOperationsTest : AbstractOperationsTestBase() {
+
+    @Test
+    fun testRenameFileAccessDenied() {
+        super.testRenameFileAccessDenied(SMB,
+                PATH_CANNOT_RENAME_OLDFILE,
+                "smb://user:password@1.2.3.4/cannot/rename.file.new")
+    }
+}

--- a/app/src/test/java/com/amaze/filemanager/filesystem/SmbOperationsTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/filesystem/SmbOperationsTest.kt
@@ -20,6 +20,7 @@
 
 package com.amaze.filemanager.filesystem
 
+import android.os.Build.VERSION_CODES.*
 import com.amaze.filemanager.shadows.ShadowMultiDex
 import com.amaze.filemanager.shadows.ShadowSmbUtil
 import com.amaze.filemanager.shadows.ShadowSmbUtil.Companion.PATH_CANNOT_RENAME_OLDFILE
@@ -28,7 +29,10 @@ import org.junit.Test
 import org.robolectric.annotation.Config
 import org.robolectric.shadows.ShadowAsyncTask
 
-@Config(shadows = [ShadowSmbUtil::class, ShadowMultiDex::class, ShadowAsyncTask::class])
+@Config(
+    shadows = [ShadowSmbUtil::class, ShadowMultiDex::class, ShadowAsyncTask::class],
+    sdk = [JELLY_BEAN, KITKAT, P]
+)
 class SmbOperationsTest : AbstractOperationsTestBase() {
 
     /**
@@ -38,8 +42,10 @@ class SmbOperationsTest : AbstractOperationsTestBase() {
      */
     @Test
     fun testRenameFileAccessDenied() {
-        super.testRenameFileAccessDenied(SMB,
-                PATH_CANNOT_RENAME_OLDFILE,
-                "smb://user:password@1.2.3.4/cannot/rename.file.new")
+        super.testRenameFileAccessDenied(
+            SMB,
+            PATH_CANNOT_RENAME_OLDFILE,
+            "smb://user:password@1.2.3.4/cannot/rename.file.new"
+        )
     }
 }

--- a/app/src/test/java/com/amaze/filemanager/filesystem/SmbOperationsTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/filesystem/SmbOperationsTest.kt
@@ -31,6 +31,11 @@ import org.robolectric.shadows.ShadowAsyncTask
 @Config(shadows = [ShadowSmbUtil::class, ShadowMultiDex::class, ShadowAsyncTask::class])
 class SmbOperationsTest : AbstractOperationsTestBase() {
 
+    /**
+     * Test case to verify rename SMB file failure scenario.
+     *
+     * @see AbstractOperationsTestBase.testRenameFileAccessDenied
+     */
     @Test
     fun testRenameFileAccessDenied() {
         super.testRenameFileAccessDenied(SMB,

--- a/app/src/test/java/com/amaze/filemanager/filesystem/SshOperationsTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/filesystem/SshOperationsTest.kt
@@ -20,8 +20,10 @@
 
 package com.amaze.filemanager.filesystem
 
+import android.os.Build.VERSION_CODES.*
 import com.amaze.filemanager.filesystem.ssh.test.MockSshConnectionPools
 import com.amaze.filemanager.shadows.ShadowMultiDex
+import com.amaze.filemanager.test.ShadowCryptUtil
 import com.amaze.filemanager.utils.OpenMode
 import io.reactivex.plugins.RxJavaPlugins
 import io.reactivex.schedulers.Schedulers
@@ -30,7 +32,10 @@ import org.junit.Test
 import org.robolectric.annotation.Config
 import org.robolectric.shadows.ShadowAsyncTask
 
-@Config(shadows = [ShadowMultiDex::class, ShadowAsyncTask::class])
+@Config(
+    shadows = [ShadowMultiDex::class, ShadowAsyncTask::class, ShadowCryptUtil::class],
+    sdk = [JELLY_BEAN, KITKAT, P]
+)
 class SshOperationsTest : AbstractOperationsTestBase() {
 
     companion object {
@@ -52,8 +57,10 @@ class SshOperationsTest : AbstractOperationsTestBase() {
     @Test
     fun testRenameFileAccessDenied() {
         MockSshConnectionPools.prepareCannotDeleteScenario()
-        super.testRenameFileAccessDenied(OpenMode.SFTP,
-        "ssh://user:password@127.0.0.1:22222/tmp/old.file",
-        "ssh://user:password@127.0.0.1:22222/tmp/new.file")
+        super.testRenameFileAccessDenied(
+            OpenMode.SFTP,
+            "ssh://user:password@127.0.0.1:22222/tmp/old.file",
+            "ssh://user:password@127.0.0.1:22222/tmp/new.file"
+        )
     }
 }

--- a/app/src/test/java/com/amaze/filemanager/filesystem/SshOperationsTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/filesystem/SshOperationsTest.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2014-2020 Arpit Khurana <arpitkh96@gmail.com>, Vishal Nehra <vishalmeham2@gmail.com>,
+ * Emmanuel Messulam<emmanuelbendavid@gmail.com>, Raymond Lai <airwave209gt at gmail.com> and Contributors.
+ *
+ * This file is part of Amaze File Manager.
+ *
+ * Amaze File Manager is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.amaze.filemanager.filesystem
+
+import com.amaze.filemanager.filesystem.ssh.test.MockSshConnectionPools
+import com.amaze.filemanager.shadows.ShadowMultiDex
+import com.amaze.filemanager.utils.OpenMode
+import io.reactivex.plugins.RxJavaPlugins
+import io.reactivex.schedulers.Schedulers
+import org.junit.BeforeClass
+import org.junit.Test
+import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowAsyncTask
+
+@Config(shadows = [ShadowMultiDex::class, ShadowAsyncTask::class])
+class SshOperationsTest : AbstractOperationsTestBase() {
+
+    companion object {
+        @BeforeClass
+        fun bootstrap() {
+            RxJavaPlugins.reset()
+            RxJavaPlugins.setIoSchedulerHandler { Schedulers.trampoline() }
+        }
+    }
+
+    @Test
+    fun testRenameFileAccessDenied() {
+        MockSshConnectionPools.prepareCannotDeleteScenario()
+        super.testRenameFileAccessDenied(OpenMode.SFTP,
+        "ssh://user:password@127.0.0.1:22222/tmp/old.file",
+        "ssh://user:password@127.0.0.1:22222/tmp/new.file")
+    }
+}

--- a/app/src/test/java/com/amaze/filemanager/filesystem/SshOperationsTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/filesystem/SshOperationsTest.kt
@@ -34,6 +34,9 @@ import org.robolectric.shadows.ShadowAsyncTask
 class SshOperationsTest : AbstractOperationsTestBase() {
 
     companion object {
+        /**
+         * Custom bootstrap function to turn RxJava to fit better in Robolectric tests.
+         */
         @BeforeClass
         fun bootstrap() {
             RxJavaPlugins.reset()
@@ -41,6 +44,11 @@ class SshOperationsTest : AbstractOperationsTestBase() {
         }
     }
 
+    /**
+     * Test case to verify rename SSH file failure scenario.
+     *
+     * @see AbstractOperationsTestBase.testRenameFileAccessDenied
+     */
     @Test
     fun testRenameFileAccessDenied() {
         MockSshConnectionPools.prepareCannotDeleteScenario()

--- a/app/src/test/java/com/amaze/filemanager/filesystem/cloud/CloudStreamSourceTest.java
+++ b/app/src/test/java/com/amaze/filemanager/filesystem/cloud/CloudStreamSourceTest.java
@@ -20,6 +20,9 @@
 
 package com.amaze.filemanager.filesystem.cloud;
 
+import static android.os.Build.VERSION_CODES.JELLY_BEAN;
+import static android.os.Build.VERSION_CODES.KITKAT;
+import static android.os.Build.VERSION_CODES.P;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
@@ -46,7 +49,9 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 /** Created by Rustam Khadipash on 31/3/2018. */
 @RunWith(AndroidJUnit4.class)
-@Config(shadows = {ShadowMultiDex.class})
+@Config(
+    shadows = {ShadowMultiDex.class},
+    sdk = {JELLY_BEAN, KITKAT, P})
 public class CloudStreamSourceTest {
   private CloudStreamSource cs;
   private String testFilePath;

--- a/app/src/test/java/com/amaze/filemanager/filesystem/compressed/B0rkenZipTest.java
+++ b/app/src/test/java/com/amaze/filemanager/filesystem/compressed/B0rkenZipTest.java
@@ -20,6 +20,9 @@
 
 package com.amaze.filemanager.filesystem.compressed;
 
+import static android.os.Build.VERSION_CODES.JELLY_BEAN;
+import static android.os.Build.VERSION_CODES.KITKAT;
+import static android.os.Build.VERSION_CODES.P;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -47,7 +50,9 @@ import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 @RunWith(AndroidJUnit4.class)
-@Config(shadows = {ShadowMultiDex.class})
+@Config(
+    shadows = {ShadowMultiDex.class},
+    sdk = {JELLY_BEAN, KITKAT, P})
 public class B0rkenZipTest {
 
   private File zipfile1 = new File(Environment.getExternalStorageDirectory(), "zip-slip.zip");

--- a/app/src/test/java/com/amaze/filemanager/filesystem/compressed/CompressedHelperTest.java
+++ b/app/src/test/java/com/amaze/filemanager/filesystem/compressed/CompressedHelperTest.java
@@ -20,6 +20,9 @@
 
 package com.amaze.filemanager.filesystem.compressed;
 
+import static android.os.Build.VERSION_CODES.JELLY_BEAN;
+import static android.os.Build.VERSION_CODES.KITKAT;
+import static android.os.Build.VERSION_CODES.P;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -57,7 +60,9 @@ import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 @RunWith(AndroidJUnit4.class)
-@Config(shadows = {ShadowMultiDex.class})
+@Config(
+    shadows = {ShadowMultiDex.class},
+    sdk = {JELLY_BEAN, KITKAT, P})
 public class CompressedHelperTest {
 
   private Context context;

--- a/app/src/test/java/com/amaze/filemanager/filesystem/compressed/extractcontents/AbstractExtractorTest.java
+++ b/app/src/test/java/com/amaze/filemanager/filesystem/compressed/extractcontents/AbstractExtractorTest.java
@@ -20,6 +20,9 @@
 
 package com.amaze.filemanager.filesystem.compressed.extractcontents;
 
+import static android.os.Build.VERSION_CODES.JELLY_BEAN;
+import static android.os.Build.VERSION_CODES.KITKAT;
+import static android.os.Build.VERSION_CODES.P;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -53,7 +56,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 @RunWith(AndroidJUnit4.class)
 @Config(
     shadows = {ShadowMultiDex.class},
-    minSdk = 14)
+    sdk = {JELLY_BEAN, KITKAT, P})
 public abstract class AbstractExtractorTest {
 
   protected abstract Class<? extends Extractor> extractorClass();

--- a/app/src/test/java/com/amaze/filemanager/filesystem/files/FileListSorterTest.java
+++ b/app/src/test/java/com/amaze/filemanager/filesystem/files/FileListSorterTest.java
@@ -20,6 +20,9 @@
 
 package com.amaze.filemanager.filesystem.files;
 
+import static android.os.Build.VERSION_CODES.JELLY_BEAN;
+import static android.os.Build.VERSION_CODES.KITKAT;
+import static android.os.Build.VERSION_CODES.P;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.lessThan;
 import static org.junit.Assert.assertEquals;
@@ -42,7 +45,9 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
  * "*{slash}*"
  */
 @RunWith(AndroidJUnit4.class)
-@Config(shadows = {ShadowMultiDex.class, ShadowDateFormat.class})
+@Config(
+    shadows = {ShadowMultiDex.class, ShadowDateFormat.class},
+    sdk = {JELLY_BEAN, KITKAT, P})
 public class FileListSorterTest {
   /**
    * Purpose: when dirsOnTop is 0, if file1 is directory && file2 is not directory, result is -1

--- a/app/src/test/java/com/amaze/filemanager/filesystem/smb/CifsContextFactoryTest.java
+++ b/app/src/test/java/com/amaze/filemanager/filesystem/smb/CifsContextFactoryTest.java
@@ -20,6 +20,9 @@
 
 package com.amaze.filemanager.filesystem.smb;
 
+import static android.os.Build.VERSION_CODES.JELLY_BEAN;
+import static android.os.Build.VERSION_CODES.KITKAT;
+import static android.os.Build.VERSION_CODES.P;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -29,18 +32,19 @@ import java.util.Properties;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.robolectric.annotation.Config;
 
 import androidx.annotation.NonNull;
 
-import jcifs.Config;
 import jcifs.ResolverType;
 import jcifs.context.BaseContext;
 
+@Config(sdk = {JELLY_BEAN, KITKAT, P})
 public class CifsContextFactoryTest {
 
   @BeforeClass
   public static void bootstrap() {
-    Config.registerSmbURLHandler();
+    jcifs.Config.registerSmbURLHandler();
   }
 
   @Test

--- a/app/src/test/java/com/amaze/filemanager/filesystem/smb/SmbHybridFileTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/filesystem/smb/SmbHybridFileTest.kt
@@ -44,11 +44,21 @@ class SmbHybridFileTest {
 
     private var ctx: Context? = null
 
+    /**
+     * Test case setup.
+     *
+     * TODO: some even more generic test case base to prevent copy-and-paste?
+     */
     @Before
     fun setUp() {
         ctx = ApplicationProvider.getApplicationContext()
     }
 
+    /**
+     * Test case to verify delete SMB file success scenario.
+     *
+     * @see HybridFile.delete
+     */
     @Test
     fun testDeleteOk() {
         val file = HybridFile(SMB, "smb://user:password@1.2.3.4/just/a/file.txt")
@@ -56,6 +66,11 @@ class SmbHybridFileTest {
         assertFalse(file.exists())
     }
 
+    /**
+     * Test case to verify delete SMB file failure scenario.
+     *
+     * @see HybridFile.delete
+     */
     @Test(expected = SmbException::class)
     fun testDeleteAccessDenied() {
         val file = HybridFile(SMB, PATH_CANNOT_DELETE_FILE)

--- a/app/src/test/java/com/amaze/filemanager/filesystem/smb/SmbHybridFileTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/filesystem/smb/SmbHybridFileTest.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2014-2020 Arpit Khurana <arpitkh96@gmail.com>, Vishal Nehra <vishalmeham2@gmail.com>,
+ * Emmanuel Messulam<emmanuelbendavid@gmail.com>, Raymond Lai <airwave209gt at gmail.com> and Contributors.
+ *
+ * This file is part of Amaze File Manager.
+ *
+ * Amaze File Manager is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.amaze.filemanager.filesystem.smb
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.amaze.filemanager.filesystem.HybridFile
+import com.amaze.filemanager.shadows.ShadowMultiDex
+import com.amaze.filemanager.shadows.ShadowSmbUtil
+import com.amaze.filemanager.shadows.ShadowSmbUtil.Companion.PATH_CANNOT_DELETE_FILE
+import com.amaze.filemanager.utils.OpenMode.SMB
+import jcifs.smb.SmbException
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.LooperMode
+
+@RunWith(AndroidJUnit4::class)
+@Config(shadows = [ShadowSmbUtil::class, ShadowMultiDex::class])
+@LooperMode(LooperMode.Mode.PAUSED)
+class SmbHybridFileTest {
+
+    private var ctx: Context? = null
+
+    @Before
+    fun setUp() {
+        ctx = ApplicationProvider.getApplicationContext()
+    }
+
+    @Test
+    fun testDeleteOk() {
+        val file = HybridFile(SMB, "smb://user:password@1.2.3.4/just/a/file.txt")
+        file.delete(ctx, false)
+        assertFalse(file.exists())
+    }
+
+    @Test(expected = SmbException::class)
+    fun testDeleteAccessDenied() {
+        val file = HybridFile(SMB, PATH_CANNOT_DELETE_FILE)
+        file.delete(ctx, false)
+        assertTrue(file.exists())
+    }
+}

--- a/app/src/test/java/com/amaze/filemanager/filesystem/smb/SmbHybridFileTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/filesystem/smb/SmbHybridFileTest.kt
@@ -21,6 +21,7 @@
 package com.amaze.filemanager.filesystem.smb
 
 import android.content.Context
+import android.os.Build.VERSION_CODES.*
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.amaze.filemanager.filesystem.HybridFile
@@ -38,7 +39,10 @@ import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
 
 @RunWith(AndroidJUnit4::class)
-@Config(shadows = [ShadowSmbUtil::class, ShadowMultiDex::class])
+@Config(
+    shadows = [ShadowSmbUtil::class, ShadowMultiDex::class],
+    sdk = [JELLY_BEAN, KITKAT, P]
+)
 @LooperMode(LooperMode.Mode.PAUSED)
 class SmbHybridFileTest {
 

--- a/app/src/test/java/com/amaze/filemanager/filesystem/smbstreamer/StreamSourceTest.java
+++ b/app/src/test/java/com/amaze/filemanager/filesystem/smbstreamer/StreamSourceTest.java
@@ -20,6 +20,9 @@
 
 package com.amaze.filemanager.filesystem.smbstreamer;
 
+import static android.os.Build.VERSION_CODES.JELLY_BEAN;
+import static android.os.Build.VERSION_CODES.KITKAT;
+import static android.os.Build.VERSION_CODES.P;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
@@ -47,7 +50,9 @@ import jcifs.smb.SmbFile;
 
 /** Created by Rustam Khadipash on 30/3/2018. */
 @RunWith(AndroidJUnit4.class)
-@Config(shadows = {ShadowMultiDex.class, ShadowSmbFile.class})
+@Config(
+    shadows = {ShadowMultiDex.class, ShadowSmbFile.class},
+    sdk = {JELLY_BEAN, KITKAT, P})
 public class StreamSourceTest {
   private SmbFile file;
   private StreamSource ss;

--- a/app/src/test/java/com/amaze/filemanager/filesystem/ssh/AbstractSftpServerTest.java
+++ b/app/src/test/java/com/amaze/filemanager/filesystem/ssh/AbstractSftpServerTest.java
@@ -20,6 +20,10 @@
 
 package com.amaze.filemanager.filesystem.ssh;
 
+import static android.os.Build.VERSION_CODES.JELLY_BEAN;
+import static android.os.Build.VERSION_CODES.KITKAT;
+import static android.os.Build.VERSION_CODES.P;
+
 import java.io.IOException;
 import java.net.BindException;
 import java.nio.file.Paths;
@@ -46,7 +50,9 @@ import android.os.Environment;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 @RunWith(AndroidJUnit4.class)
-@Config(shadows = {ShadowMultiDex.class})
+@Config(
+    shadows = {ShadowMultiDex.class},
+    sdk = {JELLY_BEAN, KITKAT, P})
 public abstract class AbstractSftpServerTest {
 
   protected SshServer server;

--- a/app/src/test/java/com/amaze/filemanager/filesystem/ssh/SshConnectionPoolTest.java
+++ b/app/src/test/java/com/amaze/filemanager/filesystem/ssh/SshConnectionPoolTest.java
@@ -20,6 +20,9 @@
 
 package com.amaze.filemanager.filesystem.ssh;
 
+import static android.os.Build.VERSION_CODES.JELLY_BEAN;
+import static android.os.Build.VERSION_CODES.KITKAT;
+import static android.os.Build.VERSION_CODES.P;
 import static com.amaze.filemanager.filesystem.ssh.test.TestUtils.saveSshConnectionSettings;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -62,7 +65,9 @@ import net.schmizz.sshj.userauth.UserAuthException;
 import net.schmizz.sshj.userauth.keyprovider.KeyProvider;
 
 @RunWith(AndroidJUnit4.class)
-@Config(shadows = {ShadowMultiDex.class, ShadowCryptUtil.class})
+@Config(
+    shadows = {ShadowMultiDex.class, ShadowCryptUtil.class},
+    sdk = {JELLY_BEAN, KITKAT, P})
 public class SshConnectionPoolTest {
 
   private static KeyPair hostKeyPair;

--- a/app/src/test/java/com/amaze/filemanager/filesystem/ssh/SshHybridFileTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/filesystem/ssh/SshHybridFileTest.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2014-2020 Arpit Khurana <arpitkh96@gmail.com>, Vishal Nehra <vishalmeham2@gmail.com>,
+ * Emmanuel Messulam<emmanuelbendavid@gmail.com>, Raymond Lai <airwave209gt at gmail.com> and Contributors.
+ *
+ * This file is part of Amaze File Manager.
+ *
+ * Amaze File Manager is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.amaze.filemanager.filesystem.ssh
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.amaze.filemanager.filesystem.HybridFile
+import com.amaze.filemanager.filesystem.ssh.test.MockSshConnectionPools
+import com.amaze.filemanager.shadows.ShadowMultiDex
+import com.amaze.filemanager.test.ShadowCryptUtil
+import com.amaze.filemanager.utils.OpenMode
+import io.reactivex.plugins.RxJavaPlugins
+import io.reactivex.schedulers.Schedulers
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.BeforeClass
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.LooperMode
+import org.robolectric.shadows.ShadowAsyncTask
+
+@RunWith(RobolectricTestRunner::class)
+@LooperMode(LooperMode.Mode.PAUSED)
+@Config(shadows = [ShadowMultiDex::class, ShadowAsyncTask::class, ShadowCryptUtil::class])
+class SshHybridFileTest {
+
+    private var ctx: Context? = null
+
+    private val path: String = "ssh://user:password@127.0.0.1:22222/test.file"
+
+    companion object {
+        @BeforeClass
+        fun bootstrap() {
+            RxJavaPlugins.reset()
+            RxJavaPlugins.setIoSchedulerHandler { Schedulers.trampoline() }
+        }
+    }
+
+    @Before
+    fun setUp() {
+        ctx = ApplicationProvider.getApplicationContext()
+    }
+
+    @Test
+    fun testCanDelete() {
+        MockSshConnectionPools.prepareCanDeleteScenario()
+        assertTrue(HybridFile(OpenMode.SFTP, path).delete(ctx!!, false))
+    }
+
+    @Test
+    fun testCannotDelete() {
+        MockSshConnectionPools.prepareCannotDeleteScenario()
+        assertFalse(HybridFile(OpenMode.SFTP, path).delete(ctx!!, false))
+    }
+}

--- a/app/src/test/java/com/amaze/filemanager/filesystem/ssh/SshHybridFileTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/filesystem/ssh/SshHybridFileTest.kt
@@ -50,6 +50,9 @@ class SshHybridFileTest {
     private val path: String = "ssh://user:password@127.0.0.1:22222/test.file"
 
     companion object {
+        /**
+         * Custom bootstrap function to turn RxJava to fit better in Robolectric tests.
+         */
         @BeforeClass
         fun bootstrap() {
             RxJavaPlugins.reset()
@@ -57,17 +60,28 @@ class SshHybridFileTest {
         }
     }
 
+    /**
+     * Test case setup.
+     *
+     * TODO: some even more generic test case base to prevent copy-and-paste?
+     */
     @Before
     fun setUp() {
         ctx = ApplicationProvider.getApplicationContext()
     }
 
+    /**
+     * Test case to verify delete SSH file success scenario.
+     */
     @Test
     fun testCanDelete() {
         MockSshConnectionPools.prepareCanDeleteScenario()
         assertTrue(HybridFile(OpenMode.SFTP, path).delete(ctx!!, false))
     }
 
+    /**
+     * Test case to verify delete SSH file failure scenario.
+     */
     @Test
     fun testCannotDelete() {
         MockSshConnectionPools.prepareCannotDeleteScenario()

--- a/app/src/test/java/com/amaze/filemanager/filesystem/ssh/SshHybridFileTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/filesystem/ssh/SshHybridFileTest.kt
@@ -21,6 +21,7 @@
 package com.amaze.filemanager.filesystem.ssh
 
 import android.content.Context
+import android.os.Build.VERSION_CODES.*
 import androidx.test.core.app.ApplicationProvider
 import com.amaze.filemanager.filesystem.HybridFile
 import com.amaze.filemanager.filesystem.ssh.test.MockSshConnectionPools
@@ -42,7 +43,10 @@ import org.robolectric.shadows.ShadowAsyncTask
 
 @RunWith(RobolectricTestRunner::class)
 @LooperMode(LooperMode.Mode.PAUSED)
-@Config(shadows = [ShadowMultiDex::class, ShadowAsyncTask::class, ShadowCryptUtil::class])
+@Config(
+    shadows = [ShadowMultiDex::class, ShadowAsyncTask::class, ShadowCryptUtil::class],
+    sdk = [JELLY_BEAN, KITKAT, P]
+)
 class SshHybridFileTest {
 
     private var ctx: Context? = null

--- a/app/src/test/java/com/amaze/filemanager/filesystem/ssh/test/MockSshConnectionPools.kt
+++ b/app/src/test/java/com/amaze/filemanager/filesystem/ssh/test/MockSshConnectionPools.kt
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2014-2020 Arpit Khurana <arpitkh96@gmail.com>, Vishal Nehra <vishalmeham2@gmail.com>,
+ * Emmanuel Messulam<emmanuelbendavid@gmail.com>, Raymond Lai <airwave209gt at gmail.com> and Contributors.
+ *
+ * This file is part of Amaze File Manager.
+ *
+ * Amaze File Manager is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.amaze.filemanager.filesystem.ssh.test
+
+import com.amaze.filemanager.filesystem.ssh.SshConnectionPool
+import net.schmizz.sshj.SSHClient
+import net.schmizz.sshj.sftp.FileAttributes
+import net.schmizz.sshj.sftp.FileMode
+import net.schmizz.sshj.sftp.SFTPClient
+import net.schmizz.sshj.sftp.SFTPException
+import org.mockito.Mockito.*
+
+object MockSshConnectionPools {
+
+    private val hostKeyPair = TestUtils.createKeyPair()
+
+    private val userKeyPair = TestUtils.createKeyPair()
+
+    fun prepareCanDeleteScenario() {
+        doPrepareSSHClientInternal(true)
+    }
+
+    fun prepareCannotDeleteScenario() {
+        doPrepareSSHClientInternal(false)
+    }
+
+    // Yes, idiot hardcoded paths. Shall expand as more test cases arrive.
+    private fun doPrepareSSHClientInternal(canDelete: Boolean) {
+        TestUtils.saveSshConnectionSettings(hostKeyPair, "user", "password", userKeyPair.private)
+
+        val fileAttributes = mock(FileAttributes::class.java).apply {
+            `when`(type).thenReturn(FileMode.Type.DIRECTORY)
+        }
+        val sftpClient = mock(SFTPClient::class.java).apply {
+            doThrow(SFTPException("Access is denied."))
+                .`when`(this).rename("/tmp/old.file", "/tmp/new.file")
+            `when`(stat("/tmp/old.file")).thenReturn(fileAttributes)
+            `when`(stat("/tmp/new.file")).thenReturn(null)
+            val fa = mock(FileAttributes::class.java).apply {
+                `when`(type).thenReturn(FileMode.Type.REGULAR)
+            }
+            `when`(stat("/test.file")).thenReturn(fa)
+
+            if (canDelete) {
+                doNothing().`when`(this).rm(anyString())
+                doNothing().`when`(this).rmdir(anyString())
+            } else {
+                `when`(rm(anyString())).thenThrow(SFTPException("Access is denied."))
+                `when`(rmdir(anyString())).thenThrow(SFTPException("Access is denied."))
+            }
+        }
+        val sshClient = mock(SSHClient::class.java).apply {
+            doNothing().`when`(this).addHostKeyVerifier(anyString())
+            doNothing().`when`(this).connect(anyString(), anyInt())
+            doNothing().`when`(this).authPassword(anyString(), anyString())
+            doNothing().`when`(this).disconnect()
+            `when`(isConnected).thenReturn(true)
+            `when`(isAuthenticated).thenReturn(true)
+            `when`(newSFTPClient()).thenReturn(sftpClient)
+        }
+
+        /*
+         * We don't need to go through authentication flow here, and in fact SshAuthenticationTask
+         * was not working in the case of Operations.rename() due to the threading model
+         * Robolectric imposed. So we are injecting the SSHClient here by force.
+         */
+        SshConnectionPool::class.java.getDeclaredField("connections").run {
+            this.isAccessible = true
+            this.set(SshConnectionPool.getInstance(),
+                mutableMapOf(
+                        Pair<String, SSHClient>("ssh://user:password@127.0.0.1:22222", sshClient)))
+        }
+
+        SshConnectionPool.setSSHClientFactory { sshClient }
+    }
+}

--- a/app/src/test/java/com/amaze/filemanager/filesystem/ssh/test/MockSshConnectionPools.kt
+++ b/app/src/test/java/com/amaze/filemanager/filesystem/ssh/test/MockSshConnectionPools.kt
@@ -86,9 +86,12 @@ object MockSshConnectionPools {
          */
         SshConnectionPool::class.java.getDeclaredField("connections").run {
             this.isAccessible = true
-            this.set(SshConnectionPool.getInstance(),
+            this.set(
+                SshConnectionPool.getInstance(),
                 mutableMapOf(
-                        Pair<String, SSHClient>("ssh://user:password@127.0.0.1:22222", sshClient)))
+                    Pair<String, SSHClient>("ssh://user:password@127.0.0.1:22222", sshClient)
+                )
+            )
         }
 
         SshConnectionPool.setSSHClientFactory { sshClient }

--- a/app/src/test/java/com/amaze/filemanager/filesystem/ssh/test/MockSshConnectionPools.kt
+++ b/app/src/test/java/com/amaze/filemanager/filesystem/ssh/test/MockSshConnectionPools.kt
@@ -30,6 +30,8 @@ import org.mockito.Mockito.*
 
 object MockSshConnectionPools {
 
+    private const val ACCESS_DENIED = "Access is denied."
+
     private val hostKeyPair = TestUtils.createKeyPair()
 
     private val userKeyPair = TestUtils.createKeyPair()
@@ -50,7 +52,7 @@ object MockSshConnectionPools {
             `when`(type).thenReturn(FileMode.Type.DIRECTORY)
         }
         val sftpClient = mock(SFTPClient::class.java).apply {
-            doThrow(SFTPException("Access is denied."))
+            doThrow(SFTPException(ACCESS_DENIED))
                 .`when`(this).rename("/tmp/old.file", "/tmp/new.file")
             `when`(stat("/tmp/old.file")).thenReturn(fileAttributes)
             `when`(stat("/tmp/new.file")).thenReturn(null)
@@ -63,8 +65,8 @@ object MockSshConnectionPools {
                 doNothing().`when`(this).rm(anyString())
                 doNothing().`when`(this).rmdir(anyString())
             } else {
-                `when`(rm(anyString())).thenThrow(SFTPException("Access is denied."))
-                `when`(rmdir(anyString())).thenThrow(SFTPException("Access is denied."))
+                `when`(rm(anyString())).thenThrow(SFTPException(ACCESS_DENIED))
+                `when`(rmdir(anyString())).thenThrow(SFTPException(ACCESS_DENIED))
             }
         }
         val sshClient = mock(SSHClient::class.java).apply {

--- a/app/src/test/java/com/amaze/filemanager/filesystem/usb/SingletonUsbOtgTest.java
+++ b/app/src/test/java/com/amaze/filemanager/filesystem/usb/SingletonUsbOtgTest.java
@@ -20,6 +20,8 @@
 
 package com.amaze.filemanager.filesystem.usb;
 
+import static android.os.Build.VERSION_CODES.N;
+import static android.os.Build.VERSION_CODES.P;
 import static com.amaze.filemanager.filesystem.usb.ReflectionHelpers.addUsbOtgDevice;
 import static org.junit.Assert.assertEquals;
 
@@ -41,7 +43,8 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 @RunWith(AndroidJUnit4.class)
 @Config(
     shadows = {ShadowMultiDex.class},
-    minSdk = 24)
+    minSdk = N,
+    maxSdk = P)
 public class SingletonUsbOtgTest {
   @Test
   public void usbConnectionTest() {

--- a/app/src/test/java/com/amaze/filemanager/filesystem/usb/UsbOtgTest.java
+++ b/app/src/test/java/com/amaze/filemanager/filesystem/usb/UsbOtgTest.java
@@ -20,6 +20,8 @@
 
 package com.amaze.filemanager.filesystem.usb;
 
+import static android.os.Build.VERSION_CODES.N;
+import static android.os.Build.VERSION_CODES.P;
 import static com.amaze.filemanager.filesystem.usb.ReflectionHelpers.addUsbOtgDevice;
 import static org.junit.Assert.assertTrue;
 
@@ -45,7 +47,8 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 @RunWith(AndroidJUnit4.class)
 @Config(
     shadows = {ShadowMultiDex.class},
-    minSdk = 24)
+    minSdk = N,
+    maxSdk = P)
 public class UsbOtgTest {
 
   @Test

--- a/app/src/test/java/com/amaze/filemanager/shadows/ShadowSmbUtil.kt
+++ b/app/src/test/java/com/amaze/filemanager/shadows/ShadowSmbUtil.kt
@@ -60,7 +60,7 @@ class ShadowSmbUtil {
 
             mockCannotRenameOld = createInternal(PATH_CANNOT_RENAME_OLDFILE)
             `when`(mockCannotRenameOld!!.renameTo(any()))
-                    .thenThrow(SmbException("Access is denied."))
+                .thenThrow(SmbException("Access is denied."))
             `when`(mockCannotRenameOld!!.exists()).thenReturn(true)
         }
 

--- a/app/src/test/java/com/amaze/filemanager/shadows/ShadowSmbUtil.kt
+++ b/app/src/test/java/com/amaze/filemanager/shadows/ShadowSmbUtil.kt
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2014-2020 Arpit Khurana <arpitkh96@gmail.com>, Vishal Nehra <vishalmeham2@gmail.com>,
+ * Emmanuel Messulam<emmanuelbendavid@gmail.com>, Raymond Lai <airwave209gt at gmail.com> and Contributors.
+ *
+ * This file is part of Amaze File Manager.
+ *
+ * Amaze File Manager is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.amaze.filemanager.shadows
+
+import com.amaze.filemanager.utils.SmbUtil
+import jcifs.context.SingletonContext
+import jcifs.smb.SmbException
+import jcifs.smb.SmbFile
+import org.mockito.Mockito.*
+import org.robolectric.annotation.Implementation
+import org.robolectric.annotation.Implements
+@Implements(SmbUtil::class)
+class ShadowSmbUtil {
+
+    companion object {
+
+        const val PATH_CANNOT_DELETE_FILE = "smb://user:password@1.2.3.4/access/denied.file"
+        const val PATH_CANNOT_MOVE_FILE = "smb://user:password@1.2.3.4/cannot/move.file"
+        const val PATH_CANNOT_RENAME_OLDFILE = "smb://user:password@1.2.3.4/cannot/rename.file.old"
+        const val PATH_CAN_RENAME_OLDFILE = "smb://user:password@1.2.3.4/rename/old.file"
+        const val PATH_CAN_RENAME_NEWFILE = "smb://user:password@1.2.3.4/rename/new.file"
+
+        var mockDeleteAccessDenied: SmbFile? = null
+        var mockDeleteDifferentNetwork: SmbFile? = null
+        var mockCannotRenameOld: SmbFile? = null
+        var mockCanRename: SmbFile? = null
+
+        init {
+            mockDeleteAccessDenied = createInternal(PATH_CANNOT_DELETE_FILE).also {
+                `when`(it.delete()).thenThrow(SmbException("Access is denied."))
+                `when`(it.exists()).thenReturn(true)
+            }
+
+            mockDeleteDifferentNetwork = createInternal(PATH_CANNOT_MOVE_FILE).also {
+                `when`(it.delete()).thenThrow(SmbException("Cannot rename between different trees"))
+                `when`(it.exists()).thenReturn(true)
+            }
+
+            mockCanRename = createInternal(PATH_CAN_RENAME_OLDFILE).also {
+                doNothing().`when`(it).renameTo(any())
+            }
+
+            mockCannotRenameOld = createInternal(PATH_CANNOT_RENAME_OLDFILE)
+            `when`(mockCannotRenameOld!!.renameTo(any()))
+                    .thenThrow(SmbException("Access is denied."))
+            `when`(mockCannotRenameOld!!.exists()).thenReturn(true)
+        }
+
+        @JvmStatic @Implementation
+        fun create(path: String): SmbFile {
+
+            return when (path) {
+                PATH_CANNOT_DELETE_FILE -> mockDeleteAccessDenied!!
+                PATH_CANNOT_MOVE_FILE -> mockDeleteDifferentNetwork!!
+                PATH_CANNOT_RENAME_OLDFILE -> mockCannotRenameOld!!
+                PATH_CAN_RENAME_OLDFILE -> mockCanRename!!
+                else -> createInternal(path).also {
+                    doNothing().`when`(it).delete()
+                    `when`(it.exists()).thenReturn(false)
+                }
+            }
+        }
+
+        private fun createInternal(path: String): SmbFile {
+            return mock(SmbFile::class.java).also {
+                `when`(it.name).thenReturn(path.substring(path.lastIndexOf('/') + 1))
+                `when`(it.path).thenReturn(path)
+                `when`(it.context).thenReturn(SingletonContext.getInstance())
+            }
+        }
+    }
+}

--- a/app/src/test/java/com/amaze/filemanager/shadows/ShadowSmbUtil.kt
+++ b/app/src/test/java/com/amaze/filemanager/shadows/ShadowSmbUtil.kt
@@ -64,6 +64,11 @@ class ShadowSmbUtil {
             `when`(mockCannotRenameOld!!.exists()).thenReturn(true)
         }
 
+        /**
+         * Shadows SmbUtil.create()
+         *
+         * @see SmbUtil.create
+         */
         @JvmStatic @Implementation
         fun create(path: String): SmbFile {
 

--- a/app/src/test/java/com/amaze/filemanager/test/ShadowCryptUtilTest.java
+++ b/app/src/test/java/com/amaze/filemanager/test/ShadowCryptUtilTest.java
@@ -20,6 +20,9 @@
 
 package com.amaze.filemanager.test;
 
+import static android.os.Build.VERSION_CODES.JELLY_BEAN;
+import static android.os.Build.VERSION_CODES.KITKAT;
+import static android.os.Build.VERSION_CODES.P;
 import static org.awaitility.Awaitility.await;
 import static org.junit.Assert.assertEquals;
 
@@ -46,7 +49,9 @@ import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.schedulers.Schedulers;
 
 @RunWith(AndroidJUnit4.class)
-@Config(shadows = {ShadowMultiDex.class, ShadowCryptUtil.class})
+@Config(
+    shadows = {ShadowMultiDex.class, ShadowCryptUtil.class},
+    sdk = {JELLY_BEAN, KITKAT, P})
 public class ShadowCryptUtilTest {
 
   @BeforeClass

--- a/app/src/test/java/com/amaze/filemanager/ui/activities/MainActivityTest.java
+++ b/app/src/test/java/com/amaze/filemanager/ui/activities/MainActivityTest.java
@@ -20,7 +20,10 @@
 
 package com.amaze.filemanager.ui.activities;
 
+import static android.os.Build.VERSION_CODES.JELLY_BEAN;
+import static android.os.Build.VERSION_CODES.KITKAT;
 import static android.os.Build.VERSION_CODES.N;
+import static android.os.Build.VERSION_CODES.P;
 import static androidx.test.core.app.ActivityScenario.launch;
 import static org.awaitility.Awaitility.await;
 import static org.junit.Assert.assertEquals;
@@ -62,6 +65,7 @@ import io.reactivex.schedulers.Schedulers;
 
 @RunWith(AndroidJUnit4.class)
 @Config(
+    sdk = {JELLY_BEAN, KITKAT, P},
     shadows = {
       ShadowMultiDex.class,
       ShadowStorageManager.class,

--- a/app/src/test/java/com/amaze/filemanager/ui/activities/PreferencesActivityTest.java
+++ b/app/src/test/java/com/amaze/filemanager/ui/activities/PreferencesActivityTest.java
@@ -20,6 +20,9 @@
 
 package com.amaze.filemanager.ui.activities;
 
+import static android.os.Build.VERSION_CODES.JELLY_BEAN;
+import static android.os.Build.VERSION_CODES.KITKAT;
+import static android.os.Build.VERSION_CODES.P;
 import static com.amaze.filemanager.ui.fragments.preference_fragments.PreferencesConstants.PREFERENCE_BOOKMARKS_ADDED;
 import static com.amaze.filemanager.ui.fragments.preference_fragments.PreferencesConstants.PREFERENCE_CHANGEPATHS;
 import static com.amaze.filemanager.ui.fragments.preference_fragments.PreferencesConstants.PREFERENCE_COLORED_NAVIGATION;
@@ -47,6 +50,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.annotation.Config;
 
 import android.content.SharedPreferences;
 import android.preference.PreferenceManager;
@@ -57,6 +61,7 @@ import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 @RunWith(AndroidJUnit4.class)
+@Config(sdk = {JELLY_BEAN, KITKAT, P})
 public class PreferencesActivityTest {
 
   private static final String[] DEFAULT_FALSE_PREFS =

--- a/app/src/test/java/com/amaze/filemanager/ui/activities/TextEditorActivityTest.java
+++ b/app/src/test/java/com/amaze/filemanager/ui/activities/TextEditorActivityTest.java
@@ -20,6 +20,9 @@
 
 package com.amaze.filemanager.ui.activities;
 
+import static android.os.Build.VERSION_CODES.JELLY_BEAN;
+import static android.os.Build.VERSION_CODES.KITKAT;
+import static android.os.Build.VERSION_CODES.P;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -52,7 +55,9 @@ import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 @RunWith(AndroidJUnit4.class)
-@Config(shadows = {ShadowMultiDex.class})
+@Config(
+    shadows = {ShadowMultiDex.class},
+    sdk = {JELLY_BEAN, KITKAT, P})
 public class TextEditorActivityTest {
 
   private final String fileContents = "fsdfsdfs";

--- a/app/src/test/java/com/amaze/filemanager/ui/colors/ColorUtilsTest.java
+++ b/app/src/test/java/com/amaze/filemanager/ui/colors/ColorUtilsTest.java
@@ -21,6 +21,7 @@
 package com.amaze.filemanager.ui.colors;
 
 import static android.os.Build.VERSION_CODES.N;
+import static android.os.Build.VERSION_CODES.P;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -40,7 +41,7 @@ import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 @RunWith(AndroidJUnit4.class)
-@Config(minSdk = N)
+@Config(minSdk = N, maxSdk = P)
 public class ColorUtilsTest {
 
   @Test

--- a/app/src/test/java/com/amaze/filemanager/ui/fragments/CloudSheetFragmentTest.java
+++ b/app/src/test/java/com/amaze/filemanager/ui/fragments/CloudSheetFragmentTest.java
@@ -20,6 +20,9 @@
 
 package com.amaze.filemanager.ui.fragments;
 
+import static android.os.Build.VERSION_CODES.JELLY_BEAN;
+import static android.os.Build.VERSION_CODES.KITKAT;
+import static android.os.Build.VERSION_CODES.P;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.robolectric.Shadows.shadowOf;
@@ -36,7 +39,7 @@ import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 @RunWith(AndroidJUnit4.class)
-@Config(minSdk = 19)
+@Config(sdk = {JELLY_BEAN, KITKAT, P})
 public class CloudSheetFragmentTest {
 
   @Test

--- a/app/src/test/java/com/amaze/filemanager/ui/icons/IconsTest.java
+++ b/app/src/test/java/com/amaze/filemanager/ui/icons/IconsTest.java
@@ -20,6 +20,9 @@
 
 package com.amaze.filemanager.ui.icons;
 
+import static android.os.Build.VERSION_CODES.JELLY_BEAN;
+import static android.os.Build.VERSION_CODES.KITKAT;
+import static android.os.Build.VERSION_CODES.P;
 import static org.junit.Assert.assertEquals;
 
 import org.junit.Before;
@@ -36,7 +39,9 @@ import android.webkit.MimeTypeMap;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 @RunWith(AndroidJUnit4.class)
-@Config(shadows = {ShadowMultiDex.class})
+@Config(
+    shadows = {ShadowMultiDex.class},
+    sdk = {JELLY_BEAN, KITKAT, P})
 public class IconsTest {
 
   @Before

--- a/app/src/test/java/com/amaze/filemanager/ui/notifications/NotificationConstantsTest.java
+++ b/app/src/test/java/com/amaze/filemanager/ui/notifications/NotificationConstantsTest.java
@@ -22,8 +22,10 @@ package com.amaze.filemanager.ui.notifications;
 
 import static android.app.NotificationManager.IMPORTANCE_HIGH;
 import static android.app.NotificationManager.IMPORTANCE_MIN;
+import static android.os.Build.VERSION_CODES.KITKAT;
 import static android.os.Build.VERSION_CODES.N;
 import static android.os.Build.VERSION_CODES.O;
+import static android.os.Build.VERSION_CODES.P;
 import static com.amaze.filemanager.ui.notifications.NotificationConstants.CHANNEL_FTP_ID;
 import static com.amaze.filemanager.ui.notifications.NotificationConstants.CHANNEL_NORMAL_ID;
 import static com.amaze.filemanager.ui.notifications.NotificationConstants.TYPE_FTP;
@@ -54,7 +56,7 @@ import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 @RunWith(AndroidJUnit4.class)
-@Config(minSdk = 19)
+@Config(sdk = {KITKAT, P})
 public class NotificationConstantsTest {
 
   private Context context;
@@ -136,7 +138,7 @@ public class NotificationConstantsTest {
   }
 
   @Test
-  @Config(minSdk = O)
+  @Config(minSdk = O, maxSdk = P)
   public void testCreateNormalChannel() {
     NotificationCompat.Builder builder = new NotificationCompat.Builder(context, CHANNEL_NORMAL_ID);
     NotificationConstants.setMetadata(context, builder, TYPE_NORMAL);
@@ -151,7 +153,7 @@ public class NotificationConstantsTest {
   }
 
   @Test
-  @Config(minSdk = O)
+  @Config(minSdk = O, maxSdk = P)
   public void testCreateFtpChannel() {
     NotificationCompat.Builder builder = new NotificationCompat.Builder(context, CHANNEL_FTP_ID);
     NotificationConstants.setMetadata(context, builder, TYPE_FTP);

--- a/app/src/test/java/com/amaze/filemanager/ui/theme/AppThemeTest.java
+++ b/app/src/test/java/com/amaze/filemanager/ui/theme/AppThemeTest.java
@@ -20,7 +20,7 @@
 
 package com.amaze.filemanager.ui.theme;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 import java.util.Calendar;
 

--- a/app/src/test/java/com/amaze/filemanager/ui/views/WarnableTextInputValidatorTest.java
+++ b/app/src/test/java/com/amaze/filemanager/ui/views/WarnableTextInputValidatorTest.java
@@ -20,6 +20,9 @@
 
 package com.amaze.filemanager.ui.views;
 
+import static android.os.Build.VERSION_CODES.JELLY_BEAN;
+import static android.os.Build.VERSION_CODES.KITKAT;
+import static android.os.Build.VERSION_CODES.P;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
@@ -29,6 +32,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
+import org.robolectric.annotation.Config;
 
 import com.amaze.filemanager.R;
 
@@ -42,6 +46,7 @@ import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 @RunWith(AndroidJUnit4.class)
+@Config(sdk = {JELLY_BEAN, KITKAT, P})
 public class WarnableTextInputValidatorTest {
 
   private Context context;

--- a/app/src/test/java/com/amaze/filemanager/utils/AnimUtilsTest.java
+++ b/app/src/test/java/com/amaze/filemanager/utils/AnimUtilsTest.java
@@ -20,6 +20,8 @@
 
 package com.amaze.filemanager.utils;
 
+import static android.os.Build.VERSION_CODES.KITKAT;
+import static android.os.Build.VERSION_CODES.P;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -43,7 +45,7 @@ import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 @RunWith(AndroidJUnit4.class)
-@Config(minSdk = 19)
+@Config(sdk = {KITKAT, P})
 public class AnimUtilsTest {
 
   @Test

--- a/app/src/test/java/com/amaze/filemanager/utils/BookSorterTest.java
+++ b/app/src/test/java/com/amaze/filemanager/utils/BookSorterTest.java
@@ -22,7 +22,8 @@ package com.amaze.filemanager.utils;
 
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.lessThan;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 
 import org.junit.Test;
 

--- a/app/src/test/java/com/amaze/filemanager/utils/ComputerParcelableTest.java
+++ b/app/src/test/java/com/amaze/filemanager/utils/ComputerParcelableTest.java
@@ -20,7 +20,8 @@
 
 package com.amaze.filemanager.utils;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 

--- a/app/src/test/java/com/amaze/filemanager/utils/SmbUtilTest.java
+++ b/app/src/test/java/com/amaze/filemanager/utils/SmbUtilTest.java
@@ -20,6 +20,9 @@
 
 package com.amaze.filemanager.utils;
 
+import static android.os.Build.VERSION_CODES.JELLY_BEAN;
+import static android.os.Build.VERSION_CODES.KITKAT;
+import static android.os.Build.VERSION_CODES.P;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
@@ -39,7 +42,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 @RunWith(AndroidJUnit4.class)
 @Config(
-    minSdk = 19,
+    sdk = {JELLY_BEAN, KITKAT, P},
     shadows = {ShadowCryptUtil.class})
 public class SmbUtilTest {
 

--- a/app/src/test/java/com/amaze/filemanager/utils/TinyDBTest.java
+++ b/app/src/test/java/com/amaze/filemanager/utils/TinyDBTest.java
@@ -20,6 +20,9 @@
 
 package com.amaze.filemanager.utils;
 
+import static android.os.Build.VERSION_CODES.JELLY_BEAN;
+import static android.os.Build.VERSION_CODES.KITKAT;
+import static android.os.Build.VERSION_CODES.P;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertNull;
 
@@ -35,7 +38,7 @@ import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 @RunWith(AndroidJUnit4.class)
-@Config(minSdk = 19)
+@Config(sdk = {JELLY_BEAN, KITKAT, P})
 public class TinyDBTest {
 
   private SharedPreferences prefs;

--- a/app/src/test/java/com/amaze/filemanager/utils/UtilsTest.java
+++ b/app/src/test/java/com/amaze/filemanager/utils/UtilsTest.java
@@ -20,7 +20,10 @@
 
 package com.amaze.filemanager.utils;
 
+import static android.os.Build.VERSION_CODES.JELLY_BEAN;
+import static android.os.Build.VERSION_CODES.KITKAT;
 import static android.os.Build.VERSION_CODES.N;
+import static android.os.Build.VERSION_CODES.P;
 import static com.amaze.filemanager.utils.Utils.formatTimer;
 import static com.amaze.filemanager.utils.Utils.sanitizeInput;
 import static org.junit.Assert.assertEquals;
@@ -53,7 +56,7 @@ import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 @RunWith(AndroidJUnit4.class)
-@Config(minSdk = 19)
+@Config(sdk = {JELLY_BEAN, KITKAT, P})
 public class UtilsTest {
   @Test
   public void
@@ -152,7 +155,7 @@ public class UtilsTest {
   }
 
   @Test
-  @Config(minSdk = N)
+  @Config(minSdk = N, maxSdk = P)
   public void testGetVolumeDirectory() throws Exception {
     StorageVolume mock = mock(StorageVolume.class);
     Field f = StorageVolume.class.getDeclaredField("mPath");

--- a/build.gradle
+++ b/build.gradle
@@ -32,9 +32,9 @@ allprojects {
         mavenCentral()
     }
     tasks.withType(Test) {
-        maxParallelForks = 2
-        maxHeapSize = "2g"
-        forkEvery = 2
+        maxParallelForks = 4
+        maxHeapSize = "4g"
+        forkEvery = 4
     }
 }
 


### PR DESCRIPTION
## PR Info
#### Issue tracker   
Fixes will automatically close the related issue

Fixes #2085

#### Release  
Addresses release/3.5
  
#### Test cases
- [x] Covered
  
#### Manual testing
- [ ] Done  
  
If yes,  
- Device:
- OS:

#### Build tasks success  
Successfully running following tasks on local 
- [ ] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`

#### Additional Info
- Prompt user with dialog on unable to delete/move/rename files for SMB/SFTP files
- Add test case for SMB/SSH rename and delete
