### PR TITLE
Use UNIX timestamp when load file list using `stat` command

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/filesystem/RootHelper.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/RootHelper.java
@@ -128,7 +128,7 @@ public class RootHelper {
       for (String currentLine : resultLines) {
         if (contains(currentLine.split(" "), name)) {
           try {
-            HybridFileParcelable parsedFile = FileUtils.parseName(currentLine);
+            HybridFileParcelable parsedFile = FileUtils.parseName(currentLine, true);
             if (parsedFile.getPermission().trim().startsWith("d")) return true;
             else if (parsedFile.getPermission().trim().startsWith("l")) {
               if (count > 5) return file.isDirectory();

--- a/app/src/main/java/com/amaze/filemanager/filesystem/files/FileUtils.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/files/FileUtils.java
@@ -783,7 +783,7 @@ public class FileUtils {
    *
    * @param line must be the line returned from 'ls' or 'stat' command
    */
-  public static HybridFileParcelable parseName(String line) {
+  public static HybridFileParcelable parseName(String line, boolean isStat) {
     boolean linked = false;
     StringBuilder name = new StringBuilder();
     StringBuilder link = new StringBuilder();
@@ -794,12 +794,17 @@ public class FileUtils {
     for (String anArray : array) {
       if (anArray.contains("->") && array[0].startsWith("l")) {
         linked = true;
+        break;
       }
     }
     int p = getColonPosition(array);
     if (p != -1) {
       date = array[p - 1] + " | " + array[p];
       size = array[p - 2];
+    } else if (isStat) {
+      date = array[5];
+      size = array[4];
+      p = 5;
     }
     if (!linked) {
       for (int i = p + 1; i < array.length; i++) {
@@ -818,7 +823,7 @@ public class FileUtils {
       link = new StringBuilder(link.toString().trim());
     }
     long Size = (size == null || size.trim().length() == 0) ? -1 : Long.parseLong(size);
-    if (date.trim().length() > 0) {
+    if (date.trim().length() > 0 && !isStat) {
       ParsePosition pos = new ParsePosition(0);
       SimpleDateFormat simpledateformat = new SimpleDateFormat("yyyy-MM-dd | HH:mm");
       Date stringDate = simpledateformat.parse(date, pos);
@@ -828,6 +833,12 @@ public class FileUtils {
       HybridFileParcelable baseFile =
           new HybridFileParcelable(
               name.toString(), array[0], stringDate != null ? stringDate.getTime() : 0, Size, true);
+      baseFile.setLink(link.toString());
+      return baseFile;
+    } else if (isStat) {
+      HybridFileParcelable baseFile =
+          new HybridFileParcelable(
+              name.toString(), array[0], Long.parseLong(date) * 1000, Size, true);
       baseFile.setLink(link.toString());
       return baseFile;
     } else {

--- a/app/src/main/java/com/amaze/filemanager/filesystem/root/ListFilesCommand.kt
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/root/ListFilesCommand.kt
@@ -99,7 +99,7 @@ object ListFilesCommand : IRootCommand() {
                 else -> sanitizedPath.plus("/")
             }
 
-            val command = "stat -c '%A %h %G %U %B %y %N' " +
+            val command = "stat -c '%A %h %G %U %B %Y %N' " +
                 "$appendedPath*" + (if (showHidden) " $appendedPath.* " else "")
             return if (!retryWithLs &&
                 !PreferenceManager.getDefaultSharedPreferences(AppConfig.getInstance())
@@ -202,7 +202,8 @@ object ListFilesCommand : IRootCommand() {
             if (isStat) rawFile.replace(
                 "('|`)".toRegex(),
                 ""
-            ) else rawFile
+            ) else rawFile,
+            isStat
         )?.apply {
             this.mode = OpenMode.ROOT
             this.name = this.path

--- a/app/src/test/java/com/amaze/filemanager/filesystem/files/FileUtilsTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/filesystem/files/FileUtilsTest.kt
@@ -358,4 +358,45 @@ class FileUtilsTest {
             assertEquals("/user/My Documents", second)
         }
     }
+
+    /**
+     * Test [FileUtils.parseName]
+     */
+    @Test
+    fun testParseStringForHybridFileParcelable() {
+        // ls
+        val a = "-rwxr-x---   1 root   shell    29431 2009-01-01 08:00 init.rc"
+        val b = "lrw-r--r--   1 root   root        15 2009-01-01 08:00 product -> /system/product"
+        val c = "drwxr-xr-x  17 root   root      4096 1970-05-19 08:40 system"
+
+        // stat with old toybox or busybox
+        // val a1 = "-rwxr-x--- 1 shell root 512 2009-01-01 08:00:00.000000000 `init.rc'"
+        // val b1 = "lrw-r--r-- 1 root root 512 2009-01-01 08:00:00.000000000 `product' -> `/system/product'"
+        // val c1 = "drwxr-xr-x 17 root root 512 1970-05-19 08:40:27.269999949 `system'"
+
+        // stat with new toybox
+        val a2 = "-rwxr-x--- 1 shell root 512 1230796800 `init.rc'"
+        val b2 = "lrw-r--r-- 1 root root 512 1230796800 `product' -> `/system/product'"
+        val c2 = "drwxr-xr-x 17 root root 512 11922027 `system'"
+
+        var result1 = FileUtils.parseName(a, false)
+        var result2 = FileUtils.parseName(a2.replace("('|`)".toRegex(), ""), true)
+        assertEquals(result1.date, result2.date)
+        assertEquals(result1.name, result2.name)
+        assertEquals(result1.path, result2.path)
+
+        result1 = FileUtils.parseName(b, false)
+        result2 = FileUtils.parseName(b2.replace("('|`)".toRegex(), ""), true)
+        assertEquals(result1.date, result2.date)
+        assertEquals(result1.name, result2.name)
+        assertEquals(result1.path, result2.path)
+        assertEquals(result1.link, result2.link)
+
+        result1 = FileUtils.parseName(c, false)
+        result2 = FileUtils.parseName(c2.replace("('|`)".toRegex(), ""), true)
+        // if using stat, seconds will also be available, so they won't be equal
+        assertNotEquals(result1.date, result2.date)
+        assertEquals(result1.name, result2.name)
+        assertEquals(result1.path, result2.path)
+    }
 }


### PR DESCRIPTION
## PR Info
#### Issue tracker   
Fixes will automatically close the related issue

Fixes #2263

#### Release  
Addresses release/
  
#### Test cases
- [x] Covered
  
#### Manual testing
- [ ] Done  
  
If yes,  
- Device:
- OS:

#### Build tasks success  
Successfully running following tasks on local 
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`

#### Additional Info
With UNIX timestamp in place hope this can eventually eliminate the need of `ls`.

This changeset won't remove `ls` usage; it can be done with another PR once proved stable.