### PR TITLE
Proper Intent and Uri for all file access permission request

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/ui/activities/superclasses/PermissionsActivity.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/activities/superclasses/PermissionsActivity.java
@@ -197,7 +197,9 @@ public class PermissionsActivity extends ThemedActivity
                 Utils.disableScreenRotation(this);
                 permissionCallbacks[ALL_FILES_PERMISSION] = onPermissionGranted;
                 try {
-                  Intent intent = new Intent(Settings.ACTION_MANAGE_ALL_FILES_ACCESS_PERMISSION);
+                  Intent intent =
+                      new Intent(Settings.ACTION_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION)
+                          .setData(Uri.parse("package:" + getPackageName()));
                   startActivity(intent);
                 } catch (Exception e) {
                   Log.e(TAG, "Failed to initial activity to grant all files access", e);

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -731,8 +731,8 @@ You only need to do this once, until the next time you select a new location for
     <string name="select_by_date">Select by date</string>
     <string name="select_similar">Select similar</string>
     <string name="error_fetching_google_play_product_list">Error fetching product list from Google Play.</string>
-    <string name="grant_all_files_permission"><html><body>Amaze needs all files permission to continue.
-        \nOn next screen, please select <b>Amaze</b> and select <b>Allow access to manage all files</b> option.
-            \n\n<font color='#ff6347'><i>Canceling this dialog will exit the app.</i></font></body></html></string>
+    <string name="grant_all_files_permission"><html><body>Since Android 11, Google requests File Managers to request user permission for managing all files on the device. Details <a href="https://developer.android.com/training/data-storage/manage-all-files" target="_blank">here</a>.
+        \n\nAmaze File Manager needs this permission too. After pressing &quot;Grant&quot;here, please select <b>Allow access to manage all files</b> option on the next screen.
+        \n\n<font color='#ff6347'><i>Canceling this dialog will exit the app.</i></font></body></html></string>
 </resources>
 


### PR DESCRIPTION
## Description
So the prompt dialog would take user directly to the switch instead.

Reference: https://stackoverflow.com/a/65876928
Fixes #3012 

#### Manual tests
- [x] Done  
  
- Device: Oneplus 2
- OS: LineageOS 18 (11)
Upon tapping grant on all file access permission request dialog, user should be taken to the file access grant toggle switch screen, instead of getting a list of apps on user's device having access to all files on device.

#### Build tasks success  
Successfully running following tasks on local:
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`