### PR TITLE
Workaround data directory access for Android >= 11 if device is rooted

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/filesystem/root/ListFilesCommand.kt
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/root/ListFilesCommand.kt
@@ -198,7 +198,7 @@ object ListFilesCommand : IRootCommand() {
         path: String,
         isStat: Boolean
     ): HybridFileParcelable? {
-        return FileUtils.parseName(
+        FileUtils.parseName(
             if (isStat) rawFile.replace(
                 "('|`)".toRegex(),
                 ""
@@ -230,6 +230,12 @@ object ListFilesCommand : IRootCommand() {
                 }
             } else {
                 this.isDirectory = isDirectory(this)
+            }
+        }.let {
+            return if (!".".equals(it?.name) && !"..".equals(it?.name)) {
+                it
+            } else {
+                null
             }
         }
     }

--- a/app/src/main/java/com/amaze/filemanager/ui/fragments/MainFragment.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/fragments/MainFragment.java
@@ -944,10 +944,19 @@ public class MainFragment extends Fragment implements BottomBarButtonPath {
       loadFilesListTask.cancel(true);
     }
 
+    final String _path =
+        FileUtil.remapPathForApi30OrAbove(path, getMainActivity().isRootExplorer());
+
+    if (!path.equals(_path)) {
+      AppConfig.toast(
+          getMainActivity(),
+          getResources().getString(R.string.redirected_to_path_using_root, _path));
+    }
+
     loadFilesListTask =
         new LoadFilesListTask(
             getActivity(),
-            path,
+            _path,
             this,
             openMode,
             getBoolean(PREFERENCE_SHOW_THUMB),
@@ -956,8 +965,8 @@ public class MainFragment extends Fragment implements BottomBarButtonPath {
               mSwipeRefreshLayout.setRefreshing(false);
               if (data != null && data.second != null) {
                 boolean isPathLayoutGrid =
-                    dataUtils.getListOrGridForPath(path, DataUtils.LIST) == DataUtils.GRID;
-                setListElements(data.second, back, path, data.first, false, isPathLayoutGrid);
+                    dataUtils.getListOrGridForPath(_path, DataUtils.LIST) == DataUtils.GRID;
+                setListElements(data.second, back, _path, data.first, false, isPathLayoutGrid);
               }
             });
     loadFilesListTask.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -700,5 +700,6 @@
     <string name="error_unsupported_v5_rar">RAR archive \"%s\" is unsupported RAR v5 archive.</string>
     <string name="ftp_prompt_restart_server">You will need to restart the FTP server for changes to take effect.</string>
     <string name="error_permission_denied">Permission denied</string>
+    <string name="redirected_to_path_using_root">Redirected to \"%s\" using root</string>
 </resources>
 

--- a/app/src/test/java/com/amaze/filemanager/filesystem/FileUtilTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/filesystem/FileUtilTest.kt
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2014-2021 Arpit Khurana <arpitkh96@gmail.com>, Vishal Nehra <vishalmeham2@gmail.com>,
+ * Emmanuel Messulam<emmanuelbendavid@gmail.com>, Raymond Lai <airwave209gt at gmail.com> and Contributors.
+ *
+ * This file is part of Amaze File Manager.
+ *
+ * Amaze File Manager is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.amaze.filemanager.filesystem
+
+import android.os.Build.VERSION_CODES.*
+import android.os.Environment
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertEquals
+import org.junit.Ignore
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.LooperMode
+
+@Ignore("Excluded until build runs on JDK 9 and Robolectric upgrades to 4.5")
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [JELLY_BEAN, KITKAT, P])
+@LooperMode(LooperMode.Mode.PAUSED)
+@Suppress("StringLiteralDuplication")
+class FileUtilTest {
+
+    /**
+     * Test [FileUtil.remapPathForApi30OrAbove] for unmeaningful paths.
+     */
+    @Test
+    fun testRemapPathForApi30OrAboveForUnmeaningfulPaths() {
+        assertEquals(
+            "/foo/bar",
+            FileUtil.remapPathForApi30OrAbove("/foo/bar", true)
+        )
+        assertEquals(
+            "/foo/bar",
+            FileUtil.remapPathForApi30OrAbove("/foo/bar", false)
+        )
+    }
+
+    /**
+     * Test [FileUtil.remapPathForApi30OrAbove] for meaningful paths but without root.
+     */
+    @Test
+    fun testRemapPathForApi30OrAboveForMeaningfulPathsWithoutRoot() {
+        val prefix = Environment.getExternalStorageDirectory().absolutePath
+        assertEquals(
+            "$prefix/Android/data",
+            FileUtil.remapPathForApi30OrAbove("$prefix/Android/data", false)
+        )
+        assertEquals(
+            "$prefix/Android/obb",
+            FileUtil.remapPathForApi30OrAbove("$prefix/Android/obb", false)
+        )
+    }
+
+    /**
+     * Test [FileUtil.remapPathForApi30OrAbove] for meaningful paths but without root.
+     */
+    @Test
+    fun testRemapPathForApi30OrAboveForMeaningfulPathsWithRoot() {
+        val prefix = Environment.getExternalStorageDirectory().absolutePath
+        assertEquals(
+            "/data/media/external-cache/Android/data",
+            FileUtil.remapPathForApi30OrAbove("$prefix/Android/data", true)
+        )
+        assertEquals(
+            "/data/media/external-cache/Android/obb",
+            FileUtil.remapPathForApi30OrAbove("$prefix/Android/obb", true)
+        )
+    }
+}


### PR DESCRIPTION
## PR Info
#### Issue tracker   
Fixes will automatically close the related issue

Fixes #2015

#### Release  
Addresses release/3.6
  
#### Test cases
- [ ] Covered
  
#### Manual testing
- [x] Done  
  
Devices:
 - Pixel 2 emulator running stock Android 11, rooted with the help of the handy script from https://github.com/newbit1/rootAVD
 - Also tested for regressions:
   * Fairphone 3 running LineageOS 16.0 (9.0)
   * LG Nexus 5x running /e/OS 0.13 (8.1)
   * Oneplus 2 running /e/OS 0.13 (10.0)
   * GPD XD running LegacyROM (4.4.4)

#### Build tasks success  
Successfully running following tasks on local 
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`

#### Additional Info

If user is on Android 11 or above, and device is rooted, when accessing Android data directory which would be blocked access, augment the path to /data/media/0/Android/data and list files using root.

Additionally, added filter to ls results for some devices (including AVD emulator) where toybox is used instead of busybox, to filter out entries "." and "..".

Thanks again to @danielzgtg for the workaround idea!