### PR TITLE
Fix FTP server status display

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/asynchronous/services/ftp/FtpService.kt
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/services/ftp/FtpService.kt
@@ -79,7 +79,6 @@ class FtpService : Service(), Runnable {
     private var username: String? = null
     private var password: String? = null
     private var isPasswordProtected = false
-    private var server: FtpServer? = null
     private var isStartedByTile = false
 
     override fun onStartCommand(intent: Intent, flags: Int, startId: Int): Int {
@@ -254,13 +253,16 @@ class FtpService : Service(), Runnable {
         const val TAG_STARTED_BY_TILE = "started_by_tile"
         // attribute of action_started, used by notification
 
-        var serverThread: Thread? = null
+        private var serverThread: Thread? = null
+        private var server: FtpServer? = null
 
         /**
          * Indicator whether FTP service is running
          */
         @JvmStatic
-        fun isRunning(): Boolean = serverThread != null
+        fun isRunning(): Boolean = server?.let {
+            !it.isStopped
+        } ?: false
 
         /**
          * Is the device connected to local network, either Ethernet or Wifi?

--- a/app/src/main/java/com/amaze/filemanager/ui/fragments/FtpServerFragment.kt
+++ b/app/src/main/java/com/amaze/filemanager/ui/fragments/FtpServerFragment.kt
@@ -223,7 +223,7 @@ class FtpServerFragment : Fragment(R.layout.fragment_ftp) {
                             }
                         }
                     }
-                    .positiveText(getString(R.string.change).toUpperCase())
+                    .positiveText(getString(R.string.change).uppercase())
                     .negativeText(R.string.cancel)
                     .build()
                     .show()
@@ -265,7 +265,7 @@ class FtpServerFragment : Fragment(R.layout.fragment_ftp) {
                     }
                 val dialog = loginDialogBuilder.customView(loginDialogView.root, true)
                     .title(getString(R.string.ftp_login))
-                    .positiveText(getString(R.string.set).toUpperCase())
+                    .positiveText(getString(R.string.set).uppercase())
                     .negativeText(getString(R.string.cancel))
                     .build()
 
@@ -322,7 +322,7 @@ class FtpServerFragment : Fragment(R.layout.fragment_ftp) {
                     }
                 }
                 timeoutBuilder
-                    .positiveText(resources.getString(R.string.set).toUpperCase())
+                    .positiveText(resources.getString(R.string.set).uppercase())
                     .negativeText(resources.getString(R.string.cancel))
                     .build()
                     .show()
@@ -349,7 +349,7 @@ class FtpServerFragment : Fragment(R.layout.fragment_ftp) {
                 stopServer()
                 statusText.text = spannedStatusNoConnection
                 ftpBtn.isEnabled = false
-                ftpBtn.text = resources.getString(R.string.start_ftp).toUpperCase()
+                ftpBtn.text = resources.getString(R.string.start_ftp).uppercase()
                 promptUserToEnableWireless()
             }
         }
@@ -370,7 +370,7 @@ class FtpServerFragment : Fragment(R.layout.fragment_ftp) {
                 else spannedStatusConnected
 
                 url.text = spannedStatusUrl
-                ftpBtn.text = resources.getString(R.string.stop_ftp).toUpperCase()
+                ftpBtn.text = resources.getString(R.string.stop_ftp).uppercase()
                 FtpNotification.updateNotification(
                     context,
                     FtpReceiverActions.STARTED_FROM_TILE == signal
@@ -379,15 +379,16 @@ class FtpServerFragment : Fragment(R.layout.fragment_ftp) {
             FtpReceiverActions.FAILED_TO_START -> {
                 statusText.text = spannedStatusNotRunning
                 Toast.makeText(context, R.string.unknown_error, Toast.LENGTH_LONG).show()
-                ftpBtn.text = resources.getString(R.string.start_ftp).toUpperCase()
+                ftpBtn.text = resources.getString(R.string.start_ftp).uppercase()
                 url.text = "URL: "
             }
             FtpReceiverActions.STOPPED -> {
                 statusText.text = spannedStatusNotRunning
                 url.text = "URL: "
-                ftpBtn.text = resources.getString(R.string.start_ftp).toUpperCase()
+                ftpBtn.text = resources.getString(R.string.start_ftp).uppercase()
             }
         }
+        updateStatus()
     }
 
     /** Sends a broadcast to start ftp server  */
@@ -412,6 +413,7 @@ class FtpServerFragment : Fragment(R.layout.fragment_ftp) {
         wifiFilter.addAction(ConnectivityManager.CONNECTIVITY_ACTION)
         requireContext().registerReceiver(mWifiReceiver, wifiFilter)
         EventBus.getDefault().register(this)
+        updateStatus()
     }
 
     override fun onPause() {
@@ -435,13 +437,13 @@ class FtpServerFragment : Fragment(R.layout.fragment_ftp) {
                 ftpBtn.isEnabled = true
             }
             url.text = "URL: "
-            ftpBtn.text = resources.getString(R.string.start_ftp).toUpperCase()
+            ftpBtn.text = resources.getString(R.string.start_ftp).uppercase()
         } else {
             accentColor = mainActivity.accent
             url.text = spannedStatusUrl
             statusText.text = spannedStatusConnected
             ftpBtn.isEnabled = true
-            ftpBtn.text = resources.getString(R.string.stop_ftp).toUpperCase()
+            ftpBtn.text = resources.getString(R.string.stop_ftp).uppercase()
         }
         val passwordDecrypted = passwordFromPreferences
         val passwordBulleted: CharSequence = OneCharacterCharSequence(


### PR DESCRIPTION
- Made FtpService.server static field. This is for work with FtpService.isRunning() static method
- Update FTP server status display at onResume(). This allows update server status even if Amaze (and the FTP service) is running at the background
- Changed String.toUpperCase() to String.uppercase() per suggested by Kotlin

## Description

#### Issue tracker   
Fixes #2526

#### Manual tests
- [x] Done  
  
- Device: Fairphone 3
- OS: LineageOS 16.0 (9.0)

#### Build tasks success  
Successfully running following tasks on local:
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`