### PR TITLE
Trap IllegalStateException at DataUtils.putDrawerMetadata

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/utils/DataUtils.java
+++ b/app/src/main/java/com/amaze/filemanager/utils/DataUtils.java
@@ -51,6 +51,8 @@ import androidx.annotation.Nullable;
 // Central data being used across activity,fragments and classes
 public class DataUtils {
 
+  private static final String TAG = DataUtils.class.getSimpleName();
+
   public static final int DELETE = 0,
       COPY = 1,
       MOVE = 2,
@@ -361,7 +363,7 @@ public class DataUtils {
     try {
       return getHiddenFiles().getValueForExactKey(path) != null;
     } catch (IllegalStateException e) {
-      Log.w(getClass().getSimpleName(), e);
+      Log.w(TAG, e);
       return false;
     }
   }
@@ -420,7 +422,14 @@ public class DataUtils {
 
   public void putDrawerMetadata(MenuItem item, MenuMetadata metadata) {
     menuMetadataMap.put(item, metadata);
-    if (!TextUtils.isEmpty(metadata.path)) tree.put(metadata.path, item.getItemId());
+    if (!TextUtils.isEmpty(metadata.path)) {
+      try {
+        tree.put(metadata.path, item.getItemId());
+      } catch (IllegalStateException e) {
+        Log.w(TAG, e);
+        menuMetadataMap.remove(item);
+      }
+    }
   }
 
   /**

--- a/app/src/test/java/com/amaze/filemanager/filesystem/SmbOperationsTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/filesystem/SmbOperationsTest.kt
@@ -25,11 +25,12 @@ import com.amaze.filemanager.file_operations.filesystem.OpenMode
 import com.amaze.filemanager.shadows.ShadowMultiDex
 import com.amaze.filemanager.shadows.ShadowSmbUtil
 import com.amaze.filemanager.shadows.ShadowSmbUtil.Companion.PATH_CANNOT_RENAME_OLDFILE
+import com.amaze.filemanager.test.ShadowTabHandler
 import org.junit.Test
 import org.robolectric.annotation.Config
 
 @Config(
-    shadows = [ShadowSmbUtil::class, ShadowMultiDex::class],
+    shadows = [ShadowSmbUtil::class, ShadowMultiDex::class, ShadowTabHandler::class],
     sdk = [JELLY_BEAN, KITKAT, P]
 )
 class SmbOperationsTest : AbstractOperationsTestBase() {

--- a/app/src/test/java/com/amaze/filemanager/test/ShadowTabHandler.kt
+++ b/app/src/test/java/com/amaze/filemanager/test/ShadowTabHandler.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2014-2021 Arpit Khurana <arpitkh96@gmail.com>, Vishal Nehra <vishalmeham2@gmail.com>,
+ * Emmanuel Messulam<emmanuelbendavid@gmail.com>, Raymond Lai <airwave209gt at gmail.com> and Contributors.
+ *
+ * This file is part of Amaze File Manager.
+ *
+ * Amaze File Manager is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.amaze.filemanager.test
+
+import com.amaze.filemanager.database.TabHandler
+import com.amaze.filemanager.database.models.explorer.Tab
+import org.robolectric.annotation.Implementation
+import org.robolectric.annotation.Implements
+
+@Implements(TabHandler::class)
+class ShadowTabHandler {
+
+    /**
+     * For places where Activity is launched, but we are not actually looking at the Tabs loaded.
+     *
+     * @see TabHandler.getAllTabs
+     */
+    @Implementation
+    fun getAllTabs(): Array<Tab> = emptyArray()
+}


### PR DESCRIPTION
Fixes #2217. On catching IllegalStateException thrown from ConcurrentRadixTree, removing the MenuItem's meta data as well.

## PR Info
#### Issue tracker   
Fixes will automatically close the related issue

Fixes #2217
-or-   
Addresses #

#### Release  
Addresses release/3.6
  
#### Test cases
- [ ] Covered
  
#### Manual testing
- [ ] Done  
  
If yes,  
- Device:
- OS:

#### Build tasks success  
Successfully running following tasks on local 
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`