### PR TITLE
Database upgrade for cloud service table

### DIFF
--- a/app/schemas/com.amaze.filemanager.database.ExplorerDatabase/8.json
+++ b/app/schemas/com.amaze.filemanager.database.ExplorerDatabase/8.json
@@ -1,0 +1,136 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 8,
+    "identityHash": "06766b689063c1bcaa4d0df3fd06f5e6",
+    "entities": [
+      {
+        "tableName": "tab",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`tab_no` INTEGER NOT NULL, `path` TEXT, `home` TEXT, PRIMARY KEY(`tab_no`))",
+        "fields": [
+          {
+            "fieldPath": "tabNumber",
+            "columnName": "tab_no",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "path",
+            "columnName": "path",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "home",
+            "columnName": "home",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "tab_no"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "sort",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`path` TEXT NOT NULL, `type` INTEGER NOT NULL, PRIMARY KEY(`path`))",
+        "fields": [
+          {
+            "fieldPath": "path",
+            "columnName": "path",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "path"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "encrypted",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `path` TEXT, `password` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "_id",
+            "columnName": "_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "path",
+            "columnName": "path",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "password",
+            "columnName": "password",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "_id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "cloud",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `service` INTEGER, `persist` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "_id",
+            "columnName": "_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serviceType",
+            "columnName": "service",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "persistData",
+            "columnName": "persist",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "_id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '06766b689063c1bcaa4d0df3fd06f5e6')"
+    ]
+  }
+}

--- a/app/src/main/java/com/amaze/filemanager/database/ExplorerDatabase.java
+++ b/app/src/main/java/com/amaze/filemanager/database/ExplorerDatabase.java
@@ -20,6 +20,8 @@
 
 package com.amaze.filemanager.database;
 
+import static com.amaze.filemanager.database.ExplorerDatabase.DATABASE_VERSION;
+
 import com.amaze.filemanager.database.daos.CloudEntryDao;
 import com.amaze.filemanager.database.daos.EncryptedEntryDao;
 import com.amaze.filemanager.database.daos.SortDao;
@@ -46,11 +48,11 @@ import androidx.sqlite.db.SupportSQLiteDatabase;
  */
 @Database(
     entities = {Tab.class, Sort.class, EncryptedEntry.class, CloudEntry.class},
-    version = 7)
+    version = DATABASE_VERSION)
 public abstract class ExplorerDatabase extends RoomDatabase {
 
   private static final String DATABASE_NAME = "explorer.db";
-  private static final int DATABASE_VERSION = 7;
+  protected static final int DATABASE_VERSION = 8;
 
   public static final String TABLE_TAB = "tab";
   public static final String TABLE_CLOUD_PERSIST = "cloud";
@@ -250,6 +252,21 @@ public abstract class ExplorerDatabase extends RoomDatabase {
         }
       };
 
+  static final Migration MIGRATION_7_8 =
+      new Migration(7, DATABASE_VERSION) {
+        @Override
+        public void migrate(@NonNull SupportSQLiteDatabase database) {
+          database.execSQL(
+              "UPDATE "
+                  + TABLE_CLOUD_PERSIST
+                  + " SET "
+                  + COLUMN_CLOUD_SERVICE
+                  + " = "
+                  + COLUMN_CLOUD_SERVICE
+                  + "+1");
+        }
+      };
+
   protected abstract TabDao tabDao();
 
   protected abstract SortDao sortDao();
@@ -266,6 +283,7 @@ public abstract class ExplorerDatabase extends RoomDatabase {
         .addMigrations(MIGRATION_4_5)
         .addMigrations(MIGRATION_5_6)
         .addMigrations(MIGRATION_6_7)
+        .addMigrations(MIGRATION_7_8)
         .allowMainThreadQueries()
         .build();
   }

--- a/app/src/main/java/com/amaze/filemanager/database/UtilitiesDatabase.java
+++ b/app/src/main/java/com/amaze/filemanager/database/UtilitiesDatabase.java
@@ -20,6 +20,8 @@
 
 package com.amaze.filemanager.database;
 
+import static com.amaze.filemanager.database.UtilitiesDatabase.DATABASE_VERSION;
+
 import com.amaze.filemanager.database.daos.BookmarkEntryDao;
 import com.amaze.filemanager.database.daos.GridEntryDao;
 import com.amaze.filemanager.database.daos.HiddenEntryDao;
