### PR TITLE
Make SAF-based backend optional in FTP server

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/filesystem/ftpserver/AndroidFileSystemFactory.kt
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/ftpserver/AndroidFileSystemFactory.kt
@@ -32,5 +32,5 @@ import org.apache.ftpserver.ftplet.User
 class AndroidFileSystemFactory(private val context: Context) : FileSystemFactory {
 
     override fun createFileSystemView(user: User?): FileSystemView =
-        AndroidFtpFileSystemView(context, user?.homeDirectory ?: FtpService.DEFAULT_PATH)
+        AndroidFtpFileSystemView(context, user?.homeDirectory ?: FtpService.defaultPath(context))
 }

--- a/app/src/main/java/com/amaze/filemanager/ui/fragments/FtpServerFragment.kt
+++ b/app/src/main/java/com/amaze/filemanager/ui/fragments/FtpServerFragment.kt
@@ -21,18 +21,16 @@
 package com.amaze.filemanager.ui.fragments
 
 import android.app.Activity.RESULT_OK
-import android.content.BroadcastReceiver
-import android.content.Context
-import android.content.Intent
-import android.content.IntentFilter
+import android.content.*
 import android.content.pm.PackageManager
 import android.graphics.drawable.ColorDrawable
 import android.net.ConnectivityManager
 import android.net.Uri
-import android.os.Build
-import android.os.Build.VERSION_CODES.*
+import android.os.Build.VERSION.SDK_INT
+import android.os.Build.VERSION_CODES.LOLLIPOP
+import android.os.Build.VERSION_CODES.M
+import android.os.Build.VERSION_CODES.O
 import android.os.Bundle
-import android.os.Environment
 import android.os.Process
 import android.provider.DocumentsContract
 import android.provider.DocumentsContract.EXTRA_INITIAL_URI
@@ -54,7 +52,6 @@ import com.afollestad.materialdialogs.folderselector.FolderChooserDialog
 import com.amaze.filemanager.R
 import com.amaze.filemanager.application.AppConfig
 import com.amaze.filemanager.asynchronous.services.ftp.FtpService
-import com.amaze.filemanager.asynchronous.services.ftp.FtpService.Companion.DEFAULT_PATH
 import com.amaze.filemanager.asynchronous.services.ftp.FtpService.Companion.KEY_PREFERENCE_PATH
 import com.amaze.filemanager.asynchronous.services.ftp.FtpService.Companion.getLocalInetAddress
 import com.amaze.filemanager.asynchronous.services.ftp.FtpService.Companion.isConnectedToLocalNetwork
