### PR TITLE
Bump EventBus 3.3.1 and use its proguard rules

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -192,7 +192,7 @@ dependencies {
     // https://mvnrepository.com/artifact/org.apache.ftpserver/ftpserver-core
     implementation group: 'org.apache.ftpserver', name: 'ftpserver-core', version: '1.1.0'
 
-    implementation 'org.greenrobot:eventbus:3.1.1'
+    implementation 'org.greenrobot:eventbus:3.3.1'
 
     implementation 'com.android.volley:volley:1.2.1'
 

--- a/app/proguard.cfg
+++ b/app/proguard.cfg
@@ -98,12 +98,6 @@
 -keep class org.bouncycastle.jcajce.spec.* {*;}
 -keep class org.bouncycastle.jce.** {*;}
 
-#EventBus
--keep class org.greenrobot.eventbus.** {*;}
--keepclassmembers class * {
-    @org.greenrobot.eventbus.Subscribe *;
-}
-
 -dontwarn javax.naming.**
 
 #From here sshj. We are not using GSSAPI to connect to SSH


### PR DESCRIPTION
## Description
Update EventBus and use its proguard rules. They're embedded since [3.3.0](https://github.com/greenrobot/EventBus/releases/tag/V3.3.0)

#### Automatic tests
<!-- remember to do manual testing when making UI changes! -->
- [ ] Added test cases
  
#### Manual tests
- [x] FtpServer still works

#### Build tasks success  
<!-- run these! -->
Successfully running following tasks on local:
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`