### PR TITLE
ColorPref fixes: "Customize" missing colour, up button behaviour

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/ui/fragments/preference_fragments/ColorPref.kt
+++ b/app/src/main/java/com/amaze/filemanager/ui/fragments/preference_fragments/ColorPref.kt
@@ -213,6 +213,8 @@ class ColorPref : PreferenceFragmentCompat(), Preference.OnPreferenceClickListen
             selectedColors?.onPreferenceClickListener = this
         }
         checkCustomization()
+        (findPreference<Preference>("category") as InvalidablePreferenceCategory?)
+            ?.invalidate(activity.accent)
     }
 
     private fun openSelectColorDialog(pref: SelectedColorsPreference) {

--- a/app/src/main/java/com/amaze/filemanager/ui/fragments/preference_fragments/ColorPref.kt
+++ b/app/src/main/java/com/amaze/filemanager/ui/fragments/preference_fragments/ColorPref.kt
@@ -80,7 +80,7 @@ class ColorPref : PreferenceFragmentCompat(), Preference.OnPreferenceClickListen
 
     /** Deal with the "up" button going to last fragment, instead of section 0.  */
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
-        if (item.itemId == com.amaze.filemanager.R.id.home && currentSection != SECTION_0) {
+        if (item.itemId == android.R.id.home && currentSection != SECTION_0) {
             switchSections()
             return true
         }
@@ -213,7 +213,7 @@ class ColorPref : PreferenceFragmentCompat(), Preference.OnPreferenceClickListen
             selectedColors?.onPreferenceClickListener = this
         }
         checkCustomization()
-        (findPreference<Preference>("category") as InvalidablePreferenceCategory?)
+        (findPreference<Preference>(KEY_CUSTOMIZE) as InvalidablePreferenceCategory?)
             ?.invalidate(activity.accent)
     }
 
@@ -224,7 +224,7 @@ class ColorPref : PreferenceFragmentCompat(), Preference.OnPreferenceClickListen
             activity.appTheme
         )
         dialog.setListener(createColorPickerDialogListener())
-        (findPreference<Preference>("category") as InvalidablePreferenceCategory?)
+        (findPreference<Preference>(KEY_CUSTOMIZE) as InvalidablePreferenceCategory?)
             ?.invalidate(activity.accent)
         dialog.setTargetFragment(this, 0)
         dialog.show(parentFragmentManager, KEY_SELECT_COLOR_CONFIG)
@@ -286,7 +286,7 @@ class ColorPref : PreferenceFragmentCompat(), Preference.OnPreferenceClickListen
                     selectedColors.invalidateColors()
                 }
             }
-            (findPreference<Preference>("category") as InvalidablePreferenceCategory?)
+            (findPreference<Preference>(KEY_CUSTOMIZE) as InvalidablePreferenceCategory?)
                 ?.invalidate(activity.accent)
         }
     }
@@ -350,5 +350,6 @@ class ColorPref : PreferenceFragmentCompat(), Preference.OnPreferenceClickListen
             PreferencesConstants.PREFERENCE_ICON_SKIN
         )
         private const val KEY_SECTION = "section"
+        private const val KEY_CUSTOMIZE = "category"
     }
 }


### PR DESCRIPTION
## PR Info
#### Issue tracker   
Fixes will automatically close the related issue

Fixes #2476
Fixes #2477
-or-   
Addresses #

#### Release  
Addresses release/3.6
  
#### Test cases
- [ ] Covered
  
#### Manual testing
- [x] Done  
  
If yes,  
- Device: Pixel 2 emulator
- OS: Android 11

#### Build tasks success  
Successfully running following tasks on local 
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`
