### PR TITLE
2128: Show FAB and expand appbar in empty folder

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/ui/fragments/MainFragment.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/fragments/MainFragment.java
@@ -1037,6 +1037,8 @@ public class MainFragment extends Fragment implements BottomBarButtonPath {
         nofilesview.setVisibility(View.VISIBLE);
         listView.setVisibility(View.GONE);
         mSwipeRefreshLayout.setEnabled(false);
+        getMainActivity().getFAB().show();
+        getMainActivity().getAppbar().getAppbarLayout().setExpanded(true);
       } else {
         mSwipeRefreshLayout.setEnabled(true);
         nofilesview.setVisibility(View.GONE);

--- a/app/src/main/java/com/amaze/filemanager/ui/fragments/MainFragment.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/fragments/MainFragment.java
@@ -1037,8 +1037,6 @@ public class MainFragment extends Fragment implements BottomBarButtonPath {
         nofilesview.setVisibility(View.VISIBLE);
         listView.setVisibility(View.GONE);
         mSwipeRefreshLayout.setEnabled(false);
-        getMainActivity().getFAB().show();
-        getMainActivity().getAppbar().getAppbarLayout().setExpanded(true);
       } else {
         mSwipeRefreshLayout.setEnabled(true);
         nofilesview.setVisibility(View.GONE);
@@ -1093,6 +1091,8 @@ public class MainFragment extends Fragment implements BottomBarButtonPath {
       }
 
       getMainActivity().updatePaths(no);
+      getMainActivity().getFAB().show();
+      getMainActivity().getAppbar().getAppbarLayout().setExpanded(true);
       listView.stopScroll();
       fastScroller.setRecyclerView(
           listView, IS_LIST ? 1 : (columns == 0 || columns == -1) ? 3 : columns);


### PR DESCRIPTION
## PR Info
#### Issue tracker   
Fixes will automatically close the related issue

Fixes #2128 
-or-   
Addresses #

#### Release  
Addresses release/3.6
  
#### Test cases
- [ ] Covered
  
#### Manual testing
- [x] Done  
  
If yes,  
- Device: Oneplus 6t
- OS: Android 10

#### Build tasks success  
Successfully running following tasks on local 
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`

#### Related PR  
Related to PR #

#### Additional Info