### PR TITLE
Fix openmode when non-numeric path passed into LoadFilesListTask

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/LoadFilesListTask.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/LoadFilesListTask.java
@@ -97,8 +97,8 @@ public class LoadFilesListTask
   protected Pair<OpenMode, ArrayList<LayoutElementParcelable>> doInBackground(Void... p) {
     HybridFile hFile = null;
 
-    if (openmode == OpenMode.UNKNOWN) {
-      hFile = new HybridFile(OpenMode.UNKNOWN, path);
+    if (OpenMode.UNKNOWN.equals(openmode) || OpenMode.CUSTOM.equals(openmode)) {
+      hFile = new HybridFile(openmode, path);
       hFile.generateMode(nullCheckOrInterrupt(mainFragment, this).getActivity());
       openmode = hFile.getMode();
 

--- a/app/src/main/java/com/amaze/filemanager/filesystem/HybridFile.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/HybridFile.java
@@ -147,7 +147,9 @@ public class HybridFile {
           mode = OpenMode.ROOT;
         }
 
-        if (mode == OpenMode.UNKNOWN) {
+        // In some cases, non-numeric path is passed into HybridFile while mode is still
+        // CUSTOM here. We are forcing OpenMode.FILE in such case too. See #2225
+        if (OpenMode.UNKNOWN.equals(mode) || OpenMode.CUSTOM.equals(mode)) {
           mode = OpenMode.FILE;
         }
       }


### PR DESCRIPTION
## PR Info
#### Issue tracker   
Fixes will automatically close the related issue

Fixes #2225

#### Release  
Addresses release/3.6
  
#### Test cases
- [ ] Covered
  
#### Manual testing
- [x] Done  
  
If yes,  
- Device: Fairphone 3 running LineageOS 16.0 (9.0), Oneplus 2 running /e/OS 0.13 (10)

#### Build tasks success  
Successfully running following tasks on local 
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`

#### Additional Info
For some unknown reasons sometimes folder would show up at Documents list, i.e. identified as Document in MediaStore. Amaze would crash when attempt to tap into such folder while in Documents list, i.e. openmode is set to CUSTOM.

Workaround this problem by parsing the path before the switch(openmode) cases, and change openmode when path is not numeric.