### PR TITLE
Add handling for R.id.exit in AppsListFragment

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/ui/activities/MainActivity.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/activities/MainActivity.java
@@ -1023,10 +1023,9 @@ public class MainActivity extends PermissionsActivity
     // The action bar home/up action should open or close the drawer.
     // ActionBarDrawerToggle will take care of this.
     if (drawer.onOptionsItemSelected(item)) return true;
-
-    if (getFragmentAtFrame() instanceof AppsListFragment && item.getItemId() == R.id.sort) {
-      ((AppsListFragment) getFragmentAtFrame()).showSortDialog(getAppTheme());
-    }
+    // Same thing goes to other Fragments loaded.
+    // If they have handled the options, we don't need to.
+    if (getFragmentAtFrame().onOptionsItemSelected(item)) return true;
 
     // Handle action buttons
     executeWithMainFragment(

--- a/app/src/main/java/com/amaze/filemanager/ui/fragments/AppsListFragment.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/fragments/AppsListFragment.java
@@ -44,6 +44,7 @@ import com.bumptech.glide.util.ViewPreloadSizeProvider;
 import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.os.Parcelable;
+import android.view.MenuItem;
 import android.view.View;
 
 import androidx.annotation.NonNull;
@@ -133,6 +134,20 @@ public class AppsListFragment extends ListFragment
 
     if (savedInstanceState != null) {
       listViewState = savedInstanceState.getParcelable(KEY_LIST_STATE);
+    }
+  }
+
+  @Override
+  public boolean onOptionsItemSelected(@NonNull MenuItem item) {
+    switch (item.getItemId()) {
+      case R.id.sort:
+        showSortDialog(((MainActivity) requireActivity()).getAppTheme());
+        return true;
+      case R.id.exit:
+        ((MainActivity) requireActivity()).goToMain(null);
+        return true;
+      default:
+        return super.onOptionsItemSelected(item);
     }
   }
 


### PR DESCRIPTION
## Description

#### Issue tracker   
Fixes #2518

#### Automatic tests
- [ ] Added test cases
  
#### Manual tests
- [x] Done  
  
If yes,
- Device: Fairphone 3
- OS: LineageOS 16.0 (9.0)

#### Build tasks success  
Successfully running following tasks on local:
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`