### PR TITLE
Lower the API requirement on triggering SAF when OTG is inserted

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/ui/views/drawer/Drawer.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/views/drawer/Drawer.java
@@ -712,7 +712,7 @@ public class Drawer implements NavigationView.OnNavigationItemSelectedListener {
           CloudUtil.checkToken(meta.path, mainActivity);
         }
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT
             && (meta.path.contains(OTGUtil.PREFIX_OTG)
                 || meta.path.startsWith(OTGUtil.PREFIX_MEDIA_REMOVABLE))
             && SingletonUsbOtg.getInstance().getUsbOtgRoot() == null) {


### PR DESCRIPTION
Lowering the bar to KITKAT should already do the trick.

## PR Info
#### Issue tracker   
Fixes will automatically close the related issue

Fixes #2213

#### Release  
Addresses release/3.6
  
#### Test cases
- [ ] Covered
  
#### Manual testing
- [ ] Done  
  
If yes,  
- Device:
- OS:

#### Build tasks success  
Successfully running following tasks on local 
- [ ] `./gradlew assembledebug`
- [ ] `./gradlew spotlessCheck`