### PR TITLE
Fixed Issue #2160 - Libraries shown twice

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/ui/activities/AboutActivity.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/activities/AboutActivity.java
@@ -221,8 +221,7 @@ public class AboutActivity extends BasicActivity implements View.OnClickListener
       case R.id.relative_layout_licenses:
         LibsBuilder libsBuilder =
             new LibsBuilder()
-                .withLibraries(
-                    "commonscompress", "apachemina", "volley") // Not autodetected for some reason
+                .withLibraries("apachemina") // Not auto-detected for some reason
                 .withActivityTitle(getString(R.string.libraries))
                 .withAboutIconShown(true)
                 .withAboutVersionShownName(true)


### PR DESCRIPTION
## PR Info
#### Issue tracker   
Fixes will automatically close the related issue

Fixes #2160

#### Release  
Addresses release/3.6
  
#### Test cases
- [ ] Covered
  
#### Manual testing
- [x] Done  
  
If yes,  
- Device: Realme Narzo 20A
- OS: Android 10

#### Build tasks success  
Successfully running following tasks on local 
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`