### PR TITLE
2106: Catch unchecked exception; return default false for hidden file

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/utils/DataUtils.java
+++ b/app/src/main/java/com/amaze/filemanager/utils/DataUtils.java
@@ -40,6 +40,7 @@ import com.googlecode.concurrenttrees.radixinverted.ConcurrentInvertedRadixTree;
 import com.googlecode.concurrenttrees.radixinverted.InvertedRadixTree;
 
 import android.text.TextUtils;
+import android.util.Log;
 import android.view.MenuItem;
 
 import androidx.annotation.Nullable;
@@ -356,7 +357,12 @@ public class DataUtils {
   }
 
   public boolean isFileHidden(String path) {
-    return getHiddenFiles().getValueForExactKey(path) != null;
+    try {
+      return getHiddenFiles().getValueForExactKey(path) != null;
+    } catch (IllegalStateException e) {
+      Log.w(getClass().getSimpleName(), e);
+      return false;
+    }
   }
 
   public ConcurrentRadixTree<VoidValue> getHiddenFiles() {


### PR DESCRIPTION
## PR Info
#### Issue tracker   
Fixes will automatically close the related issue

Fixes #2106 
-or-   
Addresses #

#### Release  
Addresses release/
  
#### Test cases
- [ ] Covered
  
#### Manual testing
- [x] Done  
  
If yes,  
- Device:
- OS:

#### Build tasks success  
Successfully running following tasks on local 
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`

#### Related PR  
Related to PR #

#### Additional Info

Reference:
https://github.com/npgall/concurrent-trees/blob/master/code/src/main/java/com/googlecode/concurrenttrees/radix/ConcurrentRadixTree.java#L989
Not sure how to reproduce, as it seems impossible given the situation. But added a catch exception to fix the issue nonetheless.