### PR TITLE
Fix wildcard imports failing CI build with unit tests

### DIFF
--- a/app/src/test/java/com/amaze/filemanager/asynchronous/asynctasks/AbstractDeleteTaskTestBase.kt
+++ b/app/src/test/java/com/amaze/filemanager/asynchronous/asynctasks/AbstractDeleteTaskTestBase.kt
@@ -22,7 +22,9 @@ package com.amaze.filemanager.asynchronous.asynctasks
 
 import android.content.Context
 import android.os.Build
-import android.os.Build.VERSION_CODES.*
+import android.os.Build.VERSION_CODES.JELLY_BEAN
+import android.os.Build.VERSION_CODES.KITKAT
+import android.os.Build.VERSION_CODES.P
 import android.os.Looper
 import android.os.storage.StorageManager
 import androidx.lifecycle.Lifecycle

--- a/app/src/test/java/com/amaze/filemanager/asynchronous/asynctasks/compress/AbstractCompressedHelperTaskTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/asynchronous/asynctasks/compress/AbstractCompressedHelperTaskTest.kt
@@ -20,7 +20,9 @@
 
 package com.amaze.filemanager.asynchronous.asynctasks.compress
 
-import android.os.Build.VERSION_CODES.*
+import android.os.Build.VERSION_CODES.JELLY_BEAN
+import android.os.Build.VERSION_CODES.KITKAT
+import android.os.Build.VERSION_CODES.P
 import android.os.Environment
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.amaze.filemanager.adapters.data.CompressedObjectParcelable

--- a/app/src/test/java/com/amaze/filemanager/asynchronous/asynctasks/ssh/SshAuthenticationTaskTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/asynchronous/asynctasks/ssh/SshAuthenticationTaskTest.kt
@@ -21,7 +21,9 @@
 package com.amaze.filemanager.asynchronous.asynctasks.ssh
 
 import android.content.Context
-import android.os.Build.VERSION_CODES.*
+import android.os.Build.VERSION_CODES.JELLY_BEAN
+import android.os.Build.VERSION_CODES.KITKAT
+import android.os.Build.VERSION_CODES.P
 import android.os.Looper
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4

--- a/app/src/test/java/com/amaze/filemanager/asynchronous/asynctasks/texteditor/read/ReadTextFileCallableTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/asynchronous/asynctasks/texteditor/read/ReadTextFileCallableTest.kt
@@ -22,7 +22,9 @@ package com.amaze.filemanager.asynchronous.asynctasks.texteditor.read
 
 import android.content.Context
 import android.net.Uri
-import android.os.Build.VERSION_CODES.*
+import android.os.Build.VERSION_CODES.JELLY_BEAN
+import android.os.Build.VERSION_CODES.KITKAT
+import android.os.Build.VERSION_CODES.P
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.amaze.filemanager.asynchronous.asynctasks.texteditor.read.ReadTextFileCallable.MAX_FILE_SIZE_CHARS

--- a/app/src/test/java/com/amaze/filemanager/asynchronous/services/ExtractServiceTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/asynchronous/services/ExtractServiceTest.kt
@@ -22,7 +22,9 @@ package com.amaze.filemanager.asynchronous.services
 
 import android.content.Context
 import android.content.Intent
-import android.os.Build.VERSION_CODES.*
+import android.os.Build.VERSION_CODES.JELLY_BEAN
+import android.os.Build.VERSION_CODES.KITKAT
+import android.os.Build.VERSION_CODES.P
 import android.os.Environment
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4

--- a/app/src/test/java/com/amaze/filemanager/asynchronous/services/ZipServiceTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/asynchronous/services/ZipServiceTest.kt
@@ -22,7 +22,9 @@ package com.amaze.filemanager.asynchronous.services
 
 import android.content.Context
 import android.content.Intent
-import android.os.Build.VERSION_CODES.*
+import android.os.Build.VERSION_CODES.JELLY_BEAN
+import android.os.Build.VERSION_CODES.KITKAT
+import android.os.Build.VERSION_CODES.P
 import android.os.Looper.getMainLooper
 import androidx.test.core.app.ApplicationProvider
 import com.amaze.filemanager.asynchronous.services.ZipService.Companion.KEY_COMPRESS_FILES

--- a/app/src/test/java/com/amaze/filemanager/filesystem/AbstractOperationsTestBase.kt
+++ b/app/src/test/java/com/amaze/filemanager/filesystem/AbstractOperationsTestBase.kt
@@ -22,7 +22,9 @@ package com.amaze.filemanager.filesystem
 
 import android.content.Context
 import android.os.Build
-import android.os.Build.VERSION_CODES.*
+import android.os.Build.VERSION_CODES.JELLY_BEAN
+import android.os.Build.VERSION_CODES.KITKAT
+import android.os.Build.VERSION_CODES.P
 import android.os.Looper
 import android.os.storage.StorageManager
 import androidx.lifecycle.Lifecycle
