### PR TITLE
Lenient FTP server connectivity check and remove AP enabled check

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -51,6 +51,7 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard.cfg'
             testProguardFile 'tests-proguard.cfg'
             buildConfigField "String", "CRYPTO_IV", "\"LxbHiJhhUXcj\""
+            buildConfigField "String", "FTP_SERVER_KEYSTORE_PASSWORD", "\"vishal007\""
             debuggable true //For "debug" banner on icon
         }
 
@@ -60,6 +61,7 @@ android {
             minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard.cfg'
             buildConfigField "String", "CRYPTO_IV", "\"LxbHiJhhUXcj\""
+            buildConfigField "String", "FTP_SERVER_KEYSTORE_PASSWORD", "\"vishal007\""
         }
     }
 

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/services/ftp/FtpTileService.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/services/ftp/FtpTileService.java
@@ -65,8 +65,7 @@ public class FtpTileService extends TileService {
                     new Intent(FtpService.ACTION_STOP_FTPSERVER).setPackage(getPackageName()));
           } else {
             if (FtpService.isConnectedToWifi(getApplicationContext())
-                || FtpService.isConnectedToLocalNetwork(getApplicationContext())
-                || FtpService.isEnabledWifiHotspot(getApplicationContext())) {
+                || FtpService.isConnectedToLocalNetwork(getApplicationContext())) {
               Intent i = new Intent(FtpService.ACTION_START_FTPSERVER).setPackage(getPackageName());
               i.putExtra(FtpService.TAG_STARTED_BY_TILE, true);
               getApplicationContext().sendBroadcast(i);

--- a/app/src/main/java/com/amaze/filemanager/ui/fragments/FtpServerFragment.kt
+++ b/app/src/main/java/com/amaze/filemanager/ui/fragments/FtpServerFragment.kt
@@ -56,7 +56,6 @@ import com.amaze.filemanager.asynchronous.services.ftp.FtpService.Companion.KEY_
 import com.amaze.filemanager.asynchronous.services.ftp.FtpService.Companion.getLocalInetAddress
 import com.amaze.filemanager.asynchronous.services.ftp.FtpService.Companion.isConnectedToLocalNetwork
 import com.amaze.filemanager.asynchronous.services.ftp.FtpService.Companion.isConnectedToWifi
-import com.amaze.filemanager.asynchronous.services.ftp.FtpService.Companion.isEnabledWifiHotspot
 import com.amaze.filemanager.asynchronous.services.ftp.FtpService.Companion.isRunning
 import com.amaze.filemanager.asynchronous.services.ftp.FtpService.FtpReceiverActions
 import com.amaze.filemanager.databinding.DialogFtpLoginBinding
@@ -149,8 +148,7 @@ class FtpServerFragment : Fragment(R.layout.fragment_ftp) {
     private fun ftpBtnOnClick() {
         if (!isRunning()) {
             if (isConnectedToWifi(requireContext()) ||
-                isConnectedToLocalNetwork(requireContext()) ||
-                isEnabledWifiHotspot(requireContext())
+                isConnectedToLocalNetwork(requireContext())
             ) {
                 startServer()
             } else {
@@ -391,18 +389,18 @@ class FtpServerFragment : Fragment(R.layout.fragment_ftp) {
     @Suppress("LabeledExpression")
     private fun createOpenDocumentTreeIntentCallback(callback: (directoryUri: Uri) -> Unit):
         ActivityResultLauncher<Intent> {
-            return registerForActivityResult(
-                ActivityResultContracts.StartActivityForResult()
-            ) {
-                if (it.resultCode == RESULT_OK && SDK_INT >= LOLLIPOP) {
-                    val directoryUri = it.data?.data ?: return@registerForActivityResult
-                    requireContext().contentResolver.takePersistableUriPermission(
-                        directoryUri, GRANT_URI_RW_PERMISSION
-                    )
-                    callback.invoke(directoryUri)
-                }
+        return registerForActivityResult(
+            ActivityResultContracts.StartActivityForResult()
+        ) {
+            if (it.resultCode == RESULT_OK && SDK_INT >= LOLLIPOP) {
+                val directoryUri = it.data?.data ?: return@registerForActivityResult
+                requireContext().contentResolver.takePersistableUriPermission(
+                    directoryUri, GRANT_URI_RW_PERMISSION
+                )
+                callback.invoke(directoryUri)
             }
         }
+    }
 
     /** Check URI access. Prompt user to DocumentsUI if necessary */
     private fun checkUriAccessIfNecessary(callback: () -> Unit) {
@@ -509,8 +507,7 @@ class FtpServerFragment : Fragment(R.layout.fragment_ftp) {
     private fun updateStatus() {
         if (!isRunning()) {
             if (!isConnectedToWifi(requireContext()) &&
-                !isConnectedToLocalNetwork(requireContext()) &&
-                !isEnabledWifiHotspot(requireContext())
+                !isConnectedToLocalNetwork(requireContext())
             ) {
                 statusText.text = spannedStatusNoConnection
                 ftpBtn.isEnabled = false


### PR DESCRIPTION
## Description
Fixes #2720, to accommodate Wifi hotspot function changes since Android 11.

Previously, we relied on fixed IP prefix (192.168.43.x) to determine device has AP enabled, if the device is not connected to network. However as of Android 11, AP address prefix is random, such IP prefix check is useless.

This PR changes the way of checking.

- First we check for active network with ConnectivityManager. This should cover any connected Wifi/Ethernet connection
- if there is no active network, enumerate available NetworkInterface on device with name `rndis` or `wlan`. This should cover tethered connection and AP on device
- lastly, remove check for AP IP prefix at FtpService.getLocalInetAddress() and AP enable check

Additionally, moved FTP server keystore's password as BuildConfig field.

#### Issue tracker   
Fixes #2720

#### Manual tests
- [x] Done  
  
Device:
- GPD XD running LegacyROM (4.4.4)
- Samsung Galaxy S2 running SlimLP (5.1.1)
- LG Nexus 5x running AOSPExtended 6.7 (9.0)
- Fairphone 3 running LineageOS 16.0 (9.0)
- Oneplus 2 running LineageOS 18 (11)

With AP mode enabled or connected, FTP server button is enabled, and is able to display the device's IP address on above Android versions.

There is one glitch though - I suspect this glitch also exist before this PR.
- Enable AP, FTP server button is enabled
- Start FTP server
- Stop FTP server
- Disable AP
- FTP server button is still enabled

AP status change seems to be not covered by methods known to us currently. May advice if you have any idea.

#### Build tasks success  
Successfully running following tasks on local:
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`