### PR TITLE
Support extracting APK set archives

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/adapters/RecyclerAdapter.java
+++ b/app/src/main/java/com/amaze/filemanager/adapters/RecyclerAdapter.java
@@ -1067,6 +1067,7 @@ public class RecyclerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
           if (description.endsWith(fileExtensionZip)
               || description.endsWith(fileExtensionJar)
               || description.endsWith(fileExtensionApk)
+              || description.endsWith(fileExtensionApks)
               || description.endsWith(fileExtensionRar)
               || description.endsWith(fileExtensionTar)
               || description.endsWith(fileExtensionGzipTarLong)

--- a/app/src/main/java/com/amaze/filemanager/filesystem/compressed/CompressedHelper.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/compressed/CompressedHelper.java
@@ -59,7 +59,8 @@ public abstract class CompressedHelper {
 
   public static final String fileExtensionZip = "zip",
       fileExtensionJar = "jar",
-      fileExtensionApk = "apk";
+      fileExtensionApk = "apk",
+      fileExtensionApks = "apks";
   public static final String fileExtensionTar = "tar";
   public static final String fileExtensionGzipTarLong = "tar.gz", fileExtensionGzipTarShort = "tgz";
   public static final String fileExtensionBzip2TarLong = "tar.bz2",
@@ -173,7 +174,8 @@ public abstract class CompressedHelper {
   private static boolean isZip(String type) {
     return type.endsWith(fileExtensionZip)
         || type.endsWith(fileExtensionJar)
-        || type.endsWith(fileExtensionApk);
+        || type.endsWith(fileExtensionApk)
+        || type.endsWith(fileExtensionApks);
   }
 
   private static boolean isTar(String type) {


### PR DESCRIPTION
## PR Info
Add support for extracting APK set archives (.apks) which can be generated from an app bundle using bundletool.
More info: https://developer.android.com/studio/command-line/bundletool#generate_apks


#### Issue tracker   
Fixes will automatically close the related issue

Fixes #2358

#### Release  
Addresses release/3.6
  
#### Test cases
- [ ] Covered
  
#### Manual testing
- [x] Done  
  
If yes,  
- Device:
- OS:

#### Build tasks success  
Successfully running following tasks on local 
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`