### PR TITLE
Use JDK 11 for building

### DIFF
--- a/.github/workflows/android-debug-artifact-ondemand.yml
+++ b/.github/workflows/android-debug-artifact-ondemand.yml
@@ -31,10 +31,11 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{ fromJson(steps.request.outputs.data).head.repo.full_name }}
           ref: ${{ steps.pr_data.outputs.branch }}
-      - name: Set up JDK 1.8
+      - name: Set up JDK 11
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
+          architecture: x64
       - name: Build with Gradle
         run: |
           echo Run on-demand by ${GITHUB_ACTOR}

--- a/.github/workflows/android-debug-artifact-release.yml
+++ b/.github/workflows/android-debug-artifact-release.yml
@@ -9,10 +9,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 1.8
+      - name: Set up JDK 11
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
+          architecture: x64
       - name: Build with Gradle
         run: |
           bash ./gradlew assembleDebug --stacktrace

--- a/.github/workflows/android-feature.yml
+++ b/.github/workflows/android-feature.yml
@@ -17,10 +17,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 1.8
+      - name: Set up JDK 11
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
+          architecture: x64
       - name: Check formatting using spotless
         run: ./gradlew spotlessCheck --stacktrace
       - name: Build with Gradle

--- a/.github/workflows/android-main.yml
+++ b/.github/workflows/android-main.yml
@@ -11,10 +11,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 1.8
+      - name: Set up JDK 11
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
+          architecture: x64
       - name: Check formatting using spotless
         run: ./gradlew spotlessCheck --stacktrace
       - name: Build with Gradle


### PR DESCRIPTION
Never understand why it worked locally but not on Github CI... expect the JDK version difference. So try this.

#### Release  
Addresses release/3.5
  
#### Test cases
- [ ] Covered
  
#### Manual testing
- [ ] Done  
  
If yes,  
- Device:
- OS:

#### Build tasks success  
Successfully running following tasks on local 
- [ ] `./gradlew assembledebug`
- [ ] `./gradlew spotlessCheck`