### PR TITLE
Fix Apps list sort button and correct rebase mistakes at FtpService related classes

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/asynchronous/services/ftp/FtpService.kt
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/services/ftp/FtpService.kt
@@ -35,7 +35,7 @@ import android.os.Build.VERSION_CODES.M
 import android.os.Environment
 import android.os.IBinder
 import android.os.SystemClock
-import android.preference.PreferenceManager
+import androidx.preference.PreferenceManager
 import com.amaze.filemanager.R
 import com.amaze.filemanager.application.AppConfig
 import com.amaze.filemanager.filesystem.files.CryptUtil

--- a/app/src/main/java/com/amaze/filemanager/ui/activities/MainActivity.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/activities/MainActivity.java
@@ -1024,6 +1024,10 @@ public class MainActivity extends PermissionsActivity
     // ActionBarDrawerToggle will take care of this.
     if (drawer.onOptionsItemSelected(item)) return true;
 
+    if (getFragmentAtFrame() instanceof AppsListFragment && item.getItemId() == R.id.sort) {
+      GeneralDialogCreation.showSortDialog((AppsListFragment) getFragmentAtFrame(), getAppTheme());
+    }
+
     // Handle action buttons
     executeWithMainFragment(
         mainFragment -> {
@@ -1060,12 +1064,6 @@ public class MainActivity extends PermissionsActivity
               break;
             case R.id.exit:
               finish();
-              break;
-            case R.id.sort:
-              Fragment fragment = getFragmentAtFrame();
-              if (fragment instanceof AppsListFragment) {
-                GeneralDialogCreation.showSortDialog((AppsListFragment) fragment, getAppTheme());
-              }
               break;
             case R.id.sortby:
               GeneralDialogCreation.showSortDialog(mainFragment, getAppTheme(), getPrefs());

--- a/app/src/main/java/com/amaze/filemanager/ui/fragments/FtpServerFragment.kt
+++ b/app/src/main/java/com/amaze/filemanager/ui/fragments/FtpServerFragment.kt
@@ -33,7 +33,6 @@ import android.os.Build.VERSION_CODES.LOLLIPOP
 import android.os.Build.VERSION_CODES.M
 import android.os.Bundle
 import android.os.Environment
-import android.preference.PreferenceManager
 import android.provider.Settings
 import android.text.InputType
 import android.text.Spanned
@@ -43,6 +42,7 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.text.HtmlCompat
 import androidx.core.text.HtmlCompat.FROM_HTML_MODE_COMPACT
 import androidx.fragment.app.Fragment
+import androidx.preference.PreferenceManager
 import com.afollestad.materialdialogs.DialogAction
 import com.afollestad.materialdialogs.MaterialDialog
 import com.afollestad.materialdialogs.folderselector.FolderChooserDialog

--- a/app/src/test/java/com/amaze/filemanager/asynchronous/services/FtpServiceTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/asynchronous/services/FtpServiceTest.kt
@@ -28,7 +28,7 @@ import android.net.wifi.WifiInfo
 import android.net.wifi.WifiManager
 import android.os.Build.VERSION_CODES.KITKAT
 import android.os.Environment
-import android.preference.PreferenceManager
+import androidx.preference.PreferenceManager
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.amaze.filemanager.asynchronous.services.ftp.FtpService


### PR DESCRIPTION
## Description
- Use AndroidX PreferenceManager to correct previous rebase mistake (if any) with FtpService-related classes
- Move handling of sort button at AppsListFragment out of executeWithMainFragment() lambda. This fixes problem of sort button not working at Apps list.

#### Manual tests
- [ ] Done  
  
- Device:
- OS:

#### Build tasks success  
Successfully running following tasks on local:
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`