@@ -40,7 +42,7 @@ import io.reactivex.android.plugins.RxAndroidPlugins
 import io.reactivex.plugins.RxJavaPlugins
 import io.reactivex.schedulers.Schedulers
 import org.junit.After
-import org.junit.Assert
+import org.junit.Assert.*
 import org.junit.Before
 import org.junit.runner.RunWith
 import org.robolectric.Shadows
@@ -113,17 +115,20 @@ abstract class AbstractOperationsTestBase {
             Shadows.shadowOf(Looper.getMainLooper()).idle()
 
             Shadows.shadowOf(activity).broadcastIntents.run {
-                Assert.assertNotNull(this)
-                Assert.assertTrue(this.size > 0)
+                assertNotNull(this)
+                assertTrue(this.size > 0)
                 this[0].apply {
-                    Assert.assertEquals(MainActivity.TAG_INTENT_FILTER_GENERAL, this.action)
+                    assertEquals(MainActivity.TAG_INTENT_FILTER_GENERAL, this.action)
                     this
                         .getParcelableArrayListExtra<HybridFileParcelable>(
                             MainActivity.TAG_INTENT_FILTER_FAILED_OPS
                         )
                         .run {
-                            Assert.assertTrue(this.size > 0)
-                            Assert.assertEquals(oldFilePath, this[0].path)
+                            assertNotNull(this)
+                            this?.let {
+                                assertTrue(it.size > 0)
+                                assertEquals(oldFilePath, it[0].path)
+                            }
                         }
                 }
             }

--- a/app/src/test/java/com/amaze/filemanager/filesystem/files/FileUtilsTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/filesystem/files/FileUtilsTest.kt
@@ -20,7 +20,9 @@
 
 package com.amaze.filemanager.filesystem.files
 
-import android.os.Build.VERSION_CODES.*
+import android.os.Build.VERSION_CODES.JELLY_BEAN
+import android.os.Build.VERSION_CODES.KITKAT
+import android.os.Build.VERSION_CODES.P
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.amaze.filemanager.filesystem.files.FileUtils.getPathsInPath
 import org.junit.Assert.*

--- a/app/src/test/java/com/amaze/filemanager/filesystem/smb/SmbHybridFileTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/filesystem/smb/SmbHybridFileTest.kt
@@ -21,7 +21,9 @@
 package com.amaze.filemanager.filesystem.smb
 
 import android.content.Context
-import android.os.Build.VERSION_CODES.*
+import android.os.Build.VERSION_CODES.JELLY_BEAN
+import android.os.Build.VERSION_CODES.KITKAT
+import android.os.Build.VERSION_CODES.P
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.amaze.filemanager.file_operations.filesystem.OpenMode

--- a/app/src/test/java/com/amaze/filemanager/filesystem/ssh/SshHybridFileTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/filesystem/ssh/SshHybridFileTest.kt
@@ -21,7 +21,9 @@
 package com.amaze.filemanager.filesystem.ssh
 
 import android.content.Context
-import android.os.Build.VERSION_CODES.*
+import android.os.Build.VERSION_CODES.JELLY_BEAN
+import android.os.Build.VERSION_CODES.KITKAT
+import android.os.Build.VERSION_CODES.P
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.amaze.filemanager.file_operations.filesystem.OpenMode

--- a/app/src/test/java/com/amaze/filemanager/ui/theme/AppThemeTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/ui/theme/AppThemeTest.kt
@@ -22,7 +22,9 @@ package com.amaze.filemanager.ui.theme
 
 import android.content.Context
 import android.content.res.Configuration
-import android.os.Build.VERSION_CODES.*
+import android.os.Build.VERSION_CODES.JELLY_BEAN
+import android.os.Build.VERSION_CODES.KITKAT
+import android.os.Build.VERSION_CODES.P
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.afollestad.materialdialogs.Theme

--- a/app/src/test/java/com/amaze/filemanager/utils/MinMaxInputFilterTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/utils/MinMaxInputFilterTest.kt
@@ -20,7 +20,9 @@
 
 package com.amaze.filemanager.utils
 
-import android.os.Build.VERSION_CODES.*
+import android.os.Build.VERSION_CODES.JELLY_BEAN
+import android.os.Build.VERSION_CODES.KITKAT
+import android.os.Build.VERSION_CODES.P
 import android.text.SpannedString
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.Assert.assertEquals


### PR DESCRIPTION
## Description
Without this, compiler will be unable to distinguish between `android.os.Build.VERSION_CODES.R` and `com.amaze.filemanager.R`.

#### Build tasks success  
Successfully running following tasks on local:
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`