### PR TITLE
Upgrade Robolectric to 4.7

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/ui/fragments/TabFragment.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/fragments/TabFragment.java
@@ -469,7 +469,7 @@ public class TabFragment extends Fragment implements ViewPager.OnPageChangeListe
                 if (viewPager.getCurrentItem() == 1) {
                   if (mainFragment != null) {
                     dataUtils.setCheckedItemsList(mainFragment.adapter.getCheckedItems());
-                    mainActivity.getActionModeHelper().disableActionMode();
+                    requireMainActivity().getActionModeHelper().disableActionMode();
                   }
                   viewPager.setCurrentItem(0, true);
                 }
@@ -481,7 +481,7 @@ public class TabFragment extends Fragment implements ViewPager.OnPageChangeListe
                 if (viewPager.getCurrentItem() == 0) {
                   if (mainFragment != null) {
                     dataUtils.setCheckedItemsList(mainFragment.adapter.getCheckedItems());
-                    mainActivity.getActionModeHelper().disableActionMode();
+                    requireMainActivity().getActionModeHelper().disableActionMode();
                   }
                   viewPager.setCurrentItem(1, true);
                 }

--- a/app/src/test/java/com/amaze/filemanager/asynchronous/asynctasks/ssh/PemToKeyPairTaskTest.java
+++ b/app/src/test/java/com/amaze/filemanager/asynchronous/asynctasks/ssh/PemToKeyPairTaskTest.java
@@ -23,7 +23,8 @@ package com.amaze.filemanager.asynchronous.asynctasks.ssh;
 import static org.junit.Assert.assertNotNull;
 
 import java.lang.reflect.Field;
