### PR TITLE
Use NtlmPasswordAuthenticator in place of NtlmPasswordAuthentication

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/utils/SmbUtil.java
+++ b/app/src/main/java/com/amaze/filemanager/utils/SmbUtil.java
@@ -31,8 +31,10 @@ import android.content.Context;
 import android.net.Uri;
 import android.text.TextUtils;
 
-import jcifs.context.SingletonContext;
-import jcifs.smb.NtlmPasswordAuthentication;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import jcifs.smb.NtlmPasswordAuthenticator;
 import jcifs.smb.SmbFile;
 
 /**
@@ -91,10 +93,45 @@ public class SmbUtil {
     Uri uri = Uri.parse(path);
     boolean disableIpcSigningCheck =
         Boolean.parseBoolean(uri.getQueryParameter(PARAM_DISABLE_IPC_SIGNING_CHECK));
+    String userInfo = uri.getUserInfo();
     return new SmbFile(
         path.indexOf('?') < 0 ? path : path.substring(0, path.indexOf('?')),
         CifsContexts.createWithDisableIpcSigningCheck(path, disableIpcSigningCheck)
-            .withCredentials(
-                new NtlmPasswordAuthentication(SingletonContext.getInstance(), uri.getUserInfo())));
+            .withCredentials(createFrom(userInfo)));
+  }
+
+  /**
+   * Create {@link NtlmPasswordAuthenticator} from given userInfo parameter.
+   *
+   * <p>Logic borrowed directly from jcifs-ng's own code. They should make that protected
+   * constructor public...
+   *
+   * @param userInfo authentication string, must be already URL decoded. {@link Uri} shall do this
+   *     for you already
+   * @return {@link NtlmPasswordAuthenticator} instance
+   */
+  protected static @NonNull NtlmPasswordAuthenticator createFrom(@Nullable String userInfo) {
+    if (!TextUtils.isEmpty(userInfo)) {
+      String dom = null;
+      String user = null;
+      String pass = null;
+      int i;
+      int u;
+      int end = userInfo.length();
+      for (i = 0, u = 0; i < end; i++) {
+        char c = userInfo.charAt(i);
+        if (c == ';') {
+          dom = userInfo.substring(0, i);
+          u = i + 1;
+        } else if (c == ':') {
+          pass = userInfo.substring(i + 1);
+          break;
+        }
+      }
+      user = userInfo.substring(u, i);
+      return new NtlmPasswordAuthenticator(dom, user, pass);
+    } else {
+      return new NtlmPasswordAuthenticator();
+    }
   }
 }

--- a/app/src/test/java/com/amaze/filemanager/asynchronous/asynctasks/AbstractDeleteTaskTestBase.kt
+++ b/app/src/test/java/com/amaze/filemanager/asynchronous/asynctasks/AbstractDeleteTaskTestBase.kt
@@ -33,6 +33,7 @@ import com.amaze.filemanager.R
 import com.amaze.filemanager.filesystem.HybridFileParcelable
 import com.amaze.filemanager.shadows.ShadowMultiDex
 import com.amaze.filemanager.shadows.ShadowSmbUtil
+import com.amaze.filemanager.test.ShadowCryptUtil
 import com.amaze.filemanager.test.ShadowTabHandler
 import com.amaze.filemanager.test.TestUtils
 import com.amaze.filemanager.ui.activities.MainActivity
