### PR TITLE
Remove bash statement causing security vulnerability in Github CI

### DIFF
--- a/.github/workflows/android-debug-artifact-ondemand.yml
+++ b/.github/workflows/android-debug-artifact-ondemand.yml
@@ -21,7 +21,6 @@ jobs:
       - name: Get PR informations
         id: pr_data
         run: |
-          echo "::set-output name=branch::${{ fromJson(steps.request.outputs.data).head.ref }}"
           echo "::set-output name=repo_name::${{ fromJson(steps.request.outputs.data).head.repo.full_name }}"
           echo "::set-output name=repo_clone_url::${{ fromJson(steps.request.outputs.data).head.repo.clone_url }}"
           echo "::set-output name=repo_ssh_url::${{ fromJson(steps.request.outputs.data).head.repo.ssh_url }}"

--- a/app/src/test/java/com/amaze/filemanager/asynchronous/asynctasks/AbstractDeleteTaskTestBase.kt
+++ b/app/src/test/java/com/amaze/filemanager/asynchronous/asynctasks/AbstractDeleteTaskTestBase.kt
@@ -22,6 +22,7 @@ package com.amaze.filemanager.asynchronous.asynctasks
 
 import android.content.Context
 import android.os.Build
+import android.os.Build.VERSION_CODES.*
 import android.os.Looper
 import android.os.storage.StorageManager
 import androidx.lifecycle.Lifecycle
@@ -30,6 +31,9 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.amaze.filemanager.R
 import com.amaze.filemanager.filesystem.HybridFileParcelable
+import com.amaze.filemanager.shadows.ShadowMultiDex
+import com.amaze.filemanager.shadows.ShadowSmbUtil
+import com.amaze.filemanager.test.ShadowTabHandler
 import com.amaze.filemanager.test.TestUtils
 import com.amaze.filemanager.ui.activities.MainActivity
 import io.reactivex.android.plugins.RxAndroidPlugins
@@ -40,12 +44,17 @@ import org.junit.Assert.*
 import org.junit.Before
 import org.junit.runner.RunWith
 import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
 import org.robolectric.shadows.ShadowSQLiteConnection
 import org.robolectric.shadows.ShadowToast
 
 @RunWith(AndroidJUnit4::class)
 @LooperMode(LooperMode.Mode.PAUSED)
+@Config(
+    shadows = [ShadowMultiDex::class, ShadowSmbUtil::class, ShadowTabHandler::class],
+    sdk = [JELLY_BEAN, KITKAT, P]
+)
 abstract class AbstractDeleteTaskTestBase {
 
     private var ctx: Context? = null

--- a/app/src/test/java/com/amaze/filemanager/asynchronous/asynctasks/SmbDeleteTaskTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/asynchronous/asynctasks/SmbDeleteTaskTest.kt
@@ -20,16 +20,11 @@
 
 package com.amaze.filemanager.asynchronous.asynctasks
 
-import android.os.Build.VERSION_CODES.*
 import com.amaze.filemanager.filesystem.HybridFileParcelable
-import com.amaze.filemanager.shadows.ShadowMultiDex
-import com.amaze.filemanager.shadows.ShadowSmbUtil
 import com.amaze.filemanager.shadows.ShadowSmbUtil.Companion.PATH_CANNOT_DELETE_FILE
 import com.amaze.filemanager.utils.SmbUtil
 import org.junit.Test
-import org.robolectric.annotation.Config
 
-@Config(shadows = [ShadowMultiDex::class, ShadowSmbUtil::class], sdk = [JELLY_BEAN, KITKAT, P])
 class SmbDeleteTaskTest : AbstractDeleteTaskTestBase() {
 
     /**

--- a/app/src/test/java/com/amaze/filemanager/asynchronous/asynctasks/SshDeleteTaskTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/asynchronous/asynctasks/SshDeleteTaskTest.kt
@@ -20,23 +20,15 @@
 
 package com.amaze.filemanager.asynchronous.asynctasks
 
-import android.os.Build.VERSION_CODES.*
 import com.amaze.filemanager.filesystem.HybridFileParcelable
 import com.amaze.filemanager.filesystem.ssh.test.MockSshConnectionPools
-import com.amaze.filemanager.shadows.ShadowMultiDex
-import com.amaze.filemanager.test.ShadowCryptUtil
 import net.schmizz.sshj.sftp.FileAttributes
 import net.schmizz.sshj.sftp.RemoteResourceInfo
 import net.schmizz.sshj.xfer.FilePermission
 import org.junit.Test
 import org.mockito.Mockito.`when`
 import org.mockito.Mockito.mock
-import org.robolectric.annotation.Config
 
-@Config(
-    shadows = [ShadowMultiDex::class, ShadowCryptUtil::class],
-    sdk = [JELLY_BEAN, KITKAT, P]
-)
 class SshDeleteTaskTest : AbstractDeleteTaskTestBase() {
 
     /**


### PR DESCRIPTION
Continuation of #2280 where one bash security vulnerability was left behind. Devs may refer to email by @JarLob back again for what I have missed :sweat_smile: 

Also attempted to fix test timeouts by forcing delete file task tests to use ShadowTabHandler too.