### PR TITLE
Fix Sign-in Google Button won't go away after creating Google Drive connection

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/ui/dialogs/GeneralDialogCreation.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/dialogs/GeneralDialogCreation.java
@@ -1433,19 +1433,24 @@ public class GeneralDialogCreation {
     View customView =
         DialogSigninWithGoogleBinding.inflate(LayoutInflater.from(mainActivity)).getRoot();
     int accentColor = mainActivity.getAccent();
+
+    MaterialDialog dialog =
+        new MaterialDialog.Builder(mainActivity)
+            .customView(customView, false)
+            .title(R.string.signin_with_google_title)
+            .negativeText(android.R.string.cancel)
+            .negativeColor(accentColor)
+            .onNegative((dlg, which) -> dlg.dismiss())
+            .build();
+
     customView
         .findViewById(R.id.signin_with_google)
         .setOnClickListener(
             v -> {
               mainActivity.addConnection(OpenMode.GDRIVE);
+              dialog.dismiss();
             });
-    new MaterialDialog.Builder(mainActivity)
-        .customView(customView, false)
-        .title(R.string.signin_with_google_title)
-        .negativeText(android.R.string.cancel)
-        .negativeColor(accentColor)
-        .onNegative((dialog, which) -> dialog.dismiss())
-        .build()
-        .show();
+
+    dialog.show();
   }
 }

--- a/app/src/test/java/com/amaze/filemanager/filesystem/root/ListFilesCommandTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/filesystem/root/ListFilesCommandTest.kt
@@ -30,6 +30,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.amaze.filemanager.file_operations.filesystem.OpenMode
 import com.amaze.filemanager.filesystem.HybridFileParcelable
 import com.amaze.filemanager.shadows.ShadowMultiDex
+import com.amaze.filemanager.test.ShadowNativeOperations
 import com.amaze.filemanager.test.TestUtils
 import com.amaze.filemanager.ui.fragments.preference_fragments.PreferencesConstants
 import org.junit.After
@@ -47,7 +48,7 @@ import java.io.InputStreamReader
 
 @RunWith(AndroidJUnit4::class)
 @Config(
-    shadows = [ShadowMultiDex::class],
+    shadows = [ShadowMultiDex::class, ShadowNativeOperations::class],
     sdk = [JELLY_BEAN, KITKAT, P]
 )
 /**

--- a/app/src/test/java/com/amaze/filemanager/filesystem/root/ListFilesCommandTest2.kt
+++ b/app/src/test/java/com/amaze/filemanager/filesystem/root/ListFilesCommandTest2.kt
@@ -31,6 +31,7 @@ import com.amaze.filemanager.exceptions.ShellCommandInvalidException
 import com.amaze.filemanager.file_operations.filesystem.OpenMode
 import com.amaze.filemanager.filesystem.HybridFileParcelable
 import com.amaze.filemanager.shadows.ShadowMultiDex
+import com.amaze.filemanager.test.ShadowNativeOperations
 import com.amaze.filemanager.test.TestUtils
 import com.amaze.filemanager.ui.fragments.preference_fragments.PreferencesConstants
 import org.junit.After
@@ -48,7 +49,7 @@ import java.io.InputStreamReader
 
 @RunWith(AndroidJUnit4::class)
 @Config(
-    shadows = [ShadowMultiDex::class],
+    shadows = [ShadowMultiDex::class, ShadowNativeOperations::class],
     sdk = [JELLY_BEAN, KITKAT, P]
 )
 /**

--- a/app/src/test/java/com/amaze/filemanager/test/ShadowNativeOperations.java
+++ b/app/src/test/java/com/amaze/filemanager/test/ShadowNativeOperations.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2014-2021 Arpit Khurana <arpitkh96@gmail.com>, Vishal Nehra <vishalmeham2@gmail.com>,
+ * Emmanuel Messulam<emmanuelbendavid@gmail.com>, Raymond Lai <airwave209gt at gmail.com> and Contributors.
+ *
+ * This file is part of Amaze File Manager.
+ *
+ * Amaze File Manager is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.amaze.filemanager.test;
+
+import org.robolectric.annotation.Implementation;
+import org.robolectric.annotation.Implements;
+
+import com.amaze.filemanager.file_operations.filesystem.root.NativeOperations;
+
+import androidx.annotation.Nullable;
+
+@Implements(NativeOperations.class)
+public class ShadowNativeOperations {
+
+  @Implementation
+  public static boolean isDirectory(@Nullable String path) {
+    return path != null && path.startsWith("d");
+  }
+}


### PR DESCRIPTION
## Description
Fixes a little problem brought by #2832. Previously, after tapping the Google Drive selection, it did brought up the Cloud Plugin dialog, but did nothing afterwards, and the Sign in with Google dialog kept on screen. This changeset fixes this behaviour, by in align with behaviours of buttons of other cloud connection types.

#### Issue tracker   

#### Automatic tests
<!-- remember to do manual testing when making UI changes! -->
- [ ] Added test cases
  
#### Manual tests
- [x] Done  
  
Device: Pixel 2 emulator
OS: Android 11

1. Tap the + button at lower right
2. Tap Cloud Connection
3. Tap Google Drive
4. Sign in with Google button is displayed
5. After tapping the Sign in with Google button, the dialog should go away automatically

#### Build tasks success  
<!-- run these! -->
Successfully running following tasks on local:
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`