@@ -52,7 +53,12 @@ import org.robolectric.shadows.ShadowToast
 @RunWith(AndroidJUnit4::class)
 @LooperMode(LooperMode.Mode.PAUSED)
 @Config(
-    shadows = [ShadowMultiDex::class, ShadowSmbUtil::class, ShadowTabHandler::class],
+    shadows = [
+        ShadowMultiDex::class,
+        ShadowSmbUtil::class,
+        ShadowTabHandler::class,
+        ShadowCryptUtil::class
+    ],
     sdk = [JELLY_BEAN, KITKAT, P]
 )
 abstract class AbstractDeleteTaskTestBase {

--- a/app/src/test/java/com/amaze/filemanager/filesystem/AbstractOperationsTestBase.kt
+++ b/app/src/test/java/com/amaze/filemanager/filesystem/AbstractOperationsTestBase.kt
@@ -22,6 +22,7 @@ package com.amaze.filemanager.filesystem
 
 import android.content.Context
 import android.os.Build
+import android.os.Build.VERSION_CODES.*
 import android.os.Looper
 import android.os.storage.StorageManager
 import androidx.lifecycle.Lifecycle
@@ -29,6 +30,9 @@ import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.amaze.filemanager.file_operations.filesystem.OpenMode
+import com.amaze.filemanager.shadows.ShadowMultiDex
+import com.amaze.filemanager.shadows.ShadowSmbUtil
+import com.amaze.filemanager.test.ShadowTabHandler
 import com.amaze.filemanager.test.TestUtils
 import com.amaze.filemanager.ui.activities.MainActivity
 import io.reactivex.android.plugins.RxAndroidPlugins
@@ -40,12 +44,17 @@ import org.junit.Before
 import org.junit.runner.RunWith
 import org.robolectric.Shadows
 import org.robolectric.android.util.concurrent.InlineExecutorService
+import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
 import org.robolectric.shadows.ShadowPausedAsyncTask
 import org.robolectric.shadows.ShadowSQLiteConnection
 
 @RunWith(AndroidJUnit4::class)
 @LooperMode(LooperMode.Mode.PAUSED)
+@Config(
+    shadows = [ShadowSmbUtil::class, ShadowMultiDex::class, ShadowTabHandler::class],
+    sdk = [JELLY_BEAN, KITKAT, P]
+)
 abstract class AbstractOperationsTestBase {
 
     protected var ctx: Context? = null

--- a/app/src/test/java/com/amaze/filemanager/filesystem/SmbOperationsTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/filesystem/SmbOperationsTest.kt
@@ -20,19 +20,10 @@
 
 package com.amaze.filemanager.filesystem
 
-import android.os.Build.VERSION_CODES.*
 import com.amaze.filemanager.file_operations.filesystem.OpenMode
-import com.amaze.filemanager.shadows.ShadowMultiDex
-import com.amaze.filemanager.shadows.ShadowSmbUtil
 import com.amaze.filemanager.shadows.ShadowSmbUtil.Companion.PATH_CANNOT_RENAME_OLDFILE
-import com.amaze.filemanager.test.ShadowTabHandler
 import org.junit.Test
-import org.robolectric.annotation.Config
 
-@Config(
-    shadows = [ShadowSmbUtil::class, ShadowMultiDex::class, ShadowTabHandler::class],
-    sdk = [JELLY_BEAN, KITKAT, P]
-)
 class SmbOperationsTest : AbstractOperationsTestBase() {
 
     /**

--- a/app/src/test/java/com/amaze/filemanager/filesystem/SshOperationsTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/filesystem/SshOperationsTest.kt
@@ -20,19 +20,10 @@
 
 package com.amaze.filemanager.filesystem
 
-import android.os.Build.VERSION_CODES.*
 import com.amaze.filemanager.file_operations.filesystem.OpenMode
 import com.amaze.filemanager.filesystem.ssh.test.MockSshConnectionPools
-import com.amaze.filemanager.shadows.ShadowMultiDex
-import com.amaze.filemanager.test.ShadowCryptUtil
-import com.amaze.filemanager.test.ShadowTabHandler
 import org.junit.Test
-import org.robolectric.annotation.Config
 
-@Config(
-    shadows = [ShadowMultiDex::class, ShadowCryptUtil::class, ShadowTabHandler::class],
-    sdk = [JELLY_BEAN, KITKAT, P]
-)
 class SshOperationsTest : AbstractOperationsTestBase() {
 
     /**

--- a/app/src/test/java/com/amaze/filemanager/test/ShadowTabHandler.kt
+++ b/app/src/test/java/com/amaze/filemanager/test/ShadowTabHandler.kt
@@ -22,11 +22,35 @@ package com.amaze.filemanager.test
 
 import com.amaze.filemanager.database.TabHandler
 import com.amaze.filemanager.database.models.explorer.Tab
+import io.reactivex.Completable
 import org.robolectric.annotation.Implementation
 import org.robolectric.annotation.Implements
+import org.robolectric.util.ReflectionHelpers
 
 @Implements(TabHandler::class)
 class ShadowTabHandler {
+
+    companion object {
+        /**
+         * Implements [TabHandler.getInstance]
+         */
+        @JvmStatic @Implementation
+        fun getInstance(): TabHandler = ReflectionHelpers.newInstance(TabHandler::class.java)
+    }
+
+    /**
+     * Implements [TabHandler.addTab]
+     */
+    @Implementation
+    fun addTab(tab: Tab): Completable {
+        return Completable.fromCallable { true }
+    }
+
+    /**
+     * Implements [TabHandler.update]
+     */
+    @Implementation
+    fun update(tab: Tab) = Unit
 
     /**
      * For places where Activity is launched, but we are not actually looking at the Tabs loaded.


### PR DESCRIPTION
Using it can allow us to fill in decoded authentication parameters.

## PR Info
#### Issue tracker   
Fixes will automatically close the related issue

Fixes #2313

#### Release  
Addresses release/3.6
 
#### Test cases
- [x] Covered
  
#### Manual testing
- [x] Done  
  
If yes,  
- Device: Fairphone 3
- OS: LineageOS 16.0 (9.0)

#### Build tasks success  
Successfully running following tasks on local 
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`