### PR TITLE
Capture SecurityException when reading USB serial number

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/utils/OTGUtil.java
+++ b/app/src/main/java/com/amaze/filemanager/utils/OTGUtil.java
@@ -47,7 +47,7 @@ import androidx.annotation.RequiresApi;
 import androidx.documentfile.provider.DocumentFile;
 
 /** Created by Vishal on 27-04-2017. */
-public abstract class OTGUtil {
+public class OTGUtil {
 
   private static final String TAG = OTGUtil.class.getSimpleName();
 

--- a/app/src/main/java/com/amaze/filemanager/utils/OTGUtil.java
+++ b/app/src/main/java/com/amaze/filemanager/utils/OTGUtil.java
@@ -47,7 +47,9 @@ import androidx.annotation.RequiresApi;
 import androidx.documentfile.provider.DocumentFile;
 
 /** Created by Vishal on 27-04-2017. */
-public class OTGUtil {
+public abstract class OTGUtil {
+
+  private static final String TAG = OTGUtil.class.getSimpleName();
 
   public static final String PREFIX_OTG = "otg:/";
 
@@ -163,10 +165,21 @@ public class OTGUtil {
 
       for (int i = 0; i < device.getInterfaceCount(); i++) {
         if (device.getInterface(i).getInterfaceClass() == UsbConstants.USB_CLASS_MASS_STORAGE) {
-          final @Nullable String serial =
-              Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP
-                  ? device.getSerialNumber()
-                  : null;
+          @Nullable String serial = null;
+          if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            try {
+              serial = device.getSerialNumber();
+            } catch (SecurityException ifPermissionDenied) {
+              // May happen when device is running Android 10 or above.
+              Log.w(
+                  TAG,
+                  "Permission denied reading serial number of device "
+                      + device.getVendorId()
+                      + ":"
+                      + device.getProductId(),
+                  ifPermissionDenied);
+            }
+          }
 
           UsbOtgRepresentation usb =
               new UsbOtgRepresentation(device.getProductId(), device.getVendorId(), serial);


### PR DESCRIPTION
Capture SecurityException that may throw on devices running Android 10 or above.

References:
https://github.com/altera2015/usbserial/pull/21
https://developer.android.com/reference/android/hardware/usb/UsbDevice#getSerialNumber()

## PR Info
#### Issue tracker   
Fixes will automatically close the related issue

Fixes #2148

#### Release  
Addresses release/3.6
  
#### Test cases
- [ ] Covered
  
#### Manual testing
- [ ] Done  
  
If yes,  
- Device:
- OS:

#### Build tasks success  
Successfully running following tasks on local 
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`
