### PR TITLE
Proguard instruction to keep CompressorInputStream descendants' constructors taking InputStream as parameter

### DIFF
--- a/app/proguard.cfg
+++ b/app/proguard.cfg
@@ -118,3 +118,9 @@
 #Ignore test classes see tests-proguard.cfg
 -dontwarn android.test.**
 -dontwarn org.junit.**
+
+#Commons-compress. See #2647.
+#Keep constructors that involves an InputStream
+-keepclassmembers class * extends org.apache.commons.compress.compressors.CompressorInputStream {
+  <init>(java.io.InputStream);
+}

--- a/app/src/main/java/com/amaze/filemanager/filesystem/compressed/Extensions.kt
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/compressed/Extensions.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2014-2021 Arpit Khurana <arpitkh96@gmail.com>, Vishal Nehra <vishalmeham2@gmail.com>,
+ * Emmanuel Messulam<emmanuelbendavid@gmail.com>, Raymond Lai <airwave209gt at gmail.com> and Contributors.
+ *
+ * This file is part of Amaze File Manager.
+ *
+ * Amaze File Manager is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.amaze.filemanager.filesystem.compressed
+
+import android.os.Build.VERSION.SDK_INT
+import android.os.Build.VERSION_CODES.M
+import com.github.junrar.Archive
+
+/**
+ * Extension function to patch [Archive.isPasswordProtected] which uses API that is not available
+ * for Android 6.0 or lower.
+ *
+ * @see [Archive.isPasswordProtected]
+ * @see [java.util.stream.Stream]
+ * @return true if archive is password protected
+ */
+fun Archive.isPasswordProtectedCompat(): Boolean {
+    return if (SDK_INT > M) {
+        this.isPasswordProtected
+    } else {
+        fileHeaders.any { obj ->
+            obj.isEncrypted
+        }
+    }
+}

--- a/app/src/main/java/com/amaze/filemanager/filesystem/compressed/extractcontents/helpers/RarExtractor.kt
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/compressed/extractcontents/helpers/RarExtractor.kt
@@ -28,6 +28,7 @@ import com.amaze.filemanager.filesystem.FileUtil
 import com.amaze.filemanager.filesystem.MakeDirectoryOperation
 import com.amaze.filemanager.filesystem.compressed.CompressedHelper
 import com.amaze.filemanager.filesystem.compressed.extractcontents.Extractor
+import com.amaze.filemanager.filesystem.compressed.isPasswordProtectedCompat
 import com.amaze.filemanager.filesystem.files.GenericCopyUtil
 import com.github.junrar.Archive
 import com.github.junrar.exception.CorruptHeaderException
@@ -68,7 +69,7 @@ class RarExtractor(
                 }
             }.getOrNull()!!
 
-            if (rarFile.isPasswordProtected || rarFile.isEncrypted) {
+            if (rarFile.isPasswordProtectedCompat() || rarFile.isEncrypted) {
                 if (ArchivePasswordCache.getInstance().containsKey(filePath)) {
                     runCatching {
                         tryExtractSmallestFileInArchive(context, rarFile)


### PR DESCRIPTION
Call this black magic, since it's not possible to even run an Espresso test against classes processed with Proguard.

Anyone have a better idea to test logic after Proguard processing, please let us know.

Additionally, fixed a regression in RarExtractor that would cause Amaze to crash when extracting RAR on Android 6.0 or lower - see #2655.

## Description

#### Issue tracker   
Fixes #2642, fixes #2647, fixes #2655

#### Manual tests
- [x] Done  

- Device: Pixel 2 emulator
- OS: Android 6.0, Android 11.

Create a production build (which will include proguard) then test extracting different archives as usual.

#### Build tasks success  
Successfully running following tasks on local:
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`