### PR TITLE
chore: add sign config to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -328,3 +328,6 @@ captures
 
 /app/src/main/res/values-in/strings.xml
 /app/src/main/res/values-iw/strings.xml
+
+# sign config
+signing.properties


### PR DESCRIPTION
./gradlew assembleFdroidRelease

Build from terminal, the sign config file is needed, so ignore it

