### PR TITLE
Verify package name before initializing ACRA and ErrorActivity

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/application/AppConfig.java
+++ b/app/src/main/java/com/amaze/filemanager/application/AppConfig.java
@@ -109,7 +109,9 @@ public class AppConfig extends GlideApplication {
   @Override
   protected void attachBaseContext(Context base) {
     super.attachBaseContext(base);
-    initACRA();
+    if (base.getPackageName().equals(BuildConfig.APPLICATION_ID)) {
+      initACRA();
+    }
   }
 
   @Override


### PR DESCRIPTION
Implementation is a bit primitive, and given the source code is publicly available, we can only slow down, but not prohibiting others from pirating without a decent code signing mechanism that will work across github, f-droid and derivatives, and google play.

## Description

#### Issue tracker   
Fixes #2641

#### Manual tests
- [x] Done  
  
- Device: Pixel 2 emulator
- OS: Android 11

that ErrorActivity will immediately finish() if app package name doesn't start with our designated bundle ID.

#### Build tasks success  
Successfully running following tasks on local:
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`
