### PR TITLE
Fix value for legacy_listing_summary

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -696,7 +696,7 @@
     <string name="clear_open_file_summary">Clears selected default file opening apps</string>
     <string name="ftp_readonly">Read-only access</string>
     <string name="legacy_listing_title">Use legacy listing for root</string>
-    <string name="legacy_listing_summary">If enabled, uses stat for listing, else uses ls</string>
+    <string name="legacy_listing_summary">If enabled, uses legacy method to list files</string>
     <string name="error_unsupported_v5_rar">RAR archive \"%s\" is unsupported RAR v5 archive.</string>
     <string name="ftp_prompt_restart_server">You will need to restart the FTP server for changes to take effect.</string>
     <string name="error_permission_denied">Permission denied</string>


### PR DESCRIPTION
## Description
Previous string value for `legacy_listing_summary` in string.xml contradicts its behaviour - Amaze will use old method (ls) to list files when preference PreferenceConstants.PREFERENCE_ROOT_LEGACY_LISTING is true, while the translation string reads contradictory meaning.

#### Manual tests
- [x] Done  
  
- Device: Fairphone 3
- OS: LineageOS 16.0 (9.0)

#### Build tasks success  
Successfully running following tasks on local:
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`
