### PR TITLE
Use JDK 11 to build

### DIFF
--- a/.github/workflows/android-debug-artifact-ondemand.yml
+++ b/.github/workflows/android-debug-artifact-ondemand.yml
@@ -30,10 +30,11 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{fromJson(steps.request.outputs.data).head.repo.full_name}}
           ref: ${{fromJson(steps.request.outputs.data).head.ref}}
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
         with:
-          java-version: 1.8
+          distribution: "adopt"
+          java-version: 11
       - name: Build with Gradle
         run: |
           echo Run on-demand by ${GITHUB_ACTOR}

--- a/.github/workflows/android-debug-artifact-release.yml
+++ b/.github/workflows/android-debug-artifact-release.yml
@@ -9,10 +9,11 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
         with:
-          java-version: 1.8
+          distribution: "adopt"
+          java-version: 11
       - name: Build with Gradle
         run: |
           bash ./gradlew assembleDebug --stacktrace

--- a/.github/workflows/android-feature.yml
+++ b/.github/workflows/android-feature.yml
@@ -17,10 +17,11 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
         with:
-          java-version: 1.8
+          distribution: "adopt"
+          java-version: 11
       - name: Check formatting using spotless
         run: ./gradlew spotlessCheck --stacktrace
       - name: Build with Gradle

--- a/.github/workflows/android-main.yml
+++ b/.github/workflows/android-main.yml
@@ -11,10 +11,11 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
         with:
-          java-version: 1.8
+          distribution: "adopt"
+          java-version: 11
       - name: Check formatting using spotless
         run: ./gradlew spotlessCheck --stacktrace
       - name: Build with Gradle


### PR DESCRIPTION
This enable Robolectric to test with SDK 30 or above (requires upgrading Robolectric though).