### PR TITLE
fix: remove obsolete 'dexOptions' gradle element

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,11 +8,6 @@ apply plugin: "com.starter.easylauncher"
 android {
     compileSdkVersion 29
 
-    dexOptions {
-        jumboMode = true
-        javaMaxHeapSize "4g"
-    }
-
     packagingOptions {
         exclude 'proguard-project.txt'
         exclude 'project.properties'


### PR DESCRIPTION
./gradlew app:assembleFdroidRelease

> Configure project :app
WARNING:DSL element 'dexOptions' is obsolete and should be removed.
It will be removed in version 8.0 of the Android Gradle plugin.
Using it has no effect, and the AndroidGradle plugin optimizes dexing automatically.
