### PR TITLE
Fix back button not responding when browsing at second level of archive

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/ui/fragments/CompressedExplorerFragment.kt
+++ b/app/src/main/java/com/amaze/filemanager/ui/fragments/CompressedExplorerFragment.kt
@@ -626,9 +626,8 @@ class CompressedExplorerFragment : Fragment(), BottomBarButtonPath {
      * Go one level up in the archive hierarchy.
      */
     fun goBack() {
-        File(relativeDirectory).parent?.let { parent ->
-            changePath(parent)
-        }
+        val parent: String = File(relativeDirectory).parent ?: ""
+        changePath(parent)
     }
 
     private val isRootRelativePath: Boolean


### PR DESCRIPTION
## Description
There was a bug in CompressedExplorerFragment.goBack() that prevent browsing back to the first level of archive. This change fixes this, by defaulting parent path to "" if no parent path can be derived.

#### Manual tests
- [x] Done  
  
- Device: Pixel 2 emulator
- OS: Android 11

#### Build tasks success  
Successfully running following tasks on local:
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`