@@ -203,7 +200,7 @@ class FtpServerFragment : Fragment(R.layout.fragment_ftp) {
                 return true
             }
             R.id.ftp_path -> {
-                if (Build.VERSION.SDK_INT >= M) {
+                if (shouldUseSafFileSystem()) {
                     activityResultHandlerOnFtpServerPathUpdate.launch(
                         Intent(Intent.ACTION_OPEN_DOCUMENT_TREE)
                     )
@@ -317,6 +314,14 @@ class FtpServerFragment : Fragment(R.layout.fragment_ftp) {
         menu.findItem(R.id.checkbox_ftp_secure).isChecked = securePreference
     }
 
+    private fun shouldUseSafFileSystem(): Boolean {
+        return mainActivity.prefs.getBoolean(
+            FtpService.KEY_PREFERENCE_SAF_FILESYSTEM,
+            false
+        ) &&
+            SDK_INT >= M
+    }
+
     private val mWifiReceiver: BroadcastReceiver = object : BroadcastReceiver() {
         override fun onReceive(context: Context, intent: Intent) {
             // connected to Wi-Fi or eth
@@ -376,7 +381,7 @@ class FtpServerFragment : Fragment(R.layout.fragment_ftp) {
             return registerForActivityResult(
                 ActivityResultContracts.StartActivityForResult()
             ) {
-                if (it.resultCode == RESULT_OK && Build.VERSION.SDK_INT >= LOLLIPOP) {
+                if (it.resultCode == RESULT_OK && SDK_INT >= LOLLIPOP) {
                     val directoryUri = it.data?.data ?: return@registerForActivityResult
                     requireContext().contentResolver.takePersistableUriPermission(
                         directoryUri, GRANT_URI_RW_PERMISSION
@@ -386,12 +391,11 @@ class FtpServerFragment : Fragment(R.layout.fragment_ftp) {
             }
         }
 
-    /** Check URI access if  */
+    /** Check URI access. Prompt user to DocumentsUI if necessary */
     private fun checkUriAccessIfNecessary(callback: () -> Unit) {
-        if (Build.VERSION.SDK_INT >= M) {
-            val directoryUri: String = mainActivity.prefs.getString(
-                KEY_PREFERENCE_PATH, DEFAULT_PATH
-            )!!
+        val directoryUri: String = mainActivity.prefs
+            .getString(KEY_PREFERENCE_PATH, defaultPathFromPreferences)!!
+        if (shouldUseSafFileSystem()) {
             Uri.parse(directoryUri).run {
                 if (requireContext().checkUriPermission(
                         this, Process.myPid(), Process.myUid(),
@@ -411,15 +415,18 @@ class FtpServerFragment : Fragment(R.layout.fragment_ftp) {
                             .onPositive { dialog, _ ->
                                 activityResultHandlerOnFtpServerPathGrantedSafAccess.launch(
                                     Intent(Intent.ACTION_OPEN_DOCUMENT_TREE).also {
-                                        if (Build.VERSION.SDK_INT >= O &&
-                                            directoryUri.startsWith(DEFAULT_PATH)
+                                        if (SDK_INT >= O &&
+                                            directoryUri.startsWith(defaultPathFromPreferences)
                                         ) {
                                             it.putExtra(
                                                 EXTRA_INITIAL_URI,
                                                 DocumentsContract.buildDocumentUri(
                                                     "com.android.externalstorage.documents",
                                                     "primary:" +
-                                                        directoryUri.substringAfter(DEFAULT_PATH)
+                                                        directoryUri
+                                                            .substringAfter(
+                                                                defaultPathFromPreferences
+                                                            )
                                                 )
                                             )
                                         }
@@ -433,6 +440,16 @@ class FtpServerFragment : Fragment(R.layout.fragment_ftp) {
                 }
             }
         } else {
+            if (directoryUri.startsWith(ContentResolver.SCHEME_CONTENT)) {
+                AppConfig.toast(
+                    mainActivity,
+                    getString(R.string.ftp_server_fallback_path_reset_prompt)
+                )
+                mainActivity.prefs
+                    .edit()
+                    .putString(KEY_PREFERENCE_PATH, FtpService.defaultPath(requireContext()))
+                    .apply()
+            }
             callback.invoke()
         }
     }
@@ -532,7 +549,7 @@ class FtpServerFragment : Fragment(R.layout.fragment_ftp) {
     private fun updatePathText() {
         val sb = StringBuilder(resources.getString(R.string.ftp_path))
             .append(": ")
-            .append(defaultPathFromPreferences)
+            .append(pathToDisplayString(defaultPathFromPreferences))
         if (readonlyPreference) sb.append(" \uD83D\uDD12")
         sharedPath.text = sb.toString()
     }
@@ -678,23 +695,18 @@ class FtpServerFragment : Fragment(R.layout.fragment_ftp) {
 
     private val defaultPathFromPreferences: String
         get() {
-            return pathToDisplayString(
-                PreferenceManager.getDefaultSharedPreferences(activity)
-                    .getString(FtpService.KEY_PREFERENCE_PATH, FtpService.DEFAULT_PATH)!!
-            )
+            return PreferenceManager.getDefaultSharedPreferences(activity)
+                .getString(KEY_PREFERENCE_PATH, FtpService.defaultPath(requireContext()))!!
         }
 
     private fun pathToDisplayString(path: String): String {
         return when {
-            path == FtpService.DEFAULT_PATH -> {
-                Environment.getExternalStorageDirectory().absolutePath
-            }
             path.startsWith("file:///") -> {
                 path.substringAfter("file://")
             }
             path.startsWith("content://") -> {
                 return Uri.parse(path).let {
-                    "/storage${it.path?.replace(':', '/')}"
+                    "/storage${it.path?.substringAfter("/tree")?.replace(':', '/')}"
                 }
             }
             else -> {

--- a/app/src/main/res/menu/ftp_server_menu.xml
+++ b/app/src/main/res/menu/ftp_server_menu.xml
@@ -20,4 +20,8 @@
     <item
         android:id="@+id/ftp_timeout"
         android:title="@string/ftp_timeout" />
+    <item
+        android:id="@+id/checkbox_ftp_legacy_filesystem"
+        android:title="@string/ftp_preference_saf_filesystem_title"
+        android:checkable="true" />
 </menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -712,7 +712,7 @@
     <string name="ftp_prompt_accept_first_start_saf_access">Since this is your first run of the FTP server, and you are using the device\'s internal storage as shared folder, please allow Amaze to access the storage using SAF.\n\n
 
 You only need to do this once, until the next time you select a new location for sharing.</string>
-    <string name="ftp_preference_saf_filesystem_title">Storage Access Framework based filesystem</string>
+    <string name="ftp_preference_saf_filesystem_title">Use legacy filesystem</string>
     <string name="ftp_preference_saf_filesystem">Enable this for support for using device external storage on newer Android versions</string>
     <string name="ftp_server_fallback_path_reset_prompt">FTP server shared path had been resetted to internal storage as you are switching back to legacy filesystem implementation. Please select a new path using the menu on the top right as necessary.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -712,5 +712,8 @@
     <string name="ftp_prompt_accept_first_start_saf_access">Since this is your first run of the FTP server, and you are using the device\'s internal storage as shared folder, please allow Amaze to access the storage using SAF.\n\n
 
 You only need to do this once, until the next time you select a new location for sharing.</string>
+    <string name="ftp_preference_saf_filesystem_title">Storage Access Framework based filesystem</string>
+    <string name="ftp_preference_saf_filesystem">Enable this for support for using device external storage on newer Android versions</string>
+    <string name="ftp_server_fallback_path_reset_prompt">FTP server shared path had been resetted to internal storage as you are switching back to legacy filesystem implementation. Please select a new path using the menu on the top right as necessary.</string>
 </resources>
 

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -130,14 +130,6 @@
         </com.amaze.filemanager.ui.views.preference.CheckBox>
     </PreferenceCategory>
 
-    <PreferenceCategory app:title="@string/ftp">
-        <com.amaze.filemanager.ui.views.preference.CheckBox
-            app:defaultValue="false"
-            app:key="ftp_saf_filesystem"
-            app:summary="@string/ftp_preference_saf_filesystem"
-            app:title="@string/ftp_preference_saf_filesystem_title"/>
-    </PreferenceCategory>
-
     <PreferenceCategory app:title="@string/miscellaneous">
         <Preference
             app:key="advancedsearch"

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -130,6 +130,14 @@
         </com.amaze.filemanager.ui.views.preference.CheckBox>
     </PreferenceCategory>
 
+    <PreferenceCategory app:title="@string/ftp">
+        <com.amaze.filemanager.ui.views.preference.CheckBox
+            app:defaultValue="false"
+            app:key="ftp_saf_filesystem"
+            app:summary="@string/ftp_preference_saf_filesystem"
+            app:title="@string/ftp_preference_saf_filesystem_title"/>
+    </PreferenceCategory>
+
     <PreferenceCategory app:title="@string/miscellaneous">
         <Preference
             app:key="advancedsearch"


### PR DESCRIPTION
As of 3.6.x cycle the DocumentFile-based implementation for FTP server is causing problems to a number of users. This PR adds an option to allow user to fallback to the original java.io.File based filesystem.

If user had been using the DocumentFile-based UI but changed back to java.io.File based filesystem, shared path will be reset to internal storage's root; user will need to change the path on their own.

(It should be possible to help users to migrate the path between the two FTP filesystem implementations however.)

I am making this against 3.6.2, but just take it against 3.7 if you think it's better.

#### Automatic tests
- [ ] Added test cases
  
#### Manual tests
- [x] Done  
  
- Device: Fairphone 3
- OS: LineageOS 16.0 (9.0)
- Device: Pixel 2 emulator
- OS: Android 11

#### Build tasks success  
<!-- run these! -->
Successfully running following tasks on local:
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`