### PR TITLE
issue #2318 fixed.

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/LoadFilesListTask.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/LoadFilesListTask.java
@@ -281,6 +281,16 @@ public class LoadFilesListTask
 
       if (baseFile.isDirectory()) {
         nullCheckOrInterrupt(mainFragment, this).folder_count++;
+         /*
+        to solve issue #2318, we will pass the real size of the folders
+        as the size parameters to layoutElement .
+         */
+        try {
+          longSize = baseFile.getSize();
+          size = Formatter.formatFileSize(nullCheckOrInterrupt(context, this), longSize);
+        } catch (NumberFormatException e) {
+          e.printStackTrace();
+        }
       } else {
         if (baseFile.getSize() != -1) {
           try {

--- a/app/src/main/java/com/amaze/filemanager/filesystem/files/FileListSorter.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/files/FileListSorter.java
@@ -95,8 +95,13 @@ public class FileListSorter implements Comparator<LayoutElementParcelable> {
       if (!file1.isDirectory && !file2.isDirectory) {
 
         return asc * Long.valueOf(file1.longSize).compareTo(file2.longSize);
-      } else {
+        //the following lines have been added to solve issue #2318
+      } else if(file1.isDirectory && file2.isDirectory){
 
+        return asc * Long.valueOf(file1.longSize).compareTo(file2.longSize);
+      }
+      else
+      {
         return file1.title.compareToIgnoreCase(file2.title);
       }
 

--- a/app/src/main/java/com/amaze/filemanager/filesystem/root/ListFilesCommand.kt
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/root/ListFilesCommand.kt
@@ -32,6 +32,7 @@ import com.amaze.filemanager.filesystem.RootHelper
 import com.amaze.filemanager.filesystem.files.FileUtils
 import com.amaze.filemanager.filesystem.root.base.IRootCommand
 import com.amaze.filemanager.ui.fragments.preference_fragments.PreferencesConstants
+import com.amaze.filemanager.utils.Utils
 import java.io.File
 import kotlin.collections.ArrayList
 
@@ -159,7 +160,14 @@ object ListFilesCommand : IRootCommand() {
             if (filesInPathFile != null) {
                 filesInPathFile.forEach { currentFile ->
                     var size: Long = 0
-                    if (!currentFile.isDirectory) size = currentFile.length()
+                    /*
+                        we will set size of folders as their actual size to resolve issue #2318.
+                     */
+                    if (!currentFile.isDirectory) {
+                        size = currentFile.length()
+                    }
+                    else
+                        size = Utils.folderSize(currentFile)
                     HybridFileParcelable(
                         currentFile.path,
                         RootHelper.parseFilePermission(currentFile),

--- a/app/src/main/java/com/amaze/filemanager/utils/Utils.java
+++ b/app/src/main/java/com/amaze/filemanager/utils/Utils.java
@@ -399,4 +399,17 @@ public class Utils {
     emailIntent.setType("message/rfc822");
     return emailIntent;
   }
+  /*
+ this method will be used to solve issue #2318 (sorting folders)
+ */
+  public static long folderSize(File directory) {
+    long length = 0;
+    for (File file : directory.listFiles()) {
+      if (file.isFile())
+        length += file.length();
+      else
+        length += folderSize(file);
+    }
+    return length;
+  }
 }


### PR DESCRIPTION
now able to sort folders as well.

1. In ListFilesCommand.kt instead of passing size zero when the variable currentFile is a directory, we obtain the size of the folder with a simple method implemented in Utils.java and set  it as size.
2. In LoadFilesListTask, in createListParcelables method we will obtain the size of the basefile when it's a directory.
3. In FileListSorter.java when comparing based on size, if both files are a directory then they'll be compared based on their real sizes.
 