@@ -60,11 +62,12 @@ import androidx.sqlite.db.SupportSQLiteDatabase;
       SmbEntry.class,
       SftpEntry.class
     },
-    version = 5,
+    version = DATABASE_VERSION,
     exportSchema = false)
 public abstract class UtilitiesDatabase extends RoomDatabase {
 
   private static final String DATABASE_NAME = "utilities.db";
+  protected static final int DATABASE_VERSION = 5;
 
   public static final String TABLE_HISTORY = "history";
   public static final String TABLE_HIDDEN = "hidden";
@@ -329,7 +332,7 @@ public abstract class UtilitiesDatabase extends RoomDatabase {
       };
 
   private static final Migration MIGRATION_4_5 =
-      new Migration(4, 5) {
+      new Migration(4, DATABASE_VERSION) {
         @Override
         public void migrate(@NonNull SupportSQLiteDatabase database) {
           String backupTable = TEMP_TABLE_PREFIX + TABLE_BOOKMARKS;
@@ -378,7 +381,7 @@ public abstract class UtilitiesDatabase extends RoomDatabase {
 
   protected abstract SftpEntryDao sftpEntryDao();
 
-  public static final UtilitiesDatabase initialize(@NonNull Context context) {
+  public static UtilitiesDatabase initialize(@NonNull Context context) {
     return Room.databaseBuilder(context, UtilitiesDatabase.class, DATABASE_NAME)
         .allowMainThreadQueries()
         .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5)

--- a/app/src/test/java/com/amaze/filemanager/database/ExplorerDatabaseMigrationTest.java
+++ b/app/src/test/java/com/amaze/filemanager/database/ExplorerDatabaseMigrationTest.java
@@ -23,12 +23,18 @@ package com.amaze.filemanager.database;
 import static android.os.Build.VERSION_CODES.JELLY_BEAN;
 import static android.os.Build.VERSION_CODES.KITKAT;
 import static android.os.Build.VERSION_CODES.P;
+import static com.amaze.filemanager.database.ExplorerDatabase.COLUMN_CLOUD_ID;
+import static com.amaze.filemanager.database.ExplorerDatabase.COLUMN_CLOUD_PERSIST;
+import static com.amaze.filemanager.database.ExplorerDatabase.COLUMN_CLOUD_SERVICE;
 import static com.amaze.filemanager.database.ExplorerDatabase.MIGRATION_1_2;
 import static com.amaze.filemanager.database.ExplorerDatabase.MIGRATION_2_3;
 import static com.amaze.filemanager.database.ExplorerDatabase.MIGRATION_3_4;
 import static com.amaze.filemanager.database.ExplorerDatabase.MIGRATION_4_5;
 import static com.amaze.filemanager.database.ExplorerDatabase.MIGRATION_5_6;
 import static com.amaze.filemanager.database.ExplorerDatabase.MIGRATION_6_7;
+import static com.amaze.filemanager.database.ExplorerDatabase.MIGRATION_7_8;
+import static com.amaze.filemanager.database.ExplorerDatabase.TABLE_CLOUD_PERSIST;
+import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
 
@@ -37,6 +43,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.annotation.Config;
 
+import com.amaze.filemanager.database.models.explorer.CloudEntry;
+import com.amaze.filemanager.file_operations.filesystem.OpenMode;
 import com.amaze.filemanager.shadows.ShadowMultiDex;
 
 import androidx.room.Room;
@@ -44,6 +52,8 @@ import androidx.sqlite.db.SupportSQLiteDatabase;
 import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.platform.app.InstrumentationRegistry;
+
+import io.reactivex.schedulers.Schedulers;
 
 @RunWith(AndroidJUnit4.class)
 @Config(
@@ -111,6 +121,104 @@ public class ExplorerDatabaseMigrationTest {
             .addMigrations(MIGRATION_6_7)
             .build();
     explorerDatabase.getOpenHelper().getWritableDatabase();
+    explorerDatabase.close();
+  }
+
+  @Test
+  public void migrateFromV7() throws IOException {
+    SupportSQLiteDatabase db = helper.createDatabase(TEST_DB, 7);
+    db.execSQL(
+        "INSERT INTO "
+            + TABLE_CLOUD_PERSIST
+            + "("
+            + COLUMN_CLOUD_ID
+            + ","
+            + COLUMN_CLOUD_SERVICE
+            + ","
+            + COLUMN_CLOUD_PERSIST
+            + ") VALUES (1,"
+            + (OpenMode.GDRIVE.ordinal() - 1)
+            + ",'abcd')");
+    db.execSQL(
+        "INSERT INTO "
+            + TABLE_CLOUD_PERSIST
+            + "("
+            + COLUMN_CLOUD_ID
+            + ","
+            + COLUMN_CLOUD_SERVICE
+            + ","
+            + COLUMN_CLOUD_PERSIST
+            + ") VALUES (2,"
+            + (OpenMode.DROPBOX.ordinal() - 1)
+            + ",'efgh')");
+    db.execSQL(
+        "INSERT INTO "
+            + TABLE_CLOUD_PERSIST
+            + "("
+            + COLUMN_CLOUD_ID
+            + ","
+            + COLUMN_CLOUD_SERVICE
+            + ","
+            + COLUMN_CLOUD_PERSIST
+            + ") VALUES (3,"
+            + (OpenMode.BOX.ordinal() - 1)
+            + ",'ijkl')");
+    db.execSQL(
+        "INSERT INTO "
+            + TABLE_CLOUD_PERSIST
+            + "("
+            + COLUMN_CLOUD_ID
+            + ","
+            + COLUMN_CLOUD_SERVICE
+            + ","
+            + COLUMN_CLOUD_PERSIST
+            + ") VALUES (4,"
+            + (OpenMode.ONEDRIVE.ordinal() - 1)
+            + ",'mnop')");
+    db.close();
+
+    ExplorerDatabase explorerDatabase =
+        Room.databaseBuilder(
+                InstrumentationRegistry.getInstrumentation().getTargetContext(),
+                ExplorerDatabase.class,
+                TEST_DB)
+            .addMigrations(MIGRATION_7_8)
+            .allowMainThreadQueries()
+            .build();
+    explorerDatabase.getOpenHelper().getWritableDatabase();
+    CloudEntry verify =
+        explorerDatabase
+            .cloudEntryDao()
+            .findByServiceType(OpenMode.GDRIVE.ordinal())
+            .subscribeOn(Schedulers.trampoline())
+            .blockingGet();
+    assertEquals(1, verify.getId());
+    assertEquals("abcd", verify.getPersistData().toString());
+    verify =
+        explorerDatabase
+            .cloudEntryDao()
+            .findByServiceType(OpenMode.BOX.ordinal())
+            .subscribeOn(Schedulers.trampoline())
+            .blockingGet();
+    assertEquals(3, verify.getId());
+    assertEquals("ijkl", verify.getPersistData().toString());
+    verify =
+        explorerDatabase
+            .cloudEntryDao()
+            .findByServiceType(OpenMode.DROPBOX.ordinal())
+            .subscribeOn(Schedulers.trampoline())
+            .blockingGet();
+    assertEquals(2, verify.getId());
+    assertEquals("efgh", verify.getPersistData().toString());
+    verify =
+        explorerDatabase
+            .cloudEntryDao()
+            .findByServiceType(OpenMode.ONEDRIVE.ordinal())
+            .subscribeOn(Schedulers.trampoline())
+            .blockingGet();
+    assertEquals(4, verify.getId());
+    assertEquals("mnop", verify.getPersistData().toString());
+
     explorerDatabase.close();
   }
 }


### PR DESCRIPTION
Fixes #2856.

As of #2827 a new `DOCUMENT_FILE` `OpenMode` enum is introduced, the cloud service entries will need move their value up by 1, which was forgotten when 3.6.2 was released.

Additionally, made the `@Database` annotation in `UtilitiesDatabase` and `ExplorerDatabase` to use version constants in the class instead.

## Description

#### Issue tracker   
Fixes #2856

#### Manual tests
- [x] Done  
  
Device: Pixel 2 emulator
OS: Android 11

1. Install Amaze FM 3.6.1
2. Install Amaze Cloud
3. Setup a cloud connection, e.g. Dropbox
4. Upgrade Amaze FM 3.6.2
5. The cloud connection setup in 3 should continue shown as the same type

#### Build tasks success  
Successfully running following tasks on local:
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`