### PR TITLE
Don't ask for storage permission on Android 11 or above

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -28,7 +28,7 @@
 
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="29" />
     <uses-permission android:name="com.android.launcher.permission.INSTALL_SHORTCUT" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="com.amaze.cloud.permission.ACCESS_PROVIDER" />

--- a/app/src/main/java/com/amaze/filemanager/ui/activities/MainActivity.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/activities/MainActivity.java
@@ -503,11 +503,11 @@ public class MainActivity extends PermissionsActivity
   }
 
   private void checkForExternalPermission() {
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-      if (!checkStoragePermission()) {
+    if (SDK_INT >= Build.VERSION_CODES.M) {
+      if (SDK_INT < Build.VERSION_CODES.R && !checkStoragePermission()) {
         requestStoragePermission(this, true);
       }
-      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+      else if (SDK_INT >= Build.VERSION_CODES.R) {
         requestAllFilesAccess(this);
       }
     }

--- a/app/src/main/java/com/amaze/filemanager/ui/activities/superclasses/PermissionsActivity.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/activities/superclasses/PermissionsActivity.java
@@ -20,6 +20,8 @@
 
 package com.amaze.filemanager.ui.activities.superclasses;
 
+import static android.os.Build.VERSION.SDK_INT;
+
 import com.afollestad.materialdialogs.DialogAction;
 import com.afollestad.materialdialogs.MaterialDialog;
 import com.amaze.filemanager.R;
@@ -60,7 +62,7 @@ public class PermissionsActivity extends ThemedActivity
   public void onRequestPermissionsResult(
       int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
     super.onRequestPermissionsResult(requestCode, permissions, grantResults);
-    if (requestCode == STORAGE_PERMISSION) {
+    if (requestCode == STORAGE_PERMISSION || requestCode == ALL_FILES_PERMISSION) {
       if (isGranted(grantResults)) {
         Utils.enableScreenRotation(this);
         permissionCallbacks[STORAGE_PERMISSION].onPermissionGranted();
@@ -181,7 +183,7 @@ public class PermissionsActivity extends ThemedActivity
    * @param onPermissionGranted permission granted callback
    */
   public void requestAllFilesAccess(@NonNull final OnPermissionGranted onPermissionGranted) {
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R && !Environment.isExternalStorageManager()) {
+    if (SDK_INT >= Build.VERSION_CODES.R && !Environment.isExternalStorageManager()) {
       final MaterialDialog materialDialog =
           GeneralDialogCreation.showBasicDialog(
               this,
@@ -194,7 +196,6 @@ public class PermissionsActivity extends ThemedActivity
           .getActionButton(DialogAction.POSITIVE)
           .setOnClickListener(
               v -> {
-                Utils.disableScreenRotation(this);
                 permissionCallbacks[ALL_FILES_PERMISSION] = onPermissionGranted;
                 try {
                   Intent intent =


### PR DESCRIPTION
## Description

With Android 11 there is already a MANAGE_EXTERNAL_STORAGE permission, which overlaps WRITE_EXTERNAL_STORAGE permission, hence limiting WRITE_EXTERNAL_STORAGE request to <= Android 10.

#### Issue tracker   
Addresses #3012

#### Manual tests
- [x] Done  

Device: Pixel 2 emulator running Android 11
On startup only All Files access permission dialog should pop up, but no storage permission dialog should pop up - **that is, one single dialog ask for file access permission**.
Device: Pixel 5 emulator running Android 10
On startup only request for storage permission dialog should pop up.
Device: Fairphone 3 running LineageOS 16.0 (9.0)
On startup only request for storage permission dialog should pop up.

#### Build tasks success  
Successfully running following tasks on local:
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`

#### Related PR  
Related to PR #3008
