### PR TITLE
Fix tests after merging

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/texteditor/write/WriteTextFileCallable.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/texteditor/write/WriteTextFileCallable.java
@@ -122,7 +122,8 @@ public class WriteTextFileCallable implements Callable<Unit> {
     return Unit.INSTANCE;
   }
 
-  private OutputStream openFile(@NonNull File file, @NonNull Context context) throws IOException {
+  private OutputStream openFile(@NonNull File file, @NonNull Context context)
+      throws IOException, StreamNotFoundException {
     OutputStream outputStream = FileUtil.getOutputStream(file, context);
 
     // try loading stream associated using root
@@ -131,7 +132,7 @@ public class WriteTextFileCallable implements Callable<Unit> {
     }
 
     if (outputStream == null) {
-      throw new IOException("Cannot read or write text file!");
+      throw new StreamNotFoundException("Cannot read or write text file!");
     }
 
     return outputStream;

--- a/app/src/test/java/com/amaze/filemanager/ui/activities/TextEditorActivityTest.java
+++ b/app/src/test/java/com/amaze/filemanager/ui/activities/TextEditorActivityTest.java
@@ -77,7 +77,7 @@ public class TextEditorActivityTest {
     intent.setData(Uri.fromFile(file));
     generateActivity(intent);
 
-    assertEquals(fileContents + "\n", text.getText().toString());
+    assertEquals(fileContents, text.getText().toString());
   }
 
   @Test


### PR DESCRIPTION
## Description
- TextEditorActivityTest, remove redundant \n
- WriteTextFileCallable.openFile(), throw StreamNotFoundException instead of IOException to make test pass

Not sure WriteTextFileCallable modification is legit... only to make tests pass. @EmmanuelMess may want to check about this.

#### Manual tests
- [ ] Done  

#### Build tasks success  
<!-- run these! -->
Successfully running following tasks on local:
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`