### PR TITLE
Fix some more leaked closeable violations

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/compress/AbstractCommonsArchiveHelperTask.kt
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/compress/AbstractCommonsArchiveHelperTask.kt
@@ -58,39 +58,39 @@ abstract class AbstractCommonsArchiveHelperTask(
     @Throws(ArchiveException::class)
     @Suppress("LabeledExpression")
     public override fun addElements(elements: ArrayList<CompressedObjectParcelable>) {
-        var tarInputStream: ArchiveInputStream?
         try {
-            tarInputStream = createFrom(FileInputStream(filePath))
-            var entry: ArchiveEntry?
-            while (tarInputStream.nextEntry.also { entry = it } != null) {
-                entry?.run {
-                    var name = name
-                    if (!CompressedHelper.isEntryPathValid(name)) {
-                        AppConfig.toast(
-                            context.get(),
-                            context.get()!!.getString(R.string.multiple_invalid_archive_entries)
-                        )
-                        return@run
-                    }
-                    if (name.endsWith(CompressedHelper.SEPARATOR)) {
-                        name = name.substring(0, name.length - 1)
-                    }
-                    val isInBaseDir =
-                        (relativePath == "" && !name.contains(CompressedHelper.SEPARATOR))
-                    val isInRelativeDir = (
-                        name.contains(CompressedHelper.SEPARATOR) &&
-                            name.substring(0, name.lastIndexOf(CompressedHelper.SEPARATOR))
-                            == relativePath
-                        )
-                    if (isInBaseDir || isInRelativeDir) {
-                        elements.add(
-                            CompressedObjectParcelable(
-                                name,
-                                lastModifiedDate.time,
-                                size,
-                                isDirectory
+            createFrom(FileInputStream(filePath)).use { tarInputStream ->
+                var entry: ArchiveEntry?
+                while (tarInputStream.nextEntry.also { entry = it } != null) {
+                    entry?.run {
+                        var name = name
+                        if (!CompressedHelper.isEntryPathValid(name)) {
+                            AppConfig.toast(
+                                context.get(),
+                                context.get()!!.getString(R.string.multiple_invalid_archive_entries)
                             )
-                        )
+                            return@run
+                        }
+                        if (name.endsWith(CompressedHelper.SEPARATOR)) {
+                            name = name.substring(0, name.length - 1)
+                        }
+                        val isInBaseDir =
+                            (relativePath == "" && !name.contains(CompressedHelper.SEPARATOR))
+                        val isInRelativeDir = (
+                            name.contains(CompressedHelper.SEPARATOR) &&
+                                name.substring(0, name.lastIndexOf(CompressedHelper.SEPARATOR))
+                                == relativePath
+                            )
+                        if (isInBaseDir || isInRelativeDir) {
+                            elements.add(
+                                CompressedObjectParcelable(
+                                    name,
+                                    lastModifiedDate.time,
+                                    size,
+                                    isDirectory
+                                )
+                            )
+                        }
                     }
                 }
             }

--- a/app/src/main/java/com/amaze/filemanager/ui/fragments/CompressedExplorerFragment.kt
+++ b/app/src/main/java/com/amaze/filemanager/ui/fragments/CompressedExplorerFragment.kt
@@ -266,8 +266,10 @@ class CompressedExplorerFragment : Fragment(), BottomBarButtonPath {
                                     }
                         }
                         compressedFile.deleteOnExit()
-                        requireContext().contentResolver.openInputStream(pathUri)
-                            ?.copyTo(FileOutputStream(compressedFile), DEFAULT_BUFFER_SIZE)
+                        FileOutputStream(compressedFile).use { outputStream ->
+                            requireContext().contentResolver.openInputStream(pathUri)
+                                ?.use { it.copyTo(outputStream, DEFAULT_BUFFER_SIZE) }
+                        }
                         isCachedCompressedFile = true
                     } catch (e: IOException) {
                         Log.e(TAG, "Error opening URI $pathUri for reading", e)


### PR DESCRIPTION
## Description
Automatically close input stream by using Kotlins built-in `use` operator.

#### Issue tracker
Fixes #3096 and similar violations


#### Automatic tests
<!-- remember to do manual testing when making UI changes! -->
- [ ] Added test cases
  
#### Manual tests
- [x] Done  
  
- OS: Android 9

#### Build tasks success  
<!-- run these! -->
Successfully running following tasks on local:
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`