### PR TITLE
2108: Make services non-sticky; start in foreground

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/asynchronous/management/ServiceWatcherUtil.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/management/ServiceWatcherUtil.java
@@ -41,6 +41,7 @@ import com.amaze.filemanager.utils.ProgressHandler;
 import android.app.NotificationManager;
 import android.content.Context;
 import android.content.Intent;
+import android.os.Build;
 import android.text.format.Formatter;
 
 import androidx.core.app.NotificationCompat;
@@ -181,7 +182,11 @@ public class ServiceWatcherUtil {
   public static synchronized void runService(final Context context, final Intent intent) {
     switch (pendingIntents.size()) {
       case 0:
-        context.startService(intent);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+          context.startForegroundService(intent);
+        } else {
+          context.startService(intent);
+        }
         break;
       case 1:
         // initialize waiting handlers
@@ -232,7 +237,6 @@ public class ServiceWatcherUtil {
       if (watcherRepeatingRunnable == null || !watcherRepeatingRunnable.isAlive()) {
         if (pendingIntents.size() == 0) {
           cancel(false);
-          return;
         } else {
           if (pendingIntents.size() == 1) {
             notificationManager.cancel(NotificationConstants.WAIT_ID);
@@ -240,9 +244,12 @@ public class ServiceWatcherUtil {
 
           final Context context = this.context.get();
           if (context != null) {
-            context.startService(pendingIntents.element());
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+              context.startForegroundService(pendingIntents.element());
+            } else {
+              context.startService(pendingIntents.element());
+            }
             cancel(true);
-            return;
           }
         }
       }

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/services/CopyService.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/services/CopyService.java
@@ -166,7 +166,7 @@ public class CopyService extends AbstractProgressiveService {
     new DoInBackground(isRootExplorer).execute(b);
 
     // If we get killed, after returning from here, restart
-    return START_STICKY;
+    return START_NOT_STICKY;
   }
 
   @Override

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/services/DecryptService.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/services/DecryptService.java
@@ -146,7 +146,7 @@ public class DecryptService extends AbstractProgressiveService {
     super.progressHalted();
     new DecryptService.BackgroundTask().execute();
 
-    return START_STICKY;
+    return START_NOT_STICKY;
   }
 
   class BackgroundTask extends AsyncTask<Void, Void, Void> {

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/services/EncryptService.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/services/EncryptService.java
@@ -142,7 +142,7 @@ public class EncryptService extends AbstractProgressiveService {
     super.progressHalted();
     new BackgroundTask().execute();
 
-    return START_STICKY;
+    return START_NOT_STICKY;
   }
 
   @Override

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/services/ExtractService.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/services/ExtractService.java
@@ -151,7 +151,7 @@ public class ExtractService extends AbstractProgressiveService {
     super.progressHalted();
     new DoWork(this, progressHandler, file, extractPath, entries).execute();
 
-    return START_STICKY;
+    return START_NOT_STICKY;
   }
 
   @Override

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/services/ZipService.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/services/ZipService.java
@@ -150,8 +150,7 @@ public class ZipService extends AbstractProgressiveService {
     super.progressHalted();
     asyncTask = new CompressAsyncTask(this, baseFiles, mZipPath);
     asyncTask.execute();
-    // If we get killed, after returning from here, restart
-    return START_STICKY;
+    return START_NOT_STICKY;
   }
 
   @Override

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/services/ftp/FtpReceiver.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/services/ftp/FtpReceiver.java
@@ -24,6 +24,7 @@ package com.amaze.filemanager.asynchronous.services.ftp;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
+import android.os.Build;
 import android.util.Log;
 
 public class FtpReceiver extends BroadcastReceiver {
@@ -38,7 +39,11 @@ public class FtpReceiver extends BroadcastReceiver {
       Intent service = new Intent(context, FtpService.class);
       service.putExtras(intent);
       if (intent.getAction().equals(FtpService.ACTION_START_FTPSERVER) && !FtpService.isRunning()) {
-        context.startService(service);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+          context.startForegroundService(service);
+        } else {
+          context.startService(service);
+        }
       } else if (intent.getAction().equals(FtpService.ACTION_STOP_FTPSERVER)) {
         context.stopService(service);
       }

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/services/ftp/FtpService.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/services/ftp/FtpService.java
@@ -147,7 +147,7 @@ public class FtpService extends Service implements Runnable {
 
     startForeground(NotificationConstants.FTP_ID, notification);
 
-    return START_STICKY;
+    return START_NOT_STICKY;
   }
 
   @Override


### PR DESCRIPTION
## PR Info
#### Issue tracker   
Fixes will automatically close the related issue

Fixes #2108
-or-   
Addresses #

#### Release  
Addresses release/3.6
  
#### Test cases
- [ ] Covered
  
#### Manual testing
- [x] Done  
  
If yes,  
- Device:
- OS:

#### Build tasks success  
Successfully running following tasks on local 
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`

#### Related PR  
Related to PR #

#### Additional Info