### PR TITLE
Google Drive compliance changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Support
 <a href="https://opencollective.com/TeamAmaze"><img width="20%" alt="OpenCollective" src="opencollective.svg" ></a>
 <a href="https://www.paypal.me/vishalnehra"><img width="20%" src="paypal.svg" alt="PayPal"></a>
 <a href="https://liberapay.com/Team-Amaze/donate"><img src="https://upload.wikimedia.org/wikipedia/commons/2/27/Liberapay_logo_v2_white-on-yellow.svg" alt="Liberapay" width="80px" ></a>  
-Or buy the [Cloud Plugin](https://play.google.com/store/apps/details?id=com.filemanager.amazecloud) supports Google Drive, Dropbox, OneDrive and Box accounts.  
+Or buy the [Cloud Plugin](https://play.google.com/store/apps/details?id=com.filemanager.amazecloud) supports Google Drive™, Dropbox, OneDrive and Box accounts.  
 
 Warning
 ---

--- a/app/src/main/java/com/amaze/filemanager/database/CloudHandler.java
+++ b/app/src/main/java/com/amaze/filemanager/database/CloudHandler.java
@@ -42,7 +42,7 @@ public class CloudHandler {
   public static final String CLOUD_PREFIX_GOOGLE_DRIVE = "gdrive:/";
   public static final String CLOUD_PREFIX_ONE_DRIVE = "onedrive:/";
 
-  public static final String CLOUD_NAME_GOOGLE_DRIVE = "Google Drive";
+  public static final String CLOUD_NAME_GOOGLE_DRIVE = "Google Drive™";
   public static final String CLOUD_NAME_DROPBOX = "Dropbox";
   public static final String CLOUD_NAME_ONE_DRIVE = "One Drive";
   public static final String CLOUD_NAME_BOX = "Box";

--- a/app/src/main/res/layout/fragment_sheet_cloud.xml
+++ b/app/src/main/res/layout/fragment_sheet_cloud.xml
@@ -143,6 +143,7 @@
                 />
 
             <com.amaze.filemanager.ui.views.ThemedTextView
+                android:tooltipText="@string/cloud_drive_tooltip"
                 android:text="@string/cloud_drive"
                 android:textColor="@android:color/darker_gray"
                 android:textSize="@dimen/material_generic_title"

--- a/app/src/main/res/values-be-rBY/strings.xml
+++ b/app/src/main/res/values-be-rBY/strings.xml
@@ -432,7 +432,7 @@
   <string name="cloud_connection">Падключэнне да воблака</string>
   <string name="cloud_connection_new">Новае падключэнне да воблака</string>
   <string name="cloud_dropbox">Dropbox</string>
-  <string name="cloud_drive">Google Дыск</string>
+  <string name="cloud_drive">Google Дыск&#8482;</string>
   <string name="cloud_onedrive">OneDrive</string>
   <string name="cloud_box">Box</string>
   <string name="cloud_get">Атрымаць плагін Воблака</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -432,7 +432,7 @@
     <string name="cloud_connection">Připojení ke cloudu</string>
     <string name="cloud_connection_new">Nové připojení ke cloudu</string>
     <string name="cloud_dropbox">Dropbox</string>
-    <string name="cloud_drive">Disk Google</string>
+    <string name="cloud_drive">Disk Google&#8482;</string>
     <string name="cloud_onedrive">OneDrive</string>
     <string name="cloud_box">Box</string>
     <string name="cloud_get">Získat Cloud plugin</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -408,7 +408,7 @@ andernfalls wird nach Treffern gesucht.</string>
     <string name="cloud_connection">Cloud-Verknüpfung</string>
     <string name="cloud_connection_new">Neue Cloud-Verknüpfung</string>
     <string name="cloud_dropbox">Dropbox</string>
-    <string name="cloud_drive">Google Drive</string>
+    <string name="cloud_drive">Google Drive&#8482;</string>
     <string name="cloud_onedrive">OneDrive</string>
     <string name="cloud_box">Box</string>
     <string name="cloud_get">Suche nach Cloud Plugins</string>

--- a/app/src/main/res/values-eo/strings.xml
+++ b/app/src/main/res/values-eo/strings.xml
@@ -453,7 +453,7 @@
     <string name="cloud_connection">Nuba konekto</string>
     <string name="cloud_connection_new">Nova nuba konekto</string>
     <string name="cloud_dropbox">Dropbox</string>
-    <string name="cloud_drive">Google Drive</string>
+    <string name="cloud_drive">Google Drive&#8482;</string>
     <string name="cloud_onedrive">OneDrive</string>
     <string name="cloud_box">Box</string>
     <string name="cloud_get">Get nuba aldonaĵo</string>

--- a/app/src/main/res/values-es-rUS/strings.xml
+++ b/app/src/main/res/values-es-rUS/strings.xml
@@ -434,7 +434,7 @@
   <string name="cloud_connection">Conexión con la nube</string>
   <string name="cloud_connection_new">Nueva conexión con la nube</string>
   <string name="cloud_dropbox">Dropbox</string>
-  <string name="cloud_drive">Google Drive</string>
+  <string name="cloud_drive">Google Drive&#8482;</string>
   <string name="cloud_onedrive">OneDrive</string>
   <string name="cloud_box">Box</string>
   <string name="cloud_get">Obtener plugin de la nube</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -457,7 +457,7 @@
     <string name="cloud_connection">Conexión a la nube</string>
     <string name="cloud_connection_new">Nueva conexión a la nube</string>
     <string name="cloud_dropbox">Dropbox</string>
-    <string name="cloud_drive">Google Drive</string>
+    <string name="cloud_drive">Google Drive&#8482;</string>
     <string name="cloud_onedrive">OneDrive</string>
     <string name="cloud_box">Box</string>
     <string name="cloud_get">Obtener complemento para conectar a la nube</string>

--- a/app/src/main/res/values-eu-rES/strings.xml
+++ b/app/src/main/res/values-eu-rES/strings.xml
@@ -451,7 +451,7 @@
     <string name="cloud_connection">Hodeiko konexioa</string>
     <string name="cloud_connection_new">Hodeiko konexio berria</string>
     <string name="cloud_dropbox">Dropbox</string>
-    <string name="cloud_drive">Google Drive</string>
+    <string name="cloud_drive">Google Drive&#8482;</string>
     <string name="cloud_onedrive">OneDrive</string>
     <string name="cloud_box">Box</string>
     <string name="cloud_get">Eskuratu hodeiko plugina</string>

--- a/app/src/main/res/values-eu/strings.xml
+++ b/app/src/main/res/values-eu/strings.xml
@@ -455,7 +455,7 @@
     <string name="cloud_connection">Hodeiko konexioa</string>
     <string name="cloud_connection_new">Hodeiko konexio berria</string>
     <string name="cloud_dropbox">Dropbox</string>
-    <string name="cloud_drive">Google Drive</string>
+    <string name="cloud_drive">Google Drive&#8482;</string>
     <string name="cloud_onedrive">OneDrive</string>
     <string name="cloud_box">Box</string>
     <string name="cloud_get">Eskuratu hodeiko plugina</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -442,7 +442,7 @@
     <string name="cloud_connection">Pilvi yhteys</string>
     <string name="cloud_connection_new">Uusi Pilviyhteys</string>
     <string name="cloud_dropbox">Dropbox</string>
-    <string name="cloud_drive">Google Drive</string>
+    <string name="cloud_drive">Google Drive&#8482;</string>
     <string name="cloud_onedrive">OneDrive</string>
     <string name="cloud_box">Box</string>
     <string name="cloud_get">Hae pilvi-lisäosa</string>

--- a/app/src/main/res/values-fr-rCA/strings.xml
+++ b/app/src/main/res/values-fr-rCA/strings.xml
@@ -417,7 +417,7 @@
   <string name="cloud_connection">Connexion Cloud</string>
   <string name="cloud_connection_new">Nouvelle connexion Cloud</string>
   <string name="cloud_dropbox">Dropbox</string>
-  <string name="cloud_drive">Google Drive</string>
+  <string name="cloud_drive">Google Drive&#8482;</string>
   <string name="cloud_onedrive">OneDrive</string>
   <string name="cloud_box">Boîte</string>
   <string name="cloud_get">Téléchargez le plugin Cloud</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -438,7 +438,7 @@
     <string name="cloud_connection">Connexion cloud</string>
     <string name="cloud_connection_new">Nouvelle connexion cloud</string>
     <string name="cloud_dropbox">Dropbox</string>
-    <string name="cloud_drive">Google Drive</string>
+    <string name="cloud_drive">Google Drive&#8482;</string>
     <string name="cloud_onedrive">OneDrive</string>
     <string name="cloud_box">Boîte</string>
     <string name="cloud_get">Téléchargez le plugin Cloud</string>

--- a/app/src/main/res/values-he/strings.xml
+++ b/app/src/main/res/values-he/strings.xml
@@ -457,7 +457,7 @@
     <string name="cloud_connection">חיבור לענן</string>
     <string name="cloud_connection_new">חיבור חדש לענן</string>
     <string name="cloud_dropbox">Dropbox</string>
-    <string name="cloud_drive">Google Drive</string>
+    <string name="cloud_drive">Google Drive&#8482;</string>
     <string name="cloud_onedrive">OneDrive</string>
     <string name="cloud_box">Box</string>
     <string name="cloud_get">הורדת תוסף ענן</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -457,7 +457,7 @@
     <string name="cloud_connection">Felhő-kapcsolat</string>
     <string name="cloud_connection_new">Új felhő kapcsolat</string>
     <string name="cloud_dropbox">Dropbox</string>
-    <string name="cloud_drive">Google Drive</string>
+    <string name="cloud_drive">Google Drive&#8482;</string>
     <string name="cloud_onedrive">OneDrive</string>
     <string name="cloud_box">Box</string>
     <string name="cloud_get">Felhő beépülő letöltése</string>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -456,7 +456,7 @@
     <string name="cloud_connection">Koneksi Cloud</string>
     <string name="cloud_connection_new">Koneksi Cloud Baru</string>
     <string name="cloud_dropbox">Dropbox</string>
-    <string name="cloud_drive">Google Drive</string>
+    <string name="cloud_drive">Google Drive&#8482;</string>
     <string name="cloud_onedrive">OneDrive</string>
     <string name="cloud_box">Box</string>
     <string name="cloud_get">Dapatkan plugin Cloud</string>

--- a/app/src/main/res/values-is/strings.xml
+++ b/app/src/main/res/values-is/strings.xml
@@ -455,7 +455,7 @@
     <string name="cloud_connection">Skýjatenging</string>
     <string name="cloud_connection_new">Ný tenging við tölvuský</string>
     <string name="cloud_dropbox">Dropbox</string>
-    <string name="cloud_drive">Google Drive</string>
+    <string name="cloud_drive">Google Drive&#8482;</string>
     <string name="cloud_onedrive">OneDrive</string>
     <string name="cloud_box">Box</string>
     <string name="cloud_get">Ná í Cloud-plugin skýjaviðbót</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -412,7 +412,7 @@ altrimenti verrà controllata solo l\'occorrenza.</string>
     <string name="cloud_connection">Connessione cloud</string>
     <string name="cloud_connection_new">Nuova connessione Cloud</string>
     <string name="cloud_dropbox">Dropbox</string>
-    <string name="cloud_drive">Google Drive</string>
+    <string name="cloud_drive">Google Drive&#8482;</string>
     <string name="cloud_onedrive">OneDrive</string>
     <string name="cloud_box">Box</string>
     <string name="cloud_get">Scarica Cloud plugin</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -452,7 +452,7 @@ Wi-Fiに接続する必要があります。\n\n
     <string name="cloud_connection">クラウド接続</string>
     <string name="cloud_connection_new">新しいクラウド接続</string>
     <string name="cloud_dropbox">Dropbox</string>
-    <string name="cloud_drive">Google Drive</string>
+    <string name="cloud_drive">Google ドライブ&#8482;</string>
     <string name="cloud_onedrive">OneDrive</string>
     <string name="cloud_box">Box</string>
     <string name="cloud_get">クラウドプラグインを入手する</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -431,7 +431,7 @@ smb_instructions
     <string name="please_wait">Proszę czekać</string>
 
     <string name="cloud_dropbox">Dropbox</string>
-    <string name="cloud_drive">Google Drive</string>
+    <string name="cloud_drive">Google Drive&#8482;</string>
     <string name="cloud_onedrive">OneDrive</string>
     <string name="change">Zmień</string>
     <string name="unknown_error">Ups, coś poszło nie tak!</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -445,7 +445,7 @@
     <string name="cloud_connection">Conexão em nuvem</string>
     <string name="cloud_connection_new">Nova conexão em nuvem</string>
     <string name="cloud_dropbox">Dropbox</string>
-    <string name="cloud_drive">Google Drive</string>
+    <string name="cloud_drive">Google Drive&#8482;</string>
     <string name="cloud_onedrive">OneDrive</string>
     <string name="cloud_box">Box</string>
     <string name="cloud_get">Obter plugin para nuvem</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -434,7 +434,7 @@
     <string name="cloud_connection">Облачное соединение</string>
     <string name="cloud_connection_new">Новое облачное соединение</string>
     <string name="cloud_dropbox">Dropbox</string>
-    <string name="cloud_drive">Google Диск</string>
+    <string name="cloud_drive">Google Диск&#8482;</string>
     <string name="cloud_onedrive">OneDrive</string>
     <string name="cloud_box">Ящик</string>
     <string name="cloud_get">Получить Облачный плагин</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -432,7 +432,7 @@
     <string name="cloud_connection">Cloudové pripojenie</string>
     <string name="cloud_connection_new">Nové cloudové pripojenie</string>
     <string name="cloud_dropbox">Dropbox</string>
-    <string name="cloud_drive">Google Drive</string>
+    <string name="cloud_drive">Google Drive&#8482;</string>
     <string name="cloud_onedrive">OneDrive</string>
     <string name="cloud_box">Box</string>
     <string name="cloud_get">Získať Cloud plugin</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -336,7 +336,7 @@
     <string name="cloud_connection">Povezava v oblak</string>
     <string name="cloud_connection_new">Nova povezava v oblak</string>
     <string name="cloud_dropbox">Dropbox</string>
-    <string name="cloud_drive">Google Drive</string>
+    <string name="cloud_drive">Google Drive&#8482;</string>
     <string name="cloud_onedrive">OneDrive</string>
     <string name="cloud_box">Box</string>
     <string name="cloud_get">Dobi vtičnik za oblak</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -454,7 +454,7 @@ kommer annars att söka efter förekomster.</string>
     <string name="cloud_connection">Moln-anslutning</string>
     <string name="cloud_connection_new">Ny Moln-anslutning</string>
     <string name="cloud_dropbox">Dropbox</string>
-    <string name="cloud_drive">Google Drive</string>
+    <string name="cloud_drive">Google Drive&#8482;</string>
     <string name="cloud_onedrive">OneDrive</string>
     <string name="cloud_box">Box</string>
     <string name="cloud_get">Hämta moln-plugin</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -452,7 +452,7 @@ Devam etmek istiyor musunuz?\"</string>
     <string name="cloud_connection">Bulut bağlantısı</string>
     <string name="cloud_connection_new">Yeni bulut bağlantısı</string>
     <string name="cloud_dropbox">Dropbox</string>
-    <string name="cloud_drive">Google Drive</string>
+    <string name="cloud_drive">Google Drive&#8482;</string>
     <string name="cloud_onedrive">OneDrive</string>
     <string name="cloud_box">Box</string>
     <string name="cloud_get">Bulut eklentisi al</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -455,7 +455,7 @@
     <string name="cloud_connection">Підключення до хмари</string>
     <string name="cloud_connection_new">Нове підключення до хмари</string>
     <string name="cloud_dropbox">Dropbox</string>
-    <string name="cloud_drive">Google Drive</string>
+    <string name="cloud_drive">Google Drive&#8482;</string>
     <string name="cloud_onedrive">OneDrive</string>
     <string name="cloud_box">Ящик</string>
     <string name="cloud_get">Отримати плагін хмари</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -445,7 +445,7 @@
     <string name="cloud_connection">网盘</string>
     <string name="cloud_connection_new">添加网盘</string>
     <string name="cloud_dropbox">Dropbox</string>
-    <string name="cloud_drive">Google Drive</string>
+    <string name="cloud_drive">Google Drive&#8482;</string>
     <string name="cloud_onedrive">OneDrive</string>
     <string name="cloud_box">Box</string>
     <string name="cloud_get">获取网盘插件</string>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -397,7 +397,7 @@
     <string name="cloud_connection">雲端連線</string>
     <string name="cloud_connection_new">新增雲端連線</string>
     <string name="cloud_dropbox">Dropbox</string>
-    <string name="cloud_drive">Google 雲端硬碟</string>
+    <string name="cloud_drive">Google 雲端硬碟&#8482;</string>
     <string name="cloud_onedrive">OneDrive</string>
     <string name="cloud_box">Box</string>
     <string name="cloud_get">取得雲端套件</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -442,7 +442,7 @@
     <string name="cloud_connection">雲端連線</string>
     <string name="cloud_connection_new">新增雲端連線</string>
     <string name="cloud_dropbox">Dropbox</string>
-    <string name="cloud_drive">Google 雲端硬碟</string>
+    <string name="cloud_drive">Google 雲端硬碟&#8482;</string>
     <string name="cloud_onedrive">OneDrive</string>
     <string name="cloud_box">Box</string>
     <string name="cloud_get">取得雲端套件</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -717,6 +717,6 @@ You only need to do this once, until the next time you select a new location for
     <string name="compressed_explorer_fragment_error_open_uri">Error opening URI \"%s\" for reading.</string>
     <string name="error_empty_archive">\"%s\" is an empty archive.</string>
     <string name="security_error">File could not be opened using this app</string>
-    <string name="cloud_drive_tooltip">Create a Google Drive connection for managing files from within Amaze File Manager.</string>
+    <string name="cloud_drive_tooltip">Create a Google Drive™ connection for managing files from within Amaze File Manager.</string>
 </resources>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -455,7 +455,7 @@
     <string name="cloud_connection">Cloud Connection</string>
     <string name="cloud_connection_new">New Cloud Connection</string>
     <string name="cloud_dropbox">Dropbox</string>
-    <string name="cloud_drive">Google Drive</string>
+    <string name="cloud_drive">Google Drive&#8482;</string>
     <string name="cloud_onedrive">OneDrive</string>
     <string name="cloud_box">Box</string>
     <string name="cloud_get">Get Cloud plugin</string>
@@ -717,5 +717,6 @@ You only need to do this once, until the next time you select a new location for
     <string name="compressed_explorer_fragment_error_open_uri">Error opening URI \"%s\" for reading.</string>
     <string name="error_empty_archive">\"%s\" is an empty archive.</string>
     <string name="security_error">File could not be opened using this app</string>
+    <string name="cloud_drive_tooltip">Create a Google Drive connection for managing files from within Amaze File Manager.</string>
 </resources>
 


### PR DESCRIPTION
## Description
- Add trademark to Google Drive button on create Cloud Connection list
- Add tooltip indicating purpose of the Google Drive button

Google Drive icon is already the same as Google gives, and I don't think it's wise to change it to coloured from the mono ones to keep the UI unified.

#### Issue tracker   
Addresses #2814, since not sure how much else should be changed as well.
  
#### Manual tests
- [x] Done  
  
- Device: Pixel 2 emulator
- OS: Android 11

#### Build tasks success  
Successfully running following tasks on local:
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`
