### PR TITLE
Remove log message truncation in Github CI actions

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -6,7 +6,6 @@ on:
       - '*'
       - '!master'
       - '!release/*'
-      -
 concurrency:
   group: build-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -22,9 +22,9 @@ jobs:
           distribution: "adopt"
           java-version: 11
       - name: Check formatting using spotless
-        run: ./gradlew spotlessCheck --stacktrace | grep -vE 'Transform|Build cache is disabled|history is available.'
+        run: ./gradlew spotlessCheck --stacktrace
       - name: Build with Gradle
         run: |
-          ./gradlew assembledebug --stacktrace | grep -vE 'Transform|Build cache is disabled|history is available.'
+          ./gradlew assembledebug --stacktrace
         env:
           TZ: UTC

--- a/.github/workflows/android-debug-artifact-ondemand.yml
+++ b/.github/workflows/android-debug-artifact-ondemand.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Build with Gradle
         run: |
           echo Run on-demand by ${GITHUB_ACTOR}
-          bash ./gradlew assembleDebug --stacktrace | grep -vE 'Transform|Build cache is disabled|history is available.'
+          bash ./gradlew assembleDebug --stacktrace
         env:
           TZ: UTC
       - name: Upload fdroid artifact

--- a/.github/workflows/android-debug-artifact-release.yml
+++ b/.github/workflows/android-debug-artifact-release.yml
@@ -16,7 +16,7 @@ jobs:
           java-version: 11
       - name: Build with Gradle
         run: |
-          bash ./gradlew assembleDebug --stacktrace | grep -vE 'Transform|Build cache is disabled|history is available.'
+          bash ./gradlew assembleDebug
         env:
           TZ: UTC
       - name: Upload fdroid artifact

--- a/.github/workflows/android-feature.yml
+++ b/.github/workflows/android-feature.yml
@@ -33,7 +33,7 @@ jobs:
         env:
           TZ: UTC
       - name: Publish test cases
