### PR TITLE
 Implement DocumentFile mode of HybridFile

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/DeleteTask.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/DeleteTask.java
@@ -31,6 +31,7 @@ import com.amaze.filemanager.database.CryptHandler;
 import com.amaze.filemanager.file_operations.exceptions.ShellNotRunningException;
 import com.amaze.filemanager.filesystem.HybridFile;
 import com.amaze.filemanager.filesystem.HybridFileParcelable;
+import com.amaze.filemanager.filesystem.SafRootHolder;
 import com.amaze.filemanager.filesystem.cloud.CloudUtil;
 import com.amaze.filemanager.filesystem.files.CryptUtil;
 import com.amaze.filemanager.filesystem.files.FileUtils;
@@ -67,14 +68,14 @@ public class DeleteTask
   private final DataUtils dataUtils = DataUtils.getInstance();
 
   public DeleteTask(@NonNull Context cd) {
-    this.cd = cd;
+    this.cd = cd.getApplicationContext();
     rootMode =
         PreferenceManager.getDefaultSharedPreferences(cd)
             .getBoolean(PreferencesConstants.PREFERENCE_ROOTMODE, false);
   }
 
   public DeleteTask(@NonNull Context cd, CompressedExplorerFragment compressedExplorerFragment) {
-    this.cd = cd;
+    this.cd = cd.getApplicationContext();
     rootMode =
         PreferenceManager.getDefaultSharedPreferences(cd)
             .getBoolean(PreferencesConstants.PREFERENCE_ROOTMODE, false);
@@ -154,6 +155,10 @@ public class DeleteTask
     switch (file.getMode()) {
       case OTG:
         DocumentFile documentFile = OTGUtil.getDocumentFile(file.getPath(), cd, false);
+        return documentFile.delete();
+      case DOCUMENT_FILE:
+        documentFile =
+            OTGUtil.getDocumentFile(file.getPath(), SafRootHolder.getUriRoot(), cd, false);
         return documentFile.delete();
       case DROPBOX:
       case BOX:

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/DeleteTask.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/DeleteTask.java
@@ -62,22 +62,23 @@ public class DeleteTask
     extends AsyncTask<ArrayList<HybridFileParcelable>, String, AsyncTaskResult<Boolean>> {
 
   private ArrayList<HybridFileParcelable> files;
-  private final Context cd;
+  private final Context applicationContext;
   private final boolean rootMode;
   private CompressedExplorerFragment compressedExplorerFragment;
   private final DataUtils dataUtils = DataUtils.getInstance();
 
-  public DeleteTask(@NonNull Context cd) {
-    this.cd = cd.getApplicationContext();
+  public DeleteTask(@NonNull Context applicationContext) {
+    this.applicationContext = applicationContext.getApplicationContext();
     rootMode =
-        PreferenceManager.getDefaultSharedPreferences(cd)
+        PreferenceManager.getDefaultSharedPreferences(applicationContext)
             .getBoolean(PreferencesConstants.PREFERENCE_ROOTMODE, false);
   }
 
-  public DeleteTask(@NonNull Context cd, CompressedExplorerFragment compressedExplorerFragment) {
-    this.cd = cd.getApplicationContext();
+  public DeleteTask(
+      @NonNull Context applicationContext, CompressedExplorerFragment compressedExplorerFragment) {
+    this.applicationContext = applicationContext.getApplicationContext();
     rootMode =
-        PreferenceManager.getDefaultSharedPreferences(cd)
+        PreferenceManager.getDefaultSharedPreferences(applicationContext)
             .getBoolean(PreferencesConstants.PREFERENCE_ROOTMODE, false);
     this.compressedExplorerFragment = compressedExplorerFragment;
   }
@@ -85,7 +86,7 @@ public class DeleteTask
   @Override
   protected void onProgressUpdate(String... values) {
     super.onProgressUpdate(values);
-    Toast.makeText(cd, values[0], Toast.LENGTH_SHORT).show();
+    Toast.makeText(applicationContext, values[0], Toast.LENGTH_SHORT).show();
   }
 
   @Override
@@ -107,14 +108,14 @@ public class DeleteTask
       // delete file from media database
       if (!file.isSmb()) {
         try {
-          deleteFromMediaDatabase(cd, file.getPath());
+          deleteFromMediaDatabase(applicationContext, file.getPath());
         } catch (Exception e) {
-          FileUtils.scanFile(cd, files.toArray(new HybridFile[files.size()]));
+          FileUtils.scanFile(applicationContext, files.toArray(new HybridFile[files.size()]));
         }
       }
 
       // delete file entry from encrypted database
-      if (file.getName(cd).endsWith(CryptUtil.CRYPT_EXTENSION)) {
+      if (file.getName(applicationContext).endsWith(CryptUtil.CRYPT_EXTENSION)) {
         CryptHandler handler = CryptHandler.getInstance();
         handler.clear(file.getPath());
       }
@@ -128,17 +129,17 @@ public class DeleteTask
 
     Intent intent = new Intent(MainActivity.KEY_INTENT_LOAD_LIST);
     if (files.size() > 0) {
-      String path = files.get(0).getParent(cd);
+      String path = files.get(0).getParent(applicationContext);
       intent.putExtra(MainActivity.KEY_INTENT_LOAD_LIST_FILE, path);
-      cd.sendBroadcast(intent);
+      applicationContext.sendBroadcast(intent);
     }
 
     if (result.result == null || !result.result) {
-      cd.sendBroadcast(
+      applicationContext.sendBroadcast(
           new Intent(TAG_INTENT_FILTER_GENERAL)
               .putParcelableArrayListExtra(TAG_INTENT_FILTER_FAILED_OPS, files));
     } else if (compressedExplorerFragment == null) {
-      AppConfig.toast(cd, R.string.done);
+      AppConfig.toast(applicationContext, R.string.done);
     }
 
     if (compressedExplorerFragment != null) {
@@ -147,18 +148,20 @@ public class DeleteTask
 
     // cancel any processing notification because of cut/paste operation
     NotificationManager notificationManager =
-        (NotificationManager) cd.getSystemService(Context.NOTIFICATION_SERVICE);
+        (NotificationManager) applicationContext.getSystemService(Context.NOTIFICATION_SERVICE);
     notificationManager.cancel(NotificationConstants.COPY_ID);
   }
 
   private boolean doDeleteFile(@NonNull HybridFileParcelable file) throws Exception {
     switch (file.getMode()) {
       case OTG:
-        DocumentFile documentFile = OTGUtil.getDocumentFile(file.getPath(), cd, false);
+        DocumentFile documentFile =
+            OTGUtil.getDocumentFile(file.getPath(), applicationContext, false);
         return documentFile.delete();
       case DOCUMENT_FILE:
         documentFile =
-            OTGUtil.getDocumentFile(file.getPath(), SafRootHolder.getUriRoot(), cd, false);
+            OTGUtil.getDocumentFile(
+                file.getPath(), SafRootHolder.getUriRoot(), applicationContext, false);
         return documentFile.delete();
       case DROPBOX:
       case BOX:
@@ -174,7 +177,7 @@ public class DeleteTask
         }
       default:
         try {
-          return (file.delete(cd, rootMode));
+          return (file.delete(applicationContext, rootMode));
         } catch (ShellNotRunningException | SmbException e) {
           e.printStackTrace();
           throw e;

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/LoadFilesListTask.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/LoadFilesListTask.java
@@ -38,6 +38,7 @@ import com.amaze.filemanager.file_operations.filesystem.OpenMode;
 import com.amaze.filemanager.filesystem.HybridFile;
 import com.amaze.filemanager.filesystem.HybridFileParcelable;
 import com.amaze.filemanager.filesystem.RootHelper;
+import com.amaze.filemanager.filesystem.SafRootHolder;
 import com.amaze.filemanager.filesystem.cloud.CloudUtil;
 import com.amaze.filemanager.filesystem.files.FileListSorter;
 import com.amaze.filemanager.filesystem.root.ListFilesCommand;
@@ -202,6 +203,15 @@ public class LoadFilesListTask
               if (elem != null) list.add(elem);
             });
         openmode = OpenMode.OTG;
+        break;
+      case DOCUMENT_FILE:
+        list = new ArrayList<>();
+        listDocumentFiles(
+            file -> {
+              LayoutElementParcelable elem = createListParcelables(file);
+              if (elem != null) list.add(elem);
+            });
+        openmode = OpenMode.DOCUMENT_FILE;
         break;
       case DROPBOX:
       case BOX:
@@ -411,9 +421,7 @@ public class LoadFilesListTask
                 || path.endsWith(".pl")
                 || path.endsWith(".prop")
                 || path.endsWith(".properties")
-                || path.endsWith(".rc")
                 || path.endsWith(".msg")
-                || path.endsWith(".odt")
                 || path.endsWith(".pages")
                 || path.endsWith(".wpd")
                 || path.endsWith(".wps"))) {
@@ -549,6 +557,18 @@ public class LoadFilesListTask
     }
 
     OTGUtil.getDocumentFiles(path, context, fileFound);
+  }
+
+  private void listDocumentFiles(OnFileFound fileFound) {
+    final Context context = this.context.get();
+
+    if (context == null) {
+      cancel(true);
+      return;
+    }
+
+    OTGUtil.getDocumentFiles(
+        SafRootHolder.getUriRoot(), path, context, OpenMode.DOCUMENT_FILE, fileFound);
   }
 
   private void listCloud(

--- a/app/src/main/java/com/amaze/filemanager/filesystem/EditableFileAbstraction.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/EditableFileAbstraction.java
@@ -25,6 +25,7 @@ import static com.amaze.filemanager.filesystem.EditableFileAbstraction.Scheme.FI
 
 import com.amaze.filemanager.utils.Utils;
 
+import android.content.ContentResolver;
 import android.content.Context;
 import android.database.Cursor;
 import android.net.Uri;
@@ -52,7 +53,7 @@ public class EditableFileAbstraction {
 
   public EditableFileAbstraction(@NonNull Context context, @NonNull Uri uri) {
     switch (uri.getScheme()) {
-      case "content":
+      case ContentResolver.SCHEME_CONTENT:
         this.uri = uri;
         this.scheme = CONTENT;
 
@@ -85,7 +86,7 @@ public class EditableFileAbstraction {
 
         this.hybridFileParcelable = null;
         break;
-      case "file":
+      case ContentResolver.SCHEME_FILE:
         this.scheme = FILE;
 
         String path = uri.getPath();

--- a/app/src/main/java/com/amaze/filemanager/filesystem/HybridFileParcelable.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/HybridFileParcelable.java
@@ -32,9 +32,8 @@ import android.os.Parcel;
 import android.os.Parcelable;
 import android.util.Log;
 
-import androidx.annotation.Nullable;
-
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import jcifs.smb.SmbException;
 import jcifs.smb.SmbFile;

--- a/app/src/main/java/com/amaze/filemanager/filesystem/HybridFileParcelable.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/HybridFileParcelable.java
@@ -20,12 +20,19 @@
 
 package com.amaze.filemanager.filesystem;
 
+import static com.amaze.filemanager.file_operations.filesystem.OpenMode.DOCUMENT_FILE;
+
 import com.amaze.filemanager.file_operations.filesystem.OpenMode;
 import com.amaze.filemanager.utils.Utils;
 
+import android.content.ContentResolver;
 import android.content.Context;
+import android.net.Uri;
 import android.os.Parcel;
 import android.os.Parcelable;
+import android.util.Log;
+
+import androidx.annotation.Nullable;
 
 import androidx.annotation.NonNull;
 
@@ -41,6 +48,7 @@ public class HybridFileParcelable extends HybridFile implements Parcelable {
   private String permission;
   private String name;
   private String link = "";
+  private Uri fullUri = null;
 
   public HybridFileParcelable(String path) {
     super(OpenMode.FILE, path);
@@ -132,6 +140,22 @@ public class HybridFileParcelable extends HybridFile implements Parcelable {
 
   public void setPermission(String permission) {
     this.permission = permission;
+  }
+
+  @Nullable
+  public Uri getFullUri() {
+    return DOCUMENT_FILE.equals(mode) ? fullUri : null;
+  }
+
+  public void setFullUri(Uri fullUri) {
+    if (!ContentResolver.SCHEME_CONTENT.equals(fullUri.getScheme())) {
+      // TODO: throw IllegalArgumentException is not a good idea here?
+      // FIXME: OpenMode is mutable (which is a bad idea) hence check for OpenMode.DOCUMENT_FILE
+      //        will not make sense either.
+      Log.d(TAG, "Provided URI is not content URI, skipping. Given URI: " + fullUri.toString());
+    } else {
+      this.fullUri = fullUri;
+    }
   }
 
   protected HybridFileParcelable(Parcel in) {

--- a/app/src/main/java/com/amaze/filemanager/filesystem/SafRootHolder.kt
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/SafRootHolder.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2020 Arpit Khurana <arpitkh96@gmail.com>, Vishal Nehra <vishalmeham2@gmail.com>,
+ * Copyright (C) 2014-2021 Arpit Khurana <arpitkh96@gmail.com>, Vishal Nehra <vishalmeham2@gmail.com>,
  * Emmanuel Messulam<emmanuelbendavid@gmail.com>, Raymond Lai <airwave209gt at gmail.com> and Contributors.
  *
  * This file is part of Amaze File Manager.
@@ -18,37 +18,15 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package com.amaze.filemanager.file_operations.filesystem;
+package com.amaze.filemanager.filesystem
 
-/**
- * Created by vishal on 10/11/16.
- *
- * <p>Class denotes the type of file being handled
- */
-public enum OpenMode {
-  UNKNOWN,
-  FILE,
-  SMB,
-  SFTP,
+import android.net.Uri
 
-  /** Custom file types like apk/images/downloads (which don't have a defined path) */
-  CUSTOM,
-
-  ROOT,
-  OTG,
-  DOCUMENT_FILE,
-  GDRIVE,
-  DROPBOX,
-  BOX,
-  ONEDRIVE;
-
-  /**
-   * Get open mode based on the id assigned. Generally used to retrieve this type after config
-   * change or to send enum as argument
-   *
-   * @param ordinal the position of enum starting from 0 for first element
-   */
-  public static OpenMode getOpenMode(int ordinal) {
-    return OpenMode.values()[ordinal];
-  }
+object SafRootHolder {
+    var uriRoot: Uri? = null
+        @JvmStatic set
+        @JvmStatic get
+    var volumeLabel: String? = null
+        @JvmStatic set
+        @JvmStatic get
 }

--- a/app/src/main/java/com/amaze/filemanager/filesystem/files/GenericCopyUtil.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/files/GenericCopyUtil.java
@@ -44,6 +44,7 @@ import com.amaze.filemanager.filesystem.FileProperties;
 import com.amaze.filemanager.filesystem.HybridFile;
 import com.amaze.filemanager.filesystem.HybridFileParcelable;
 import com.amaze.filemanager.filesystem.MediaStoreHack;
+import com.amaze.filemanager.filesystem.SafRootHolder;
 import com.amaze.filemanager.filesystem.cloud.CloudUtil;
 import com.amaze.filemanager.utils.DataUtils;
 import com.amaze.filemanager.utils.OTGUtil;
@@ -104,11 +105,14 @@ public class GenericCopyUtil {
 
     try {
       // initializing the input channels based on file types
-      if (mSourceFile.isOtgFile()) {
+      if (mSourceFile.isOtgFile() || mSourceFile.isDocumentFile()) {
         // source is in otg
         ContentResolver contentResolver = mContext.getContentResolver();
         DocumentFile documentSourceFile =
-            OTGUtil.getDocumentFile(mSourceFile.getPath(), mContext, false);
+            mSourceFile.isDocumentFile()
+                ? OTGUtil.getDocumentFile(
+                    mSourceFile.getPath(), SafRootHolder.getUriRoot(), mContext, false)
+                : OTGUtil.getDocumentFile(mSourceFile.getPath(), mContext, false);
 
         bufferedInputStream =
             new BufferedInputStream(
@@ -162,11 +166,14 @@ public class GenericCopyUtil {
       }
 
       // initializing the output channels based on file types
-      if (mTargetFile.isOtgFile()) {
+      if (mTargetFile.isOtgFile() || mTargetFile.isDocumentFile()) {
         // target in OTG, obtain streams from DocumentFile Uri's
         ContentResolver contentResolver = mContext.getContentResolver();
         DocumentFile documentTargetFile =
-            OTGUtil.getDocumentFile(mTargetFile.getPath(), mContext, true);
+            mTargetFile.isDocumentFile()
+                ? OTGUtil.getDocumentFile(
+                    mTargetFile.getPath(), SafRootHolder.getUriRoot(), mContext, true)
+                : OTGUtil.getDocumentFile(mTargetFile.getPath(), mContext, true);
 
         bufferedOutputStream =
             new BufferedOutputStream(

--- a/app/src/main/java/com/amaze/filemanager/ui/ItemPopupMenu.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/ItemPopupMenu.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import com.amaze.filemanager.R;
 import com.amaze.filemanager.adapters.data.LayoutElementParcelable;
 import com.amaze.filemanager.asynchronous.services.EncryptService;
+import com.amaze.filemanager.file_operations.filesystem.OpenMode;
 import com.amaze.filemanager.filesystem.HybridFileParcelable;
 import com.amaze.filemanager.filesystem.PasteHelper;
 import com.amaze.filemanager.filesystem.files.EncryptDecryptUtils;
@@ -43,11 +44,14 @@ import com.amaze.filemanager.utils.DataUtils;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
+import android.net.Uri;
 import android.view.MenuItem;
 import android.view.View;
 import android.widget.PopupMenu;
 import android.widget.Toast;
 
+import androidx.annotation.Nullable;
+import androidx.documentfile.provider.DocumentFile;
 import androidx.preference.PreferenceManager;
 
 /**
@@ -165,7 +169,17 @@ public class ItemPopupMenu extends PopupMenu implements PopupMenu.OnMenuItemClic
       case R.id.open_with:
         boolean useNewStack =
             sharedPrefs.getBoolean(PreferencesConstants.PREFERENCE_TEXTEDITOR_NEWSTACK, false);
-        FileUtils.openWith(new File(rowItem.desc), mainActivity, useNewStack);
+        if (OpenMode.DOCUMENT_FILE.equals(rowItem.getMode())) {
+          @Nullable Uri fullUri = rowItem.generateBaseFile().getFullUri();
+          if (fullUri != null) {
+            FileUtils.openWith(
+                DocumentFile.fromSingleUri(context, fullUri), mainActivity, useNewStack);
+          } else {
+            FileUtils.openWith(new File(rowItem.desc), mainActivity, useNewStack);
+          }
+        } else {
+          FileUtils.openWith(new File(rowItem.desc), mainActivity, useNewStack);
+        }
         return true;
       case R.id.encrypt:
         final Intent encryptIntent = new Intent(context, EncryptService.class);

--- a/app/src/main/java/com/amaze/filemanager/ui/fragments/MainFragment.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/fragments/MainFragment.java
@@ -119,7 +119,6 @@ import android.widget.Toast;
 
 import androidx.activity.result.ActivityResultLauncher;
 import androidx.activity.result.contract.ActivityResultContracts;
-import androidx.annotation.ChecksSdkIntAtLeast;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
@@ -994,7 +993,8 @@ public class MainFragment extends Fragment
   @RequiresApi(api = Q)
   private OpenMode loadPathInQ(String actualPath, String providedPath, OpenMode providedMode) {
     boolean hasAccessToSpecialFolder = false;
-    List<UriPermission> uriPermissions = getContext().getContentResolver().getPersistedUriPermissions();
+    List<UriPermission> uriPermissions =
+        getContext().getContentResolver().getPersistedUriPermissions();
 
     if (uriPermissions != null && uriPermissions.size() > 0) {
       for (UriPermission p : uriPermissions) {
@@ -1008,23 +1008,23 @@ public class MainFragment extends Fragment
 
     if (!hasAccessToSpecialFolder) {
       Intent intent =
-              new Intent(Intent.ACTION_OPEN_DOCUMENT_TREE)
-                      .putExtra(
-                              DocumentsContract.EXTRA_INITIAL_URI,
-                              Uri.parse(FileProperties.remapPathForApi30OrAbove(providedPath, true)));
+          new Intent(Intent.ACTION_OPEN_DOCUMENT_TREE)
+              .putExtra(
+                  DocumentsContract.EXTRA_INITIAL_URI,
+                  Uri.parse(FileProperties.remapPathForApi30OrAbove(providedPath, true)));
       MaterialDialog d =
-              GeneralDialogCreation.showBasicDialog(
-                      getMainActivity(),
-                      R.string.android_data_prompt_saf_access,
-                      R.string.android_data_prompt_saf_access_title,
-                      android.R.string.ok,
-                      android.R.string.cancel);
+          GeneralDialogCreation.showBasicDialog(
+              getMainActivity(),
+              R.string.android_data_prompt_saf_access,
+              R.string.android_data_prompt_saf_access_title,
+              android.R.string.ok,
+              android.R.string.cancel);
       d.getActionButton(DialogAction.POSITIVE)
-              .setOnClickListener(
-                      v -> {
-                        handleDocumentUriForRestrictedDirectories.launch(intent);
-                        d.dismiss();
-                      });
+          .setOnClickListener(
+              v -> {
+                handleDocumentUriForRestrictedDirectories.launch(intent);
+                d.dismiss();
+              });
       d.show();
       return providedMode;
     } else {

--- a/app/src/main/java/com/amaze/filemanager/ui/fragments/MainFragment.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/fragments/MainFragment.java
@@ -20,7 +20,10 @@
 
 package com.amaze.filemanager.ui.fragments;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static android.os.Build.VERSION_CODES.JELLY_BEAN;
+import static android.os.Build.VERSION_CODES.JELLY_BEAN_MR2;
+import static android.os.Build.VERSION_CODES.Q;
 import static com.amaze.filemanager.filesystem.ssh.SshConnectionPool.SSH_URI_PREFIX;
 import static com.amaze.filemanager.ui.fragments.preference_fragments.PreferencesConstants.PREFERENCE_SHOW_DIVIDERS;
 import static com.amaze.filemanager.ui.fragments.preference_fragments.PreferencesConstants.PREFERENCE_SHOW_GOBACK_BUTTON;
@@ -33,8 +36,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 
-import org.jetbrains.annotations.NotNull;
-
+import com.afollestad.materialdialogs.DialogAction;
 import com.afollestad.materialdialogs.MaterialDialog;
 import com.amaze.filemanager.R;
 import com.amaze.filemanager.adapters.RecyclerAdapter;
@@ -52,6 +54,7 @@ import com.amaze.filemanager.filesystem.FileProperties;
 import com.amaze.filemanager.filesystem.HybridFile;
 import com.amaze.filemanager.filesystem.HybridFileParcelable;
 import com.amaze.filemanager.filesystem.PasteHelper;
+import com.amaze.filemanager.filesystem.SafRootHolder;
 import com.amaze.filemanager.filesystem.cloud.CloudUtil;
 import com.amaze.filemanager.filesystem.files.CryptUtil;
 import com.amaze.filemanager.filesystem.files.EncryptDecryptUtils;
@@ -86,6 +89,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.SharedPreferences;
+import android.content.UriPermission;
 import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
 import android.content.res.Resources;
@@ -96,6 +100,8 @@ import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Build;
 import android.os.Bundle;
+import android.os.Environment;
+import android.provider.DocumentsContract;
 import android.text.TextUtils;
 import android.text.format.Formatter;
 import android.util.Log;
@@ -111,6 +117,8 @@ import android.widget.ImageView;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import androidx.activity.result.ActivityResultLauncher;
+import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.view.ActionMode;
@@ -163,6 +171,22 @@ public class MainFragment extends Fragment
 
   private MainFragmentViewModel mainFragmentViewModel;
 
+  private ActivityResultLauncher<Intent> handleDocumentUriForRestrictedDirectories =
+      registerForActivityResult(
+          new ActivityResultContracts.StartActivityForResult(),
+          result -> {
+            if (SDK_INT >= Q) {
+              getContext()
+                  .getContentResolver()
+                  .takePersistableUriPermission(
+                      result.getData().getData(),
+                      Intent.FLAG_GRANT_READ_URI_PERMISSION
+                          | Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
+              SafRootHolder.setUriRoot(result.getData().getData());
+              loadlist(result.getData().getDataString(), false, OpenMode.DOCUMENT_FILE);
+            }
+          });
+
   @Override
   public void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
@@ -191,32 +215,25 @@ public class MainFragment extends Fragment
   }
 
   @Override
-  public void onViewCreated(
-      @NonNull @NotNull View view,
-      @Nullable @org.jetbrains.annotations.Nullable Bundle savedInstanceState) {
+  @SuppressWarnings("PMD.NPathComplexity")
+  public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
     super.onViewCreated(view, savedInstanceState);
     mainFragmentViewModel = new ViewModelProvider(this).get(MainFragmentViewModel.class);
     listView = rootView.findViewById(R.id.listView);
     mToolbarContainer = getMainActivity().getAppbar().getAppbarLayout();
     fastScroller = rootView.findViewById(R.id.fastscroll);
     fastScroller.setPressedHandleColor(mainFragmentViewModel.getAccentColor());
-    listView.setOnTouchListener(
+    View.OnTouchListener onTouchListener =
         (view1, motionEvent) -> {
           if (adapter != null && mainFragmentViewModel.getStopAnims()) {
             stopAnimation();
             mainFragmentViewModel.setStopAnims(false);
           }
           return false;
-        });
+        };
+    listView.setOnTouchListener(onTouchListener);
     //    listView.setOnDragListener(new MainFragmentDragListener());
-    mToolbarContainer.setOnTouchListener(
-        (view1, motionEvent) -> {
-          if (adapter != null && mainFragmentViewModel.getStopAnims()) {
-            stopAnimation();
-            mainFragmentViewModel.setStopAnims(false);
-          }
-          return false;
-        });
+    mToolbarContainer.setOnTouchListener(onTouchListener);
 
     mSwipeRefreshLayout = rootView.findViewById(R.id.activity_main_swipe_refresh_layout);
 
@@ -440,7 +457,13 @@ public class MainFragment extends Fragment
                       ? R.string.deselect_all
                       : R.string.select_all);
 
-          if (getMainActivity().mReturnIntent && Build.VERSION.SDK_INT >= JELLY_BEAN) {
+          if (mainFragmentViewModel.getOpenMode() != OpenMode.FILE) {
+            hideOption(R.id.addshortcut, menu);
+            hideOption(R.id.compress, menu);
+            return true;
+          }
+
+          if (getMainActivity().mReturnIntent && SDK_INT >= JELLY_BEAN) {
             showOption(R.id.openmulti, menu);
           }
           // tv.setText(checkedItems.size());
@@ -489,8 +512,9 @@ public class MainFragment extends Fragment
                 hideOption(R.id.share, menu);
                 hideOption(R.id.openmulti, menu);
               }
-              if (getMainActivity().mReturnIntent)
-                if (Build.VERSION.SDK_INT >= 16) showOption(R.id.openmulti, menu);
+              if (getMainActivity().mReturnIntent && SDK_INT >= JELLY_BEAN) {
+                showOption(R.id.openmulti, menu);
+              }
 
             } else {
               hideOption(R.id.openparent, menu);
@@ -837,6 +861,16 @@ public class MainFragment extends Fragment
                     (MainActivity) getActivity(),
                     sharedPref);
                 break;
+              case DOCUMENT_FILE:
+                FileUtils.openFile(
+                    OTGUtil.getDocumentFile(
+                        layoutElementParcelable.desc,
+                        SafRootHolder.getUriRoot(),
+                        getContext(),
+                        false),
+                    (MainActivity) getActivity(),
+                    sharedPref);
+                break;
               case DROPBOX:
               case BOX:
               case GDRIVE:
@@ -903,11 +937,13 @@ public class MainFragment extends Fragment
   /**
    * This loads a path into the MainFragment.
    *
-   * @param path the path to be loaded
+   * @param providedPath the path to be loaded
    * @param back if we're coming back from any directory and want the scroll to be restored
-   * @param openMode the mode in which the directory should be opened
+   * @param providedOpenMode the mode in which the directory should be opened
    */
-  public void loadlist(final String path, final boolean back, final OpenMode openMode) {
+  @SuppressWarnings("PMD.NPathComplexity")
+  public void loadlist(
+      final String providedPath, final boolean back, final OpenMode providedOpenMode) {
     if (mainFragmentViewModel == null) {
       Log.w(getClass().getSimpleName(), "Viewmodel not available to load the data");
       return;
@@ -922,10 +958,51 @@ public class MainFragment extends Fragment
       loadFilesListTask.cancel(true);
     }
 
+    OpenMode openMode = providedOpenMode;
+    String actualPath = FileProperties.remapPathForApi30OrAbove(providedPath, false);
+
+    if (!providedPath.equals(actualPath) && SDK_INT >= Q) {
+      boolean hasAccessToSpecialFolder = false;
+      List<UriPermission> uriPermissions =
+          getContext().getContentResolver().getPersistedUriPermissions();
+      if (uriPermissions != null && uriPermissions.size() > 0) {
+        for (UriPermission p : uriPermissions) {
+          if (p.isReadPermission() && actualPath.startsWith(p.getUri().toString())) {
+            hasAccessToSpecialFolder = true;
+            SafRootHolder.setUriRoot(p.getUri());
+            break;
+          }
+        }
+      }
+      if (!hasAccessToSpecialFolder) {
+        Intent intent =
+            new Intent(Intent.ACTION_OPEN_DOCUMENT_TREE)
+                .putExtra(
+                    DocumentsContract.EXTRA_INITIAL_URI,
+                    Uri.parse(FileProperties.remapPathForApi30OrAbove(providedPath, true)));
+        MaterialDialog d =
+            GeneralDialogCreation.showBasicDialog(
+                getMainActivity(),
+                R.string.android_data_prompt_saf_access,
+                R.string.android_data_prompt_saf_access_title,
+                android.R.string.ok,
+                android.R.string.cancel);
+        d.getActionButton(DialogAction.POSITIVE)
+            .setOnClickListener(
+                v -> {
+                  handleDocumentUriForRestrictedDirectories.launch(intent);
+                  d.dismiss();
+                });
+        d.show();
+      } else {
+        openMode = OpenMode.DOCUMENT_FILE;
+      }
+    }
+
     loadFilesListTask =
         new LoadFilesListTask(
             getActivity(),
-            path,
+            actualPath,
             this,
             openMode,
             getBoolean(PREFERENCE_SHOW_THUMB),
@@ -934,10 +1011,12 @@ public class MainFragment extends Fragment
               mSwipeRefreshLayout.setRefreshing(false);
               if (data != null && data.second != null) {
                 boolean isPathLayoutGrid =
-                    DataUtils.getInstance().getListOrGridForPath(path, DataUtils.LIST)
+                    DataUtils.getInstance().getListOrGridForPath(providedPath, DataUtils.LIST)
                         == DataUtils.GRID;
-                setListElements(data.second, back, path, data.first, false, isPathLayoutGrid);
-                setListElements(data.second, back, path, data.first, false, isPathLayoutGrid);
+                setListElements(
+                    data.second, back, providedPath, data.first, false, isPathLayoutGrid);
+                setListElements(
+                    data.second, back, providedPath, data.first, false, isPathLayoutGrid);
               } else {
                 Log.w(getClass().getSimpleName(), "Load list operation cancelled");
               }
@@ -1132,7 +1211,7 @@ public class MainFragment extends Fragment
    * pending opened files in application cache
    */
   private void resumeDecryptOperations() {
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
+    if (SDK_INT >= JELLY_BEAN_MR2) {
       (getActivity())
           .registerReceiver(
               decryptReceiver, new IntentFilter(EncryptDecryptUtils.DECRYPT_BROADCAST));
@@ -1282,6 +1361,8 @@ public class MainFragment extends Fragment
                     .substring(SSH_URI_PREFIX.length())
                     .contains("/")) {
               loadlist(mainFragmentViewModel.getHome(), false, OpenMode.FILE);
+            } else if (OpenMode.DOCUMENT_FILE.equals(mainFragmentViewModel.getOpenMode())) {
+              loadlist(currentFile.getParent(getContext()), true, currentFile.getMode());
             } else {
               loadlist(
                   currentFile.getParent(getContext()), true, mainFragmentViewModel.getOpenMode());
@@ -1289,8 +1370,34 @@ public class MainFragment extends Fragment
           } else if (("/").equals(mainFragmentViewModel.getCurrentPath())
               || (mainFragmentViewModel.getHome() != null
                   && mainFragmentViewModel.getHome().equals(mainFragmentViewModel.getCurrentPath()))
-              || mainFragmentViewModel.getIsOnCloud()) getMainActivity().exit();
-          else if (FileUtils.canGoBack(getContext(), currentFile)) {
+              || mainFragmentViewModel.getIsOnCloud()) {
+            getMainActivity().exit();
+          } else if (OpenMode.DOCUMENT_FILE.equals(mainFragmentViewModel.getOpenMode())) {
+            if (!currentFile.getPath().startsWith("content://")) {
+              mainFragmentViewModel.setOpenMode(OpenMode.FILE);
+              currentFile.setMode(OpenMode.FILE);
+              currentFile.setPath(Environment.getExternalStorageDirectory().getAbsolutePath());
+              loadlist(currentFile.getPath(), false, mainFragmentViewModel.getOpenMode());
+            } else {
+              List<String> pathSegments = Uri.parse(currentFile.getPath()).getPathSegments();
+              if (pathSegments.size() < 4) {
+                mainFragmentViewModel.setOpenMode(OpenMode.FILE);
+                String subPath = pathSegments.get(1);
+                currentFile.setMode(OpenMode.FILE);
+                currentFile.setPath(
+                    new File(
+                            Environment.getExternalStorageDirectory(),
+                            subPath.substring(
+                                subPath.lastIndexOf(':') + 1, subPath.lastIndexOf('/')))
+                        .getAbsolutePath());
+                loadlist(currentFile.getPath(), false, mainFragmentViewModel.getOpenMode());
+              } else {
+                loadlist(
+                    currentFile.getParent(getContext()), true, mainFragmentViewModel.getOpenMode());
+              }
+            }
+
+          } else if (FileUtils.canGoBack(getContext(), currentFile)) {
             loadlist(
                 currentFile.getParent(getContext()), true, mainFragmentViewModel.getOpenMode());
           } else getMainActivity().exit();
@@ -1429,7 +1536,7 @@ public class MainFragment extends Fragment
       customFileObserver.stopWatching();
     }
 
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
+    if (SDK_INT >= JELLY_BEAN_MR2) {
       (getActivity()).unregisterReceiver(decryptReceiver);
     }
   }

--- a/app/src/main/java/com/amaze/filemanager/ui/fragments/MainFragment.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/fragments/MainFragment.java
@@ -964,6 +964,11 @@ public class MainFragment extends Fragment
     if (!providedPath.equals(actualPath) && SDK_INT >= Q) {
       openMode = loadPathInQ(actualPath, providedPath, providedOpenMode);
     }
+    // Monkeypatch :( to fix problems with unexpected non content URI path while openMode is still
+    // OpenMode.DOCUMENT_FILE
+    else if (actualPath.startsWith("/") && OpenMode.DOCUMENT_FILE.equals(openMode)) {
+      openMode = OpenMode.FILE;
+    }
 
     loadFilesListTask =
         new LoadFilesListTask(
@@ -992,6 +997,7 @@ public class MainFragment extends Fragment
 
   @RequiresApi(api = Q)
   private OpenMode loadPathInQ(String actualPath, String providedPath, OpenMode providedMode) {
+
     boolean hasAccessToSpecialFolder = false;
     List<UriPermission> uriPermissions =
         getContext().getContentResolver().getPersistedUriPermissions();

--- a/app/src/main/java/com/amaze/filemanager/utils/MainActivityHelper.java
+++ b/app/src/main/java/com/amaze/filemanager/utils/MainActivityHelper.java
@@ -35,6 +35,7 @@ import java.util.ArrayList;
 
 import com.afollestad.materialdialogs.MaterialDialog;
 import com.amaze.filemanager.R;
+import com.amaze.filemanager.application.AppConfig;
 import com.amaze.filemanager.asynchronous.asynctasks.DeleteTask;
 import com.amaze.filemanager.asynchronous.management.ServiceWatcherUtil;
 import com.amaze.filemanager.asynchronous.services.ZipService;
@@ -48,6 +49,7 @@ import com.amaze.filemanager.filesystem.FileProperties;
 import com.amaze.filemanager.filesystem.HybridFile;
 import com.amaze.filemanager.filesystem.HybridFileParcelable;
 import com.amaze.filemanager.filesystem.Operations;
+import com.amaze.filemanager.filesystem.SafRootHolder;
 import com.amaze.filemanager.filesystem.compressed.CompressedHelper;
 import com.amaze.filemanager.filesystem.compressed.showcontents.Decompressor;
 import com.amaze.filemanager.filesystem.files.CryptUtil;
@@ -79,6 +81,7 @@ import android.widget.TextView;
 import android.widget.Toast;
 
 import androidx.annotation.StringRes;
+import androidx.documentfile.provider.DocumentFile;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
 import androidx.preference.PreferenceManager;
@@ -434,6 +437,13 @@ public class MainActivityHelper {
       return SmbUtil.checkFolder(path);
     } else if (OpenMode.SFTP.equals(openMode)) {
       return SshClientUtils.checkFolder(path);
+    } else if (OpenMode.DOCUMENT_FILE.equals(openMode)) {
+      DocumentFile d =
+          DocumentFile.fromTreeUri(AppConfig.getInstance(), SafRootHolder.getUriRoot());
+      if (d == null) return DOESNT_EXIST;
+      else {
+        return WRITABLE_OR_ON_SDCARD;
+      }
     } else {
       File folder = new File(path);
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {

--- a/app/src/main/java/com/amaze/filemanager/utils/OTGUtil.kt
+++ b/app/src/main/java/com/amaze/filemanager/utils/OTGUtil.kt
@@ -182,7 +182,7 @@ object OTGUtil {
                     ).split(PATH_SEPARATOR_ENCODED)
                         .filterNot { it.isEmpty() or it.isBlank() }
                         .forEach {
-                            retval = this.findFile(it)
+                            retval = retval?.findFile(it)
                         }
                 } else {
                     var nextDocument = this.findFile(part)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -711,6 +711,8 @@
     <string name="ftp_prompt_accept_first_start_saf_access">Since this is your first run of the FTP server, and you are using the device\'s internal storage as shared folder, please allow Amaze to access the storage using SAF.\n\n
 
 You only need to do this once, until the next time you select a new location for sharing.</string>
+    <string name="android_data_prompt_saf_access">Since Android 10, Android had imposed restrictions on certain directories, and they need to access with Storage Access Framework.\n\nPlease allow Amaze to access the directory from the system\'s file manager by tapping \"Allow Access\".</string>
+    <string name="android_data_prompt_saf_access_title">Grant SAF access</string>
     <string name="ftp_preference_saf_filesystem_title">Use legacy filesystem</string>
     <string name="ftp_preference_saf_filesystem">Enable this for support for using device external storage on newer Android versions</string>
     <string name="ftp_server_fallback_path_reset_prompt">FTP server shared path had been resetted to internal storage as you are switching back to legacy filesystem implementation. Please select a new path using the menu on the top right as necessary.</string>

--- a/app/src/test/java/com/amaze/filemanager/utils/OpenModeTest.java
+++ b/app/src/test/java/com/amaze/filemanager/utils/OpenModeTest.java
@@ -22,6 +22,7 @@ package com.amaze.filemanager.utils;
 
 import static com.amaze.filemanager.file_operations.filesystem.OpenMode.BOX;
 import static com.amaze.filemanager.file_operations.filesystem.OpenMode.CUSTOM;
+import static com.amaze.filemanager.file_operations.filesystem.OpenMode.DOCUMENT_FILE;
 import static com.amaze.filemanager.file_operations.filesystem.OpenMode.DROPBOX;
 import static com.amaze.filemanager.file_operations.filesystem.OpenMode.FILE;
 import static com.amaze.filemanager.file_operations.filesystem.OpenMode.GDRIVE;
@@ -50,10 +51,11 @@ public class OpenModeTest {
     assertEquals(CUSTOM, OpenMode.getOpenMode(4));
     assertEquals(ROOT, OpenMode.getOpenMode(5));
     assertEquals(OTG, OpenMode.getOpenMode(6));
-    assertEquals(GDRIVE, OpenMode.getOpenMode(7));
-    assertEquals(DROPBOX, OpenMode.getOpenMode(8));
-    assertEquals(BOX, OpenMode.getOpenMode(9));
-    assertEquals(ONEDRIVE, OpenMode.getOpenMode(10));
+    assertEquals(DOCUMENT_FILE, OpenMode.getOpenMode(7));
+    assertEquals(GDRIVE, OpenMode.getOpenMode(8));
+    assertEquals(DROPBOX, OpenMode.getOpenMode(9));
+    assertEquals(BOX, OpenMode.getOpenMode(10));
+    assertEquals(ONEDRIVE, OpenMode.getOpenMode(11));
     assertThrows(ArrayIndexOutOfBoundsException.class, () -> OpenMode.getOpenMode(-1));
     assertThrows(ArrayIndexOutOfBoundsException.class, () -> OpenMode.getOpenMode(MAX_VALUE));
   }


### PR DESCRIPTION
Supercedes #2708. Original PR description below.
-------
For fixing #2015, so ugly assumptions here and there.

- Added `DOCUMENT_FILE` mode in `HybridFile`, with the internals sharing code with `OTG` where possible
- Implement `SafRootHolder` for holding the SAF root URI. Ugly, and will have problems when two tabs are handling different SAF root URIs - e.g. one is at `Android/data` and one is at `Android/obb` - but OTG implementation is having the same problem on handling multiple OTG devices, so...

## Description

#### Issue tracker   
Fixes #2015

#### Automatic tests
- [ ] Added test cases
  
#### Manual tests
- [x] Done  
  
- Device: Pixel 2 emulator
- OS: Android 11
Tested for create/rename/delete folder, file, open text file in `TextEditorActivity`.

#### Build tasks success  
Successfully running following tasks on local:
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`