### PR TITLE
ZipService fixes for #2686

### DIFF
--- a/app/src/test/java/com/amaze/filemanager/asynchronous/services/ZipServiceTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/asynchronous/services/ZipServiceTest.kt
@@ -32,8 +32,7 @@ import com.amaze.filemanager.shadows.ShadowMultiDex
 import net.lingala.zip4j.ZipFile
 import net.lingala.zip4j.model.FileHeader
 import org.awaitility.Awaitility.await
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
+import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -115,17 +114,20 @@ class ZipServiceTest {
         await().atMost(10, TimeUnit.SECONDS).until { zipPath.length() > 0 }
         val verify = ZipFile(zipPath)
         val entries = verify.fileHeaders
-        assertEquals(files.size, entries.size)
+        assertEquals(files.filter { it.isFile }.size, entries.size)
         entries.sortBy { it.fileName }
-        verify.fileHeaders.forEachIndexed { idx: Int, any: Any? ->
-            run {
-                val entry = any as FileHeader
-                assertEquals(
-                    "${entry.fileName} timestamp not equal. " +
-                        "${Date(files[idx].lastModified())} " +
-                        "vs ${Date(entry.lastModifiedTimeEpoch)}",
-                    files[idx].lastModified(), entry.lastModifiedTimeEpoch
-                )
+        files.filter { it.isFile }.run {
+            verify.fileHeaders.forEachIndexed { idx: Int, any: Any? ->
+                run {
+                    val entry = any as FileHeader
+                    assertFalse(entry.fileName.startsWith('/'))
+                    assertEquals(
+                        "${entry.fileName} timestamp not equal. " +
+                            "${Date(this[idx].lastModified())} " +
+                            "vs ${Date(entry.lastModifiedTimeEpoch)}",
+                        this[idx].lastModified(), entry.lastModifiedTimeEpoch
+                    )
+                }
             }
         }
     }


### PR DESCRIPTION
## Description
- Do not append / to each zip entry
- Do not add directory itself as zip entry

#### Issue tracker   
Fixes #2686

#### Automatic tests
<!-- remember to do manual testing when making UI changes! -->
- [x] Added test cases
  
#### Manual tests
- [x] Done  
  
Device: Pixel 2 emulator
OS: Android 11
Test cases:
- Zip a folder on Android with Amaze
- Zip 2 folders and a file Android with Amaze

Both zip files should be
- opened properly on Amaze
- opened properly on Windows Explorer and 7zip File Manager
- on Linux, File Roller should be able to open the zip properly too
- No files the same name as folder should be visible when viewing the zip files

#### Build tasks success  
<!-- run these! -->
Successfully running following tasks on local:
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`