-import java.util.concurrent.CountDownLatch;
+import java.security.KeyPair;
+import java.util.concurrent.ExecutionException;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -94,34 +95,19 @@ public class PemToKeyPairTaskTest {
           + "Private-MAC: f742e2954fbb0c98984db0d9855a0f15507ecc0a";
 
   @Test
-  public void testUnencryptedKeyToKeyPair() throws InterruptedException {
-    CountDownLatch waiter = new CountDownLatch(1);
-    PemToKeyPairTask task =
-        new PemToKeyPairTask(
-            unencryptedPuttyKey,
-            result -> {
-              assertNotNull(result);
-              assertNotNull(result.getPublic());
-              assertNotNull(result.getPrivate());
-              waiter.countDown();
-            });
-    task.execute();
-    waiter.await();
+  public void testUnencryptedKeyToKeyPair() throws InterruptedException, ExecutionException {
+    PemToKeyPairTask task = new PemToKeyPairTask(unencryptedPuttyKey, result -> {});
+    KeyPair result = task.execute().get();
+    assertNotNull(result);
+    assertNotNull(result.getPublic());
+    assertNotNull(result.getPrivate());
   }
 
   @Test
   public void testEncryptedKeyToKeyPair()
-      throws InterruptedException, NoSuchFieldException, IllegalAccessException {
-    CountDownLatch waiter = new CountDownLatch(1);
-    PemToKeyPairTask task =
-        new PemToKeyPairTask(
-            encryptedPuttyKey,
-            result -> {
-              assertNotNull(result);
-              assertNotNull(result.getPublic());
-              assertNotNull(result.getPrivate());
-              waiter.countDown();
-            });
+      throws InterruptedException, NoSuchFieldException, IllegalAccessException,
+          ExecutionException {
+    PemToKeyPairTask task = new PemToKeyPairTask(encryptedPuttyKey, result -> {});
     Field field = PemToKeyPairTask.class.getDeclaredField("passwordFinder");
     field.setAccessible(true);
     field.set(
@@ -137,7 +123,9 @@ public class PemToKeyPairTaskTest {
             return false;
           }
         });
-    task.execute();
-    waiter.await();
+    KeyPair result = task.execute().get();
+    assertNotNull(result);
+    assertNotNull(result.getPublic());
+    assertNotNull(result.getPrivate());
   }
 }

--- a/app/src/test/java/com/amaze/filemanager/asynchronous/asynctasks/ssh/PemToKeyPairTaskTest2.java
+++ b/app/src/test/java/com/amaze/filemanager/asynchronous/asynctasks/ssh/PemToKeyPairTaskTest2.java
@@ -23,7 +23,8 @@ package com.amaze.filemanager.asynchronous.asynctasks.ssh;
 import static org.junit.Assert.assertNotNull;
 
 import java.lang.reflect.Field;
-import java.util.concurrent.CountDownLatch;
+import java.security.KeyPair;
+import java.util.concurrent.ExecutionException;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -61,34 +62,19 @@ public class PemToKeyPairTaskTest2 {
           + "-----END OPENSSH PRIVATE KEY-----";
 
   @Test
-  public void testUnencryptedKeyToKeyPair() throws InterruptedException {
-    CountDownLatch waiter = new CountDownLatch(1);
-    PemToKeyPairTask task =
-        new PemToKeyPairTask(
-            unencryptedOpenSshKey,
-            result -> {
-              assertNotNull(result);
-              assertNotNull(result.getPublic());
-              assertNotNull(result.getPrivate());
-              waiter.countDown();
-            });
-    task.execute();
-    waiter.await();
+  public void testUnencryptedKeyToKeyPair() throws ExecutionException, InterruptedException {
+    PemToKeyPairTask task = new PemToKeyPairTask(unencryptedOpenSshKey, result -> {});
+    KeyPair result = task.execute().get();
+    assertNotNull(result);
+    assertNotNull(result.getPublic());
+    assertNotNull(result.getPrivate());
   }
 
   @Test
   public void testEncryptedKeyToKeyPair()
-      throws InterruptedException, NoSuchFieldException, IllegalAccessException {
-    CountDownLatch waiter = new CountDownLatch(1);
-    PemToKeyPairTask task =
-        new PemToKeyPairTask(
-            encryptedOpenSshKey,
-            result -> {
-              assertNotNull(result);
-              assertNotNull(result.getPublic());
-              assertNotNull(result.getPrivate());
-              waiter.countDown();
-            });
+      throws InterruptedException, NoSuchFieldException, IllegalAccessException,
+          ExecutionException {
+    PemToKeyPairTask task = new PemToKeyPairTask(encryptedOpenSshKey, result -> {});
     Field field = PemToKeyPairTask.class.getDeclaredField("passwordFinder");
     field.setAccessible(true);
     field.set(
@@ -104,7 +90,9 @@ public class PemToKeyPairTaskTest2 {
             return false;
           }
         });
-    task.execute();
-    waiter.await();
+    KeyPair result = task.execute().get();
+    assertNotNull(result);
+    assertNotNull(result.getPublic());
+    assertNotNull(result.getPrivate());
   }
 }

--- a/app/src/test/java/com/amaze/filemanager/database/ExplorerDatabaseMigrationTest.java
+++ b/app/src/test/java/com/amaze/filemanager/database/ExplorerDatabaseMigrationTest.java
@@ -46,6 +46,7 @@ import org.robolectric.annotation.Config;
 import com.amaze.filemanager.database.models.explorer.CloudEntry;
 import com.amaze.filemanager.file_operations.filesystem.OpenMode;
 import com.amaze.filemanager.shadows.ShadowMultiDex;
+import com.amaze.filemanager.test.ShadowCryptUtil;
 
 import androidx.room.Room;
 import androidx.sqlite.db.SupportSQLiteDatabase;
@@ -57,7 +58,7 @@ import io.reactivex.schedulers.Schedulers;
 
 @RunWith(AndroidJUnit4.class)
 @Config(
-    shadows = {ShadowMultiDex.class},
+    shadows = {ShadowMultiDex.class, ShadowCryptUtil.class},
     sdk = {JELLY_BEAN, KITKAT, P})
 public class ExplorerDatabaseMigrationTest {
 

--- a/app/src/test/java/com/amaze/filemanager/filesystem/compressed/B0rkenZipTest.java
+++ b/app/src/test/java/com/amaze/filemanager/filesystem/compressed/B0rkenZipTest.java
@@ -23,6 +23,7 @@ package com.amaze.filemanager.filesystem.compressed;
 import static android.os.Build.VERSION_CODES.JELLY_BEAN;
 import static android.os.Build.VERSION_CODES.KITKAT;
 import static android.os.Build.VERSION_CODES.P;
+import static kotlin.io.ConstantsKt.DEFAULT_BUFFER_SIZE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -30,11 +31,11 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.util.List;
 
-import org.apache.commons.compress.utils.IOUtils;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.annotation.Config;
+import org.robolectric.shadows.ShadowLooper;
 import org.robolectric.shadows.ShadowToast;
 
 import com.amaze.filemanager.R;
@@ -49,6 +50,8 @@ import android.os.Environment;
 
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import kotlin.io.ByteStreamsKt;
 
 @RunWith(AndroidJUnit4.class)
 @Config(
@@ -81,15 +84,18 @@ public class B0rkenZipTest {
 
   @Before
   public void setUp() throws Exception {
-    IOUtils.copy(
+    ByteStreamsKt.copyTo(
         getClass().getClassLoader().getResourceAsStream("zip-slip.zip"),
-        new FileOutputStream(zipfile1));
-    IOUtils.copy(
+        new FileOutputStream(zipfile1),
+        DEFAULT_BUFFER_SIZE);
+    ByteStreamsKt.copyTo(
         getClass().getClassLoader().getResourceAsStream("zip-slip-win.zip"),
-        new FileOutputStream(zipfile2));
-    IOUtils.copy(
+        new FileOutputStream(zipfile2),
+        DEFAULT_BUFFER_SIZE);
+    ByteStreamsKt.copyTo(
         getClass().getClassLoader().getResourceAsStream("test-slashprefix.zip"),
-        new FileOutputStream(zipfile3));
+        new FileOutputStream(zipfile3),
+        DEFAULT_BUFFER_SIZE);
   }
 
   @Test
@@ -146,6 +152,7 @@ public class B0rkenZipTest {
     List<CompressedObjectParcelable> result = task.execute().get().result;
     assertEquals(1, result.size());
     assertEquals("good.txt", result.get(0).path);
+    ShadowLooper.idleMainLooper();
     assertEquals(
         ApplicationProvider.getApplicationContext()
             .getString(R.string.multiple_invalid_archive_entries),
@@ -162,6 +169,7 @@ public class B0rkenZipTest {
             false,
             (data) -> {});
     List<CompressedObjectParcelable> result = task.execute().get().result;
+    ShadowLooper.idleMainLooper();
     assertEquals(1, result.size());
     assertEquals("good.txt", result.get(0).path);
     assertEquals(

--- a/app/src/test/java/com/amaze/filemanager/filesystem/files/FileListSorterTest.java
+++ b/app/src/test/java/com/amaze/filemanager/filesystem/files/FileListSorterTest.java
@@ -31,7 +31,6 @@ import static org.junit.Assert.assertThat;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.annotation.Config;
-import org.robolectric.shadows.ShadowDateFormat;
 
 import com.amaze.filemanager.adapters.data.LayoutElementParcelable;
 import com.amaze.filemanager.file_operations.filesystem.OpenMode;
@@ -46,7 +45,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
  */
 @RunWith(AndroidJUnit4.class)
 @Config(
-    shadows = {ShadowMultiDex.class, ShadowDateFormat.class},
+    shadows = {ShadowMultiDex.class},
     sdk = {JELLY_BEAN, KITKAT, P})
 public class FileListSorterTest {
   /**

--- a/app/src/test/java/com/amaze/filemanager/utils/AnimUtilsTest.java
+++ b/app/src/test/java/com/amaze/filemanager/utils/AnimUtilsTest.java
@@ -28,17 +28,16 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.mock;
-import static org.robolectric.Shadows.shadowOf;
 
 import java.lang.reflect.Field;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.annotation.Config;
+import org.robolectric.shadows.ShadowLooper;
 
 import com.amaze.filemanager.ui.views.ThemedTextView;
 
-import android.os.Looper;
 import android.view.animation.Interpolator;
 
 import androidx.test.core.app.ApplicationProvider;
@@ -68,7 +67,7 @@ public class AnimUtilsTest {
     mock.setSelected(false);
 
     AnimUtils.marqueeAfterDelay(150, mock);
-    shadowOf(Looper.myLooper()).getScheduler().advanceToLastPostedRunnable();
+    ShadowLooper.runUiThreadTasksIncludingDelayedTasks();
     assertTrue(mock.isSelected());
   }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@
 buildscript {
     ext {
         kotlin_version = "1.5.0"
-        robolectricVersion = '4.3.1'
+        robolectricVersion = '4.7'
         glideVersion = '4.11.0'
         sshjVersion = '0.32.0'
         jcifsVersion = '2.1.6'
@@ -99,22 +99,26 @@ configurations {
     robo27
     robo28
     robo29
+    robo30
+    robo31
 }
 
 dependencies {
-    robo16 "org.robolectric:android-all:4.1.2_r1-robolectric-r1"
-    robo17 "org.robolectric:android-all:4.2.2_r1.2-robolectric-r1"
-    robo18 "org.robolectric:android-all:4.3_r2-robolectric-r1"
-    robo19 "org.robolectric:android-all:4.4_r1-robolectric-r2"
-    robo21 "org.robolectric:android-all:5.0.2_r3-robolectric-r0"
-    robo22 "org.robolectric:android-all:5.1.1_r9-robolectric-r2"
-    robo23 "org.robolectric:android-all:6.0.1_r3-robolectric-r1"
-    robo24 "org.robolectric:android-all:7.0.0_r1-robolectric-r1"
-    robo25 "org.robolectric:android-all:7.1.0_r7-robolectric-r1"
-    robo26 "org.robolectric:android-all:8.0.0_r4-robolectric-r1"
-    robo27 "org.robolectric:android-all:8.1.0-robolectric-4611349"
-    robo28 "org.robolectric:android-all:9-robolectric-4913185-2"
-    robo29 "org.robolectric:android-all:10-robolectric-5803371"
+    robo16 "org.robolectric:android-all-instrumented:4.1.2_r1-robolectric-r1-i2"
+    robo17 "org.robolectric:android-all-instrumented:4.2.2_r1.2-robolectric-r1-i2"
+    robo18 "org.robolectric:android-all-instrumented:4.3_r2-robolectric-r1-i2"
+    robo19 "org.robolectric:android-all-instrumented:4.4_r1-robolectric-r2-i2"
+    robo21 "org.robolectric:android-all-instrumented:5.0.2_r3-robolectric-r0-i2"
+    robo22 "org.robolectric:android-all-instrumented:5.1.1_r9-robolectric-r2-i2"
+    robo23 "org.robolectric:android-all-instrumented:6.0.1_r3-robolectric-r1-i2"
+    robo24 "org.robolectric:android-all-instrumented:7.0.0_r1-robolectric-r1-i2"
+    robo25 "org.robolectric:android-all-instrumented:7.1.0_r7-robolectric-r1-i2"
+    robo26 "org.robolectric:android-all-instrumented:8.0.0_r4-robolectric-r1-i2"
+    robo27 "org.robolectric:android-all-instrumented:8.1.0-robolectric-4611349-i2"
+    robo28 "org.robolectric:android-all-instrumented:9-robolectric-4913185-2-i2"
+    robo29 "org.robolectric:android-all-instrumented:10-robolectric-5803371-i2"
+    robo30 "org.robolectric:android-all-instrumented:11-robolectric-6757853-i2"
+    robo31 "org.robolectric:android-all-instrumented:12-robolectric-7732740-i2"
 }
 
 def robolectricDependencies = "${rootProject.buildDir.path}/robolectric"
@@ -133,6 +137,8 @@ task fetchRobolectricDependencies(type: Copy) {
     from configurations.robo27
     from configurations.robo28
     from configurations.robo29
+    from configurations.robo30
+    from configurations.robo31
     into robolectricDependencies
 }
 


### PR DESCRIPTION
## Description
Additionally, inside SshConnectionPool, eliminated the CountdownLatch when waiting for converting PEM to private key AsyncTask; instead it became a blocking call. Should not hurt performance by much, but with simpler code and most importantly, work around Robolectric's default PAUSED LooperMode, which doesn't work well with code containing CountdownLatches.
  
#### Manual tests
- [x] Done  
  
- Device: Pixel 2 emulator
- OS: Android 11
SSH connection with key authentication should not be affected by the refactoring to SshConnectionPool.

#### Build tasks success  
Successfully running following tasks on local:
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`
