### PR TITLE
fix issue 2731 : Added catch for ShellCommandInvalidException

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/filesystem/root/RenameFileCommand.kt
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/root/RenameFileCommand.kt
@@ -38,8 +38,13 @@ object RenameFileCommand : IRootCommand() {
         val mountPoint = MountPathCommand.mountPath(oldPath, MountPathCommand.READ_WRITE)
         val command = "mv \"${RootHelper.getCommandLineString(oldPath)}\"" +
             " \"${RootHelper.getCommandLineString(newPath)}\""
-        val output = runShellCommandToList(command)
-        mountPoint?.let { MountPathCommand.mountPath(it, MountPathCommand.READ_ONLY) }
-        return output.isEmpty()
+        return try {
+            val output = runShellCommandToList(command)
+            mountPoint?.let { MountPathCommand.mountPath(it, MountPathCommand.READ_ONLY) }
+            output.isEmpty()
+        }catch(e: ShellCommandInvalidException){
+            e.printStackTrace()
+            false
+        }
     }
 }


### PR DESCRIPTION
<!-- 
Read this first:
To open a pull request read this file,
uncomment the corresponding lines and 
complete them.
-->

## Description
when changing file name of system file, the shell returns exit code 1 (i.e not permitted)  and thus the exception is triggered, added a catch for ShellCommandInvalidException and fixed the issue

#### Issue tracker  
Fixes #2731 
<!-- Fixes will automatically close the related issue -->
<!-- Fixes # -->
<!-- Addresses won't automatically close the related issue -->
<!-- Addresses # -->

#### Automatic tests
<!-- remember to do manual testing when making UI changes! -->
- [ ] Added test cases
  
#### Manual tests
- [x] Done  
  
<!-- If yes, -->
<!-- 
- Device:
- OS:
-->

#### Build tasks success  
<!-- run these! -->
Successfully running following tasks on local:
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`

<!-- If there are related PRs please add them here -->
<!--
#### Related PR  
Related to PR #
-->