### PR TITLE
Move library version number to top-level build.gradle

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -103,31 +103,6 @@ android {
     }
 }
 
-ext {
-    robolectricVersion = '4.3.1'
-    glideVersion = '4.11.0'
-    sshjVersion = '0.26.0'
-    jcifsVersion = '2.1.3'
-    fabSpeedDialVersion = '3.1.1'
-    roomVersion = '2.2.5'
-    bouncyCastleVersion = '1.66'
-    awaitilityVersion = "3.1.6"
-    androidMaterialVersion = "1.3.0"
-    androidXFragmentVersion = "1.3.0"
-    androidXAppCompatVersion = "1.2.0"
-    androidXTestVersion = "1.3.0"
-    androidXTestExtVersion = "1.1.2"
-    junitVersion = "4.13.2"
-    slf4jVersion = "1.7.25"
-    mockitoVersion = "3.4.4"
-    androidBillingVersion = "2.1.0"
-    junrarVersion = "7.4.0"
-    zip4jVersion = "2.6.4"
-    androidXAppCompatVersion = "1.1.0"
-    androidXPrefVersion = "1.1.1"
-    materialDialogsVersion = "0.9.6.0"
-}
-
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
     implementation 'com.readystatesoftware.systembartint:systembartint:1.0.3'
@@ -167,7 +142,7 @@ dependencies {
     kaptTest "com.google.auto.service:auto-service:1.0-rc4"
 
     androidTestImplementation "junit:junit:$junitVersion"//tests the app logic
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
+    androidTestImplementation "androidx.test.espresso:espresso-core:$espressoVersion"
     androidTestImplementation "androidx.test:core:$androidXTestVersion"
     androidTestImplementation "androidx.test:runner:$androidXTestVersion"
     androidTestImplementation "androidx.test:rules:$androidXTestVersion"

--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,33 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.4.10'
+    ext {
+        kotlin_version = "1.4.10"
+        robolectricVersion = '4.3.1'
+        glideVersion = '4.11.0'
+        sshjVersion = '0.26.0'
+        jcifsVersion = '2.1.3'
+        fabSpeedDialVersion = '3.1.1'
+        roomVersion = '2.2.5'
+        bouncyCastleVersion = '1.66'
+        awaitilityVersion = "3.1.6"
+        androidMaterialVersion = "1.3.0"
+        androidXFragmentVersion = "1.3.0"
+        androidXAppCompatVersion = "1.2.0"
+        androidXTestVersion = "1.3.0"
+        androidXTestExtVersion = "1.1.2"
+        junitVersion = "4.13.2"
+        slf4jVersion = "1.7.25"
+        mockitoVersion = "3.4.4"
+        androidBillingVersion = "2.1.0"
+        junrarVersion = "7.4.0"
+        zip4jVersion = "2.6.4"
+        espressoVersion = "3.3.0"
+        androidXPrefVersion = "1.1.1"
+        materialDialogsVersion = "0.9.6.0"
+    }
     repositories {
         google()
-        jcenter()
         maven {
             url "https://plugins.gradle.org/m2/"
         }
@@ -27,7 +50,6 @@ allprojects {
 
     repositories {
         google()
-        jcenter()
         maven { url "https://jitpack.io" }
         maven { url "https://jcenter.bintray.com" }
         mavenCentral()

--- a/file_operations/build.gradle
+++ b/file_operations/build.gradle
@@ -34,34 +34,13 @@ android {
     }
 }
 
-ext {
-    robolectricVersion = '4.3.1'
-    glideVersion = '4.11.0'
-    sshjVersion = '0.26.0'
-    jcifsVersion = '2.1.3'
-    fabSpeedDialVersion = '3.1.1'
-    roomVersion = '2.2.5'
-    bouncyCastleVersion = '1.65'
-    awaitilityVersion = "3.1.6"
-    androidXTestVersion = "1.2.0"
-    junitVersion = "4.13"
-    slf4jVersion = "1.7.25"
-    mockitoVersion = "3.4.4"
-    androidBillingVersion = "2.1.0"
-}
-
 dependencies {
     implementation 'org.apache.commons:commons-compress:1.18'
 
-    implementation ('com.github.junrar:junrar:0.7') {
-        exclude module: 'commons-logging'
-        exclude module: 'commons-logging-api'
-        exclude module: 'maven-scm-api'
-        exclude module: 'maven-scm-provider-svnexe'
-    }
+    implementation "com.github.junrar:junrar:$junrarVersion"
 
     //zip4j: support password-protected zips
-    implementation 'net.lingala.zip4j:zip4j:1.3.2'
+    implementation "net.lingala.zip4j:zip4j:$zip4jVersion"
 
     implementation project(':commons_compress_7z')
 
@@ -82,7 +61,7 @@ dependencies {
     testImplementation "androidx.test:core:$androidXTestVersion"
     testImplementation "androidx.test:runner:$androidXTestVersion"
     testImplementation "androidx.test:rules:$androidXTestVersion"
-    testImplementation 'androidx.test.ext:junit:1.1.1'
+    testImplementation "androidx.test.ext:junit:$androidXTestExtVersion"
     //testImplementation 'androidx.test.uiautomator:uiautomator:2.2.0'
     testImplementation "org.mockito:mockito-core:$mockitoVersion"
     testImplementation "org.apache.sshd:sshd-core:1.7.0"
@@ -91,18 +70,18 @@ dependencies {
     testAnnotationProcessor "com.google.auto.service:auto-service:1.0-rc4"
 
     androidTestImplementation "junit:junit:$junitVersion"//tests the app logic
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
+    androidTestImplementation "androidx.test.espresso:espresso-core:$espressoVersion"
     androidTestImplementation "androidx.test:core:$androidXTestVersion"
     androidTestImplementation "androidx.test:runner:$androidXTestVersion"
     androidTestImplementation "androidx.test:rules:$androidXTestVersion"
-    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
+    androidTestImplementation "androidx.test.ext:junit:$androidXTestExtVersion"
     androidTestImplementation 'commons-net:commons-net:3.6'
     androidTestImplementation "org.awaitility:awaitility:$awaitilityVersion"
 
     implementation fileTree(dir: "libs", include: ["*.jar"])
     implementation 'androidx.appcompat:appcompat:1.2.0'
-    testImplementation 'junit:junit:4.12'
+    testImplementation "junit:junit:$junitVersion"
     androidTestImplementation 'androidx.test.ext:junit:1.1.2'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
+    androidTestImplementation "androidx.test.espresso:espresso-core:$espressoVersion"
 
 }


### PR DESCRIPTION
There was inconsistencies between dependencies on app and file_operations modules. Moving the version numbers up to top-level can help keeping all modules using the same lib versions.

Also removed jcenter as repository as suggested from Android Studio. Details: https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/