### PR TITLE
FileUtils: call to OpenFileDialogFragment using explicit mime type

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/filesystem/files/FileUtils.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/files/FileUtils.java
@@ -600,8 +600,8 @@ public class FileUtils {
     boolean useNewStack =
         sharedPrefs.getBoolean(PreferencesConstants.PREFERENCE_TEXTEDITOR_NEWSTACK, false);
     boolean defaultHandler = isSelfDefault(f, m);
-    SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(m);
     final Toast[] studioCount = {null};
+    final int studio_count = PreferenceManager.getDefaultSharedPreferences(m).getInt("studio", 0);
 
     if (f.getName().toLowerCase().endsWith(".apk")) {
       GeneralDialogCreation.showPackageDialog(f, m);
@@ -611,35 +611,26 @@ public class FileUtils {
       Intent intent = new Intent(m, DatabaseViewerActivity.class);
       intent.putExtra("path", f.getPath());
       m.startActivity(intent);
-    } else if (Icons.getTypeOfFile(f.getPath(), f.isDirectory()) == Icons.AUDIO) {
-      final int studio_count = sharedPreferences.getInt("studio", 0);
-      Uri uri = Uri.fromFile(f);
-      final Intent intent = new Intent();
-      intent.setAction(Intent.ACTION_VIEW);
-      intent.setDataAndType(uri, "audio/*");
-
+    } else if (Icons.getTypeOfFile(f.getPath(), f.isDirectory()) == Icons.AUDIO
+        && studio_count != 0) {
       // Behold! It's the  legendary easter egg!
-      if (studio_count != 0) {
-        new CountDownTimer(studio_count, 1000) {
-          @Override
-          public void onTick(long millisUntilFinished) {
-            int sec = (int) millisUntilFinished / 1000;
-            if (studioCount[0] != null) studioCount[0].cancel();
-            studioCount[0] = Toast.makeText(m, sec + "", Toast.LENGTH_LONG);
-            studioCount[0].show();
-          }
+      new CountDownTimer(studio_count, 1000) {
+        @Override
+        public void onTick(long millisUntilFinished) {
+          int sec = (int) millisUntilFinished / 1000;
+          if (studioCount[0] != null) studioCount[0].cancel();
+          studioCount[0] = Toast.makeText(m, sec + "", Toast.LENGTH_LONG);
+          studioCount[0].show();
+        }
 
-          @Override
-          public void onFinish() {
-            if (studioCount[0] != null) studioCount[0].cancel();
-            studioCount[0] = Toast.makeText(m, m.getString(R.string.opening), Toast.LENGTH_LONG);
-            studioCount[0].show();
-            openFileDialogFragmentFor(f, m, "audio/*");
-          }
-        }.start();
-      } else {
-        openFileDialogFragmentFor(f, m);
-      }
+        @Override
+        public void onFinish() {
+          if (studioCount[0] != null) studioCount[0].cancel();
+          studioCount[0] = Toast.makeText(m, m.getString(R.string.opening), Toast.LENGTH_LONG);
+          studioCount[0].show();
+          openFileDialogFragmentFor(f, m, "audio/*");
+        }
+      }.start();
     } else {
       try {
         openFileDialogFragmentFor(f, m);

--- a/app/src/main/java/com/amaze/filemanager/filesystem/files/FileUtils.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/files/FileUtils.java
@@ -634,31 +634,47 @@ public class FileUtils {
             if (studioCount[0] != null) studioCount[0].cancel();
             studioCount[0] = Toast.makeText(m, m.getString(R.string.opening), Toast.LENGTH_LONG);
             studioCount[0].show();
-            OpenFileDialogFragment.Companion.openFileOrShow(
-                FileProvider.getUriForFile(m, m.getPackageName(), f),
-                "audio/*",
-                useNewStack,
-                m,
-                false);
+            openFileDialogFragmentFor(f, m, "audio/*");
           }
         }.start();
       } else {
-        OpenFileDialogFragment.Companion.openFileOrShow(
-            FileProvider.getUriForFile(m, m.getPackageName(), f), "*/*", useNewStack, m, false);
+        openFileDialogFragmentFor(f, m);
       }
     } else {
       try {
-        OpenFileDialogFragment.Companion.openFileOrShow(
-            FileProvider.getUriForFile(m, m.getPackageName(), f),
-            MimeTypes.getMimeType(f.getAbsolutePath(), false),
-            useNewStack,
-            m,
-            false);
+        openFileDialogFragmentFor(f, m);
       } catch (Exception e) {
         Toast.makeText(m, m.getString(R.string.no_app_found), Toast.LENGTH_LONG).show();
         openWith(f, m, useNewStack);
       }
     }
+  }
+
+  private static void openFileDialogFragmentFor(
+      @NonNull File file, @NonNull MainActivity mainActivity) {
+    openFileDialogFragmentFor(
+        file, mainActivity, MimeTypes.getMimeType(file.getAbsolutePath(), false));
+  }
+
+  private static void openFileDialogFragmentFor(
+      @NonNull File file, @NonNull MainActivity mainActivity, @NonNull String mimeType) {
+    OpenFileDialogFragment.Companion.openFileOrShow(
+        FileProvider.getUriForFile(mainActivity, mainActivity.getPackageName(), file),
+        mimeType,
+        false,
+        mainActivity,
+        false);
+  }
+
+  private static void openFileDialogFragmentFor(
+      @NonNull DocumentFile file, @NonNull MainActivity mainActivity) {
+    openFileDialogFragmentFor(
+        file.getUri(), mainActivity, MimeTypes.getMimeType(file.getUri().toString(), false));
+  }
+
+  private static void openFileDialogFragmentFor(
+      @NonNull Uri uri, @NonNull MainActivity mainActivity, @NonNull String mimeType) {
+    OpenFileDialogFragment.Companion.openFileOrShow(uri, mimeType, false, mainActivity, false);
   }
 
   private static boolean isSelfDefault(File f, Context c) {
@@ -679,8 +695,7 @@ public class FileUtils {
     boolean useNewStack =
         sharedPrefs.getBoolean(PreferencesConstants.PREFERENCE_TEXTEDITOR_NEWSTACK, false);
     try {
-      OpenFileDialogFragment.Companion.openFileOrShow(
-          f.getUri(), MimeTypes.getMimeType(f.getUri().toString(), false), useNewStack, m, false);
+      openFileDialogFragmentFor(f, m);
     } catch (Exception e) {
       Toast.makeText(m, m.getString(R.string.no_app_found), Toast.LENGTH_LONG).show();
       openWith(f, m, useNewStack);


### PR DESCRIPTION
## PR Info
#### Issue tracker   
Fixes will automatically close the related issue

Fixes #2166

#### Release  
Addresses release/3.6
  
#### Test cases
- [ ] Covered
  
#### Manual testing
- [x] Done  
  
If yes,  
- Device: Pixel 3 emulator
- OS: Android 10

#### Build tasks success  
Successfully running following tasks on local 
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`

#### Additional Info
Fixes #2166. Previous call to OpenFileDialogFragment was using wildcard MIME type while caller (FileUtils) could already know the MIME type advance, causing #2166 to occur. Fixed by explicitly specifying the MIME type.

Also made call to OpenFileDialogFragment.openFileOrShow() to separate methods to prevent complaints about code duplication.

