### PR TITLE
Trap IOException on stat() failures

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/filesystem/HybridFile.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/HybridFile.java
@@ -470,11 +470,10 @@ public class HybridFile {
                       .stat(SshClientUtils.extractRemotePathFrom(path))
                       .getType()
                       .equals(FileMode.Type.DIRECTORY);
-                } catch (SFTPException notFound) {
+                } catch (IOException executionFailure) {
                   Log.e(
-                      getClass().getSimpleName(),
-                      "Fail to execute isDirectory for SFTP path :" + path);
-                  notFound.printStackTrace();
+                      TAG, "Fail to execute isDirectory for SFTP path :" + path, executionFailure);
+                  executionFailure.printStackTrace();
                   return false;
                 }
               }

--- a/app/src/main/java/com/amaze/filemanager/filesystem/HybridFile.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/HybridFile.java
@@ -521,7 +521,8 @@ public class HybridFile {
                     } catch (IOException notFound) {
                       Log.e(
                           getClass().getSimpleName(),
-                          "Fail to execute isDirectory for SFTP path :" + path, notFound);
+                          "Fail to execute isDirectory for SFTP path :" + path,
+                          notFound);
                       return false;
                     }
                   }


### PR DESCRIPTION
## Description
As band-it solution to prevent crash, by trapping IOException that would cause containing SftpTemplate to not return anything (but null).

#### Issue tracker   
Addresses #2779

#### Automatic tests
<!-- remember to do manual testing when making UI changes! -->
- [ ] Added test cases
  
#### Manual tests
- [ ] Done  
  
#### Build tasks success  
<!-- run these! -->
Successfully running following tasks on local:
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`