### PR TITLE
Fix ExternalSdCardOperation.getDocumentFile()

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/filesystem/ExternalSdCardOperation.kt
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/ExternalSdCardOperation.kt
@@ -83,7 +83,7 @@ object ExternalSdCardOperation {
             return document
         }
 
-        val parts = relativePath.split("\\/").toTypedArray()
+        val parts = relativePath.split("/").toTypedArray()
         for (i in parts.indices) {
             if (document == null) {
                 return null


### PR DESCRIPTION
It was found that the arguments passed to String.split() in splitting given path was incorrectly interpreted, causing some SD card related operations to fail, especially when there is folder prefix(es).

Original code in Java should be calling
https://developer.android.com/reference/java/lang/String#split(java.lang.String)

while it was then calling this instead, when code was transformed into Kotlin, not recognizing the argument as regex but normal string
https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.text/split.html

For example, for a file on the SD card `"tmp/DummyFile"`, it was interpreted as `["tmp/DummyFile"]` but not `["tmp", "DummyFile"]`, i.e. not splitted correctly. After this change paths should be splitted correctly.

I read that the regex in original code should be just splitting with `/`... so be it. Only a single `/` would be enough.

## Description

#### Issue tracker   
Addresses #2142 (I don't know if it would fix the issue, so just _addresses_ here)

#### Manual tests
- [x] Done  
  
- Device: Fairphone 3
- OS: LineageOS 16.0 (9.0)

on copying files to a subfolder on the same external SD card. Before the fix when the paste happens, SAF dialog will popup even when I had already grant SAF permission to Amaze; afterwards the paste operation would fail.

After applying the changeset this problem will disappear.

#### Build tasks success  
<!-- run these! -->
Successfully running following tasks on local:
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`
