### PR TITLE
Filter ls entries ending with . and ..

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/filesystem/root/ListFilesCommand.kt
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/root/ListFilesCommand.kt
@@ -54,7 +54,9 @@ object ListFilesCommand : IRootCommand() {
             // we're rooted and we're trying to load file with superuser
             // we're at the root directories, superuser is required!
             val result = executeRootCommand(path, showHidden)
-            result.first.forEach {
+            result.first.filter {
+                !it.endsWith(".") && !it.endsWith("..")
+            }.forEach {
                 if (!it.contains("Permission denied")) {
                     parseStringForHybridFile(
                         it, path,


### PR DESCRIPTION
From deprecated PR while working on #2015. Quoting log message:

> Added filter to ls results for some devices (including AVD emulator) where `toybox` is used instead of `busybox`, to filter out entries "." and "..".

## PR Info
#### Issue tracker   
Fixes will automatically close the related issue

Fixes #
-or-   
Addresses #

#### Release  
Addresses release/
  
#### Test cases
- [ ] Covered
  
#### Manual testing
- [ ] Done  
  
If yes,  
- Device:
- OS:

#### Build tasks success  
Successfully running following tasks on local 
- [ ] `./gradlew assembledebug`
- [ ] `./gradlew spotlessCheck`

#### Related PR  
Related to PR #

#### Additional Info