### PR TITLE
fix: fix build failed on M1 chip

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,7 +6,7 @@ apply plugin: 'com.hiya.jacoco-android'
 apply plugin: "com.starter.easylauncher"
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
 
     packagingOptions {
         exclude 'proguard-project.txt'

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         sshjVersion = '0.32.0'
         jcifsVersion = '2.1.6'
         fabSpeedDialVersion = '3.1.1'
-        roomVersion = '2.3.0'
+        roomVersion = '2.4.0-rc01'
         bouncyCastleVersion = '1.68'
         awaitilityVersion = "3.1.6"
         androidMaterialVersion = "1.4.0"

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         sshjVersion = '0.32.0'
         jcifsVersion = '2.1.6'
         fabSpeedDialVersion = '3.1.1'
-        roomVersion = '2.4.0-rc01'
+        roomVersion = '2.4.0'
         bouncyCastleVersion = '1.68'
         awaitilityVersion = "3.1.6"
         androidMaterialVersion = "1.4.0"


### PR DESCRIPTION
## Description

Fix Room’s SQLite native library to support Apple’s M1 chips

https://developer.android.com/jetpack/androidx/releases/room#2.4.0-alpha03

https://issuetracker.google.com/issues/174695268

Upgrade compileSdkVersion to 31 for room's dependency

#### Issue tracker   
Fixes #3062

#### Automatic tests
<!-- remember to do manual testing when making UI changes! -->
- [ ] Added test cases
  
#### Manual tests
- [x] Done  
  
<!-- If yes, -->
<!-- 
- Device:
- OS:
-->

#### Build tasks success  
<!-- run these! -->
Successfully running following tasks on local:
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`

<!-- If there are related PRs please add them here -->
<!--
#### Related PR  
Related to PR #
-->
