### PR TITLE
Fix Issue #2441: seperated debug & release icons

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,6 +3,7 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
 apply plugin: 'kotlin-android-extensions'
 apply plugin: 'com.hiya.jacoco-android'
+apply plugin: 'com.akaita.android.easylauncher'
 
 android {
     compileSdkVersion 29
@@ -286,6 +287,10 @@ project.afterEvaluate {
 
 clean.dependsOn supportOldLangCodes
 clean.mustRunAfter supportOldLangCodes
+
+easylauncher {
+    foregroundIconNames "@mipmap/ic_launcher_foreground" // Foreground of adaptive launcher icon
+}
 
 jacoco {
     toolVersion = "0.8.4"

--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,7 @@ buildscript {
         classpath 'com.android.tools.build:gradle:4.1.0'
         classpath 'com.hiya:jacoco-android:0.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath 'com.akaita.android:easylauncher:1.3.1'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }


### PR DESCRIPTION
## PR Info
#### Issue tracker   
#2441 

Fixes #
Added label in debug build icon

#### Release  
Addresses release/3.6
  
#### Test cases
- [x] Covered
  
#### Manual testing
- [x] Done  
  
If yes,  
- Device: Infinix Note 5
- OS: Android 10

#### Build tasks success  
Successfully running following tasks on local 
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`

#### Related PR  
Related to PR #

#### Additional Info
![image](https://user-images.githubusercontent.com/55531939/119251811-390cf000-bbc6-11eb-89f1-8dd5ab7deb11.png)
![image](https://user-images.githubusercontent.com/55531939/119251840-68236180-bbc6-11eb-8c12-70f8aea088c5.png)