+        if: always()
         run: |
           export CODACY_PROJECT_TOKEN=${{ secrets.CODACY_TOKEN }}
           bash <(curl -Ls https://coverage.codacy.com/get.sh)
-        continue-on-error: true

--- a/.github/workflows/android-feature.yml
+++ b/.github/workflows/android-feature.yml
@@ -33,7 +33,6 @@ jobs:
         env:
           TZ: UTC
       - name: Publish test cases
-        if: always()
         run: |
           export CODACY_PROJECT_TOKEN=${{ secrets.CODACY_TOKEN }}
           bash <(curl -Ls https://coverage.codacy.com/get.sh)

--- a/.github/workflows/android-feature.yml
+++ b/.github/workflows/android-feature.yml
@@ -22,17 +22,18 @@ jobs:
           distribution: "adopt"
           java-version: 11
       - name: Check formatting using spotless
-        run: ./gradlew spotlessCheck --stacktrace | grep -vE 'Transform|Build cache is disabled|history is available.'
+        run: ./gradlew spotlessCheck --stacktrace
       - name: Build with Gradle
         run: |
-          ./gradlew assembledebug --stacktrace | grep -vE 'Transform|Build cache is disabled|history is available.'
+          ./gradlew assembledebug --stacktrace
         env:
           TZ: UTC
       - name: Run test cases
-        run: ./gradlew jacocoTestPlayDebugUnitTestReport --stacktrace --info | grep -vE 'Transform|Build cache is disabled|history is available.'
+        run: ./gradlew jacocoTestPlayDebugUnitTestReport --stacktrace --info
         env:
           TZ: UTC
       - name: Publish test cases
+        if: always()
         run: |
           export CODACY_PROJECT_TOKEN=${{ secrets.CODACY_TOKEN }}
           bash <(curl -Ls https://coverage.codacy.com/get.sh)

--- a/.github/workflows/android-main.yml
+++ b/.github/workflows/android-main.yml
@@ -32,7 +32,6 @@ jobs:
         env:
           TZ: UTC
       - name: Publish test cases
-        if: always()
         run: |
           export CODACY_PROJECT_TOKEN=${{ secrets.CODACY_TOKEN }}
           bash <(curl -Ls https://coverage.codacy.com/get.sh)

--- a/.github/workflows/android-main.yml
+++ b/.github/workflows/android-main.yml
@@ -32,6 +32,7 @@ jobs:
         env:
           TZ: UTC
       - name: Publish test cases
+        if: always()
         run: |
           export CODACY_PROJECT_TOKEN=${{ secrets.CODACY_TOKEN }}
           bash <(curl -Ls https://coverage.codacy.com/get.sh)

--- a/.github/workflows/android-main.yml
+++ b/.github/workflows/android-main.yml
@@ -21,17 +21,18 @@ jobs:
           distribution: "adopt"
           java-version: 11
       - name: Check formatting using spotless
-        run: ./gradlew spotlessCheck --stacktrace | grep -vE 'Transform|Build cache is disabled|history is available.'
+        run: ./gradlew spotlessCheck
       - name: Build with Gradle
         run: |
-          ./gradlew assembledebug --stacktrace | grep -vE 'Transform|Build cache is disabled|history is available.'
+          ./gradlew assembledebug
         env:
           TZ: UTC
       - name: Run test cases
-        run: ./gradlew jacocoTestPlayDebugUnitTestReport --stacktrace | grep -vE 'Transform|Build cache is disabled|history is available.'
+        run: ./gradlew jacocoTestPlayDebugUnitTestReport
         env:
           TZ: UTC
       - name: Publish test cases
+        if: always()
         run: |
           export CODACY_PROJECT_TOKEN=${{ secrets.CODACY_TOKEN }}
           bash <(curl -Ls https://coverage.codacy.com/get.sh)

--- a/app/src/test/java/com/amaze/filemanager/utils/UtilsTest.java
+++ b/app/src/test/java/com/amaze/filemanager/utils/UtilsTest.java
@@ -61,12 +61,8 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 public class UtilsTest {
 
   @Test
-  public void testFailTheTests() {
-    assertEquals(3, 1+1);
-  }
-
-  @Test
-  public void testSanitizeInput() { // This function is sanitize the string. It removes ";","|","&&","..."
+  public void testSanitizeInput() {
+    // This function is sanitize the string. It removes ";","|","&&","..."
     // from string.
     assertEquals("a", sanitizeInput("|a|")); // test the removing of pipe sign from string.
     assertEquals("a", sanitizeInput("...a...")); // test the removing of dots from string.

--- a/app/src/test/java/com/amaze/filemanager/utils/UtilsTest.java
+++ b/app/src/test/java/com/amaze/filemanager/utils/UtilsTest.java
@@ -61,8 +61,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 public class UtilsTest {
 
   @Test
-  public void testSanitizeInput() {
-    // This function is sanitize the string. It removes ";","|","&&","..."
+  public void testSanitizeInput() {                 // This function is sanitize the string. It removes ";","|","&&","..."
     // from string.
     assertEquals("a", sanitizeInput("|a|")); // test the removing of pipe sign from string.
     assertEquals("a", sanitizeInput("...a...")); // test the removing of dots from string.

--- a/app/src/test/java/com/amaze/filemanager/utils/UtilsTest.java
+++ b/app/src/test/java/com/amaze/filemanager/utils/UtilsTest.java
@@ -61,7 +61,8 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 public class UtilsTest {
 
   @Test
-  public void testSanitizeInput() {                 // This function is sanitize the string. It removes ";","|","&&","..."
+  public void testSanitizeInput() {
+    // This function is sanitize the string. It removes ";","|","&&","..."
     // from string.
     assertEquals("a", sanitizeInput("|a|")); // test the removing of pipe sign from string.
     assertEquals("a", sanitizeInput("...a...")); // test the removing of dots from string.

--- a/app/src/test/java/com/amaze/filemanager/utils/UtilsTest.java
+++ b/app/src/test/java/com/amaze/filemanager/utils/UtilsTest.java
@@ -59,6 +59,12 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 @RunWith(AndroidJUnit4.class)
 @Config(sdk = {JELLY_BEAN, KITKAT, P})
 public class UtilsTest {
+
+  @Test
+  public void testFailTheTests() {
+    assertEquals(3, 1+1);
+  }
+
   @Test
   public void
       testSanitizeInput() { // This function is sanitize the string. It removes ";","|","&&","..."

--- a/app/src/test/java/com/amaze/filemanager/utils/UtilsTest.java
+++ b/app/src/test/java/com/amaze/filemanager/utils/UtilsTest.java
@@ -66,8 +66,7 @@ public class UtilsTest {
   }
 
   @Test
-  public void
-      testSanitizeInput() { // This function is sanitize the string. It removes ";","|","&&","..."
+  public void testSanitizeInput() { // This function is sanitize the string. It removes ";","|","&&","..."
     // from string.
     assertEquals("a", sanitizeInput("|a|")); // test the removing of pipe sign from string.
     assertEquals("a", sanitizeInput("...a...")); // test the removing of dots from string.

--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ buildscript {
 }
 
 plugins {
-    id "com.diffplug.gradle.spotless" version "4.3.0"
+    id "com.diffplug.spotless" version "5.14.2"
 }
 
 allprojects {


### PR DESCRIPTION
Fixes #2717.

In fact, it seems [only we truncate log messages](https://github.com/search?l=YAML&q=gradlew+spotlessCheck+grep&type=Code).