### PR TITLE
Fixed issue where dialogs wouldn't allow multiline input.

### DIFF
--- a/app/src/main/res/layout/dialog_singleedittext.xml
+++ b/app/src/main/res/layout/dialog_singleedittext.xml
@@ -17,7 +17,7 @@
             android:layout_height="wrap_content"
             android:layout_gravity="center_vertical"
             android:ems="10"
-            android:inputType="textCapWords" />
+            android:inputType="textCapWords|textMultiLine" />
     </com.amaze.filemanager.ui.views.WarnableTextInputLayout>
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
<!-- 
Read this first:
To open a pull request read this file,
uncomment the corresponding lines and 
complete them.
-->

## Description
Edited dialog_singleedittext.xml to allow multiline text input. This fixes bug #2634 and allows the rename dialog box to have multiline input. However, this also makes it so that all other dialogs that use dialog_singleedittext.xml also have support for multiline input. I don't know if this is the desired outcome, as the issue only specifically names the rename dialog box. (This is also my first contribution to an open source project ever). 

#### Issue tracker   
<!-- Fixes will automatically close the related issue -->
Fixes #2634
<!-- Addresses won't automatically close the related issue -->
<!-- Addresses # -->

#### Manual tests
- [x] Done  
  
<!-- If yes, -->
<!-- 
- Device: Pixel 3
- OS: Android 11.0
-->

#### Build tasks success  
<!-- run these! -->
Successfully running following tasks on local:
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`
