### PR TITLE
CompressedExplorerFragment refactorings

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/adapters/CompressedExplorerAdapter.java
+++ b/app/src/main/java/com/amaze/filemanager/adapters/CompressedExplorerAdapter.java
@@ -153,7 +153,7 @@ public class CompressedExplorerAdapter extends RecyclerView.Adapter<CompressedIt
       compressedExplorerFragment.mActionModeCallback);*/
       compressedExplorerFragment.mActionMode =
           compressedExplorerFragment
-              .getMainActivity()
+              .requireMainActivity()
               .getAppbar()
               .getToolbar()
               .startActionMode(compressedExplorerFragment.mActionModeCallback);

--- a/app/src/main/java/com/amaze/filemanager/ui/drag/RecyclerAdapterDragListener.kt
+++ b/app/src/main/java/com/amaze/filemanager/ui/drag/RecyclerAdapterDragListener.kt
@@ -142,7 +142,7 @@ class RecyclerAdapterDragListener(
                     var currentFileParcelable: HybridFileParcelable? = null
                     var isCurrentElementDirectory: Boolean? = null
                     var isEmptyArea: Boolean? = null
-                    var pasteLocation: String = if (adapter.itemsDigested.size == 0) {
+                    var pasteLocation: String? = if (adapter.itemsDigested.size == 0) {
                         mainFragment.currentPath
                     } else {
                         if (holder == null || holder.adapterPosition == RecyclerView.NO_POSITION) {
@@ -226,7 +226,7 @@ class RecyclerAdapterDragListener(
                             ).format(pasteLocation)
                     )
                     DragAndDropDialog.showDialogOrPerformOperation(
-                        pasteLocation,
+                        pasteLocation!!,
                         arrayList, mainFragment.mainActivity
                     )
                     adapter.toggleChecked(false)

--- a/app/src/main/java/com/amaze/filemanager/ui/fragments/CompressedExplorerFragment.kt
+++ b/app/src/main/java/com/amaze/filemanager/ui/fragments/CompressedExplorerFragment.kt
@@ -242,7 +242,7 @@ class CompressedExplorerFragment : Fragment(), BottomBarButtonPath {
     }
 
     private fun prepareCompressedFile(pathArg: String): String {
-        var fileName: String? = null
+        lateinit var fileName: String
         val pathUri = Uri.parse(pathArg)
         if (ContentResolver.SCHEME_CONTENT == pathUri.scheme) {
             requireContext()
@@ -285,11 +285,11 @@ class CompressedExplorerFragment : Fragment(), BottomBarButtonPath {
                     }
                 }
         } else {
-            compressedFile = File(pathUri.path).also {
+            compressedFile = File(pathUri.path!!).also {
                 fileName = it.name.substring(0, it.name.lastIndexOf("."))
             }
         }
-        return fileName!!
+        return fileName
     }
 
     override fun onSaveInstanceState(outState: Bundle) {

--- a/app/src/main/java/com/amaze/filemanager/ui/fragments/CompressedExplorerFragment.kt
+++ b/app/src/main/java/com/amaze/filemanager/ui/fragments/CompressedExplorerFragment.kt
@@ -113,12 +113,12 @@ class CompressedExplorerFragment : Fragment(), BottomBarButtonPath {
     var showLastModified = false
     var gobackitem = false
     var listView: RecyclerView? = null
-    var swipeRefreshLayout: SwipeRefreshLayout? = null
+    lateinit var swipeRefreshLayout: SwipeRefreshLayout
     /** flag states whether to open file after service extracts it */
     @JvmField
     var isOpen = false
-    private var fastScroller: FastScroller? = null
-    private var decompressor: Decompressor? = null
+    private lateinit var fastScroller: FastScroller
+    private lateinit var decompressor: Decompressor
     private var addheader = true
     private var dividerItemDecoration: DividerItemDecoration? = null
     private var showDividers = false
@@ -129,7 +129,7 @@ class CompressedExplorerFragment : Fragment(), BottomBarButtonPath {
     private var isCachedCompressedFile = false
     private val offsetListenerForToolbar =
         OnOffsetChangedListener { appBarLayout: AppBarLayout?, verticalOffset: Int ->
-            fastScroller?.updateHandlePosition(verticalOffset, 112)
+            fastScroller.updateHandlePosition(verticalOffset, 112)
         }
 
     override fun onCreateView(
@@ -161,7 +161,7 @@ class CompressedExplorerFragment : Fragment(), BottomBarButtonPath {
             { elements ->
                 viewModel.folder?.run {
                     createViews(elements, this)
-                    swipeRefreshLayout?.isRefreshing = false
+                    swipeRefreshLayout.isRefreshing = false
                     updateBottomBar()
                 }
             }
@@ -428,7 +428,7 @@ class CompressedExplorerFragment : Fragment(), BottomBarButtonPath {
                                     .value!![it.checkedItemPositions[i]].path
                             i++
                         }
-                        decompressor?.decompress(compressedFile.path, dirs)
+                        decompressor.decompress(compressedFile.path, dirs)
                         mode.finish()
                         return true
                     }
@@ -515,7 +515,7 @@ class CompressedExplorerFragment : Fragment(), BottomBarButtonPath {
         var folder = path
         if (folder.startsWith("/")) folder = folder.substring(1)
         val addGoBackItem = gobackitem && !isRoot(folder)
-        decompressor?.let {
+        decompressor.let {
             it.changePath(
                 folder,
                 addGoBackItem,
@@ -535,7 +535,7 @@ class CompressedExplorerFragment : Fragment(), BottomBarButtonPath {
                     }
                 }
             ).execute()
-            swipeRefreshLayout?.isRefreshing = true
+            swipeRefreshLayout.isRefreshing = true
             updateBottomBar()
         } ?: archiveCorruptOrUnsupportedToast(null)
     }
@@ -612,7 +612,7 @@ class CompressedExplorerFragment : Fragment(), BottomBarButtonPath {
         listView?.stopScroll()
         relativeDirectory = dir
         updateBottomBar()
-        swipeRefreshLayout?.isRefreshing = false
+        swipeRefreshLayout.isRefreshing = false
     }
 
     /**

--- a/app/src/main/java/com/amaze/filemanager/ui/fragments/MainFragment.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/fragments/MainFragment.java
@@ -1814,6 +1814,7 @@ public class MainFragment extends Fragment
     }
   }
 
+  @Nullable
   public String getCurrentPath() {
     if (mainFragmentViewModel == null) {
       Log.w(getClass().getSimpleName(), "Viewmodel not available to get current path");
@@ -1823,7 +1824,7 @@ public class MainFragment extends Fragment
   }
 
   @Override
-  public void changePath(String path) {
+  public void changePath(@NonNull String path) {
     loadlist(path, false, mainFragmentViewModel.getOpenMode());
   }
 

--- a/app/src/main/java/com/amaze/filemanager/utils/BottomBarButtonPath.kt
+++ b/app/src/main/java/com/amaze/filemanager/utils/BottomBarButtonPath.kt
@@ -24,14 +24,12 @@ import androidx.annotation.DrawableRes
 
 /**
  * This lets BottomBar be independent of the Fragment MainActivity is housing
- *
- * @author Emmanuel on 20/8/2017, at 13:35.
  */
 interface BottomBarButtonPath {
     /**
      * This allows the fragment to change the path represented in the BottomBar directly
      */
-    fun changePath(path: String?)
+    fun changePath(path: String)
     val path: String?
 
     @get:DrawableRes


### PR DESCRIPTION
## Description
Continuation of #2754 to improve code quality after converting CompressedExplorerFragment to Kotlin.

~~Although based on 3.6.2, not necessarily to be included in 3.6.2 release.~~

#### Automatic tests
<!-- remember to do manual testing when making UI changes! -->
- [ ] Added test cases
  
#### Manual tests
- [x] Done  
  
- Device: Pixel 2 emulator
- OS: Android 11
Test for basic functionality for possible regressions

#### Build tasks success  
<!-- run these! -->
Successfully running following tasks on local:
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`