### PR TITLE
FileUtils.parseName(): Fallback for cases when datetime string cannot be parsed

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/filesystem/files/FileUtils.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/files/FileUtils.java
@@ -752,8 +752,12 @@ public class FileUtils {
       ParsePosition pos = new ParsePosition(0);
       SimpleDateFormat simpledateformat = new SimpleDateFormat("yyyy-MM-dd | HH:mm");
       Date stringDate = simpledateformat.parse(date, pos);
+      if (stringDate == null) {
+        Log.w(TAG, "parseName: unable to parse datetime string [" + date + "]");
+      }
       HybridFileParcelable baseFile =
-          new HybridFileParcelable(name.toString(), array[0], stringDate.getTime(), Size, true);
+          new HybridFileParcelable(
+              name.toString(), array[0], stringDate != null ? stringDate.getTime() : 0, Size, true);
       baseFile.setLink(link.toString());
       return baseFile;
     } else {


### PR DESCRIPTION
## PR Info
#### Issue tracker   
Fixes will automatically close the related issue

Fixes #2182

#### Release  
Addresses release/3.5
  
#### Test cases
- [ ] Covered
  
#### Manual testing
- [ ] Done  
  
If yes,  
- Device:
- OS:

#### Build tasks success  
Successfully running following tasks on local 
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`

#### Additional Info
Not really a fix but band-it solution for now, since we have no idea of what passed into `date` - but to log the string in question for improvement (if necessary).