### PR TITLE
Update Bouncycastle to 1.68, jcifs to 2.1.6

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -100,6 +100,16 @@ android {
 }
 
 dependencies {
+
+    modules {
+        module("org.bouncycastle:bcprov-jdk15to18") {
+            replacedBy("org.bouncycastle:bcprov-jdk15on")
+        }
+        module("org.bouncycastle:bcpkix-jdk15to18") {
+            replacedBy("org.bouncycastle:bcpkix-jdk15on")
+        }
+    }
+
     implementation fileTree(include: ['*.jar'], dir: 'libs')
     implementation 'com.readystatesoftware.systembartint:systembartint:1.0.3'
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,10 +6,10 @@ buildscript {
         robolectricVersion = '4.3.1'
         glideVersion = '4.11.0'
         sshjVersion = '0.26.0'
-        jcifsVersion = '2.1.3'
+        jcifsVersion = '2.1.6'
         fabSpeedDialVersion = '3.1.1'
         roomVersion = '2.2.5'
-        bouncyCastleVersion = '1.66'
+        bouncyCastleVersion = '1.68'
         awaitilityVersion = "3.1.6"
         androidMaterialVersion = "1.3.0"
         androidXFragmentVersion = "1.3.0"


### PR DESCRIPTION
## Description
With jcifs release 2.1.6 which uses Bouncycastle 1.68, we can plug the security hole eventually.

jcifs is using the `jdk15to18` variant of Bouncycastle which guarantees compatibility, but should not be the case for us since Dalvik should not really care about Java class versions, hence this PR forces jcifs uses the `jdk15on` variant which Amaze currently uses.

#### Issue tracker   
Fixes #2169

#### Manual tests
- [x] Done  
  
- Device: Fairphone 3
- OS: LineageOS 16.0 (9.0)
- Situations: access SMB share, connect to SSH server, encrypt/decrypt files

#### Build tasks success  
Successfully running following tasks on local:
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`