### PR TITLE
Fix: replace add icon with cut icon (drag n drop)

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/adapters/RecyclerAdapter.java
+++ b/app/src/main/java/com/amaze/filemanager/adapters/RecyclerAdapter.java
@@ -963,7 +963,7 @@ public class RecyclerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
   }
 
   private int getDragIconReference(String rememberMovePreference) {
-    int iconRef = R.drawable.ic_add_white_24dp;
+    int iconRef = R.drawable._ic_content_cut_white_36dp;
     if (rememberMovePreference.equalsIgnoreCase(
         PreferencesConstants.PREFERENCE_DRAG_REMEMBER_MOVE)) {
       iconRef = R.drawable.ic_content_cut_white_36dp;


### PR DESCRIPTION
Fixes #2544

Hi @VishalNehra!

I don't think is quite right yet! I just replaced the add icon with the cut icon for now (a small win that I couldn't find where to actually change the code)

Do we need to add a new custom cut/copy icon, or does one already exist?

Looking forward to your review!

thanks!