### PR TITLE
Trap exceptions thrown when processing corrupt archives

### DIFF
--- a/.github/workflows/android-main.yml
+++ b/.github/workflows/android-main.yml
@@ -60,7 +60,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        api-level: [ 23]#[ 16, 19, 28 ]
+        api-level: [ 23 ]#[ 16, 19, 28 ]
             steps:
               - name: checkout
                 uses: actions/checkout@v2

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/compress/AbstractCompressedTarArchiveHelperTask.kt
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/compress/AbstractCompressedTarArchiveHelperTask.kt
@@ -23,6 +23,7 @@ package com.amaze.filemanager.asynchronous.asynctasks.compress
 import android.content.Context
 import com.amaze.filemanager.adapters.data.CompressedObjectParcelable
 import com.amaze.filemanager.asynchronous.asynctasks.AsyncTaskResult
+import com.amaze.filemanager.filesystem.compressed.extractcontents.Extractor
 import com.amaze.filemanager.utils.OnAsyncTaskFinished
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream
 import org.apache.commons.compress.compressors.CompressorInputStream
@@ -57,6 +58,10 @@ abstract class AbstractCompressedTarArchiveHelperTask(
     abstract fun getCompressorInputStreamClass(): Class<out CompressorInputStream>
 
     override fun createFrom(inputStream: InputStream): TarArchiveInputStream {
-        return TarArchiveInputStream(compressorInputStreamConstructor.newInstance(inputStream))
+        return runCatching {
+            TarArchiveInputStream(compressorInputStreamConstructor.newInstance(inputStream))
+        }.getOrElse {
+            throw Extractor.BadArchiveNotice(it)
+        }
     }
 }

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/compress/RarHelperTask.kt
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/compress/RarHelperTask.kt
@@ -51,11 +51,11 @@ class RarHelperTask(
     @Throws(ArchiveException::class)
     override fun addElements(elements: ArrayList<CompressedObjectParcelable>) {
         try {
-            val zipfile = Archive(File(fileLocation))
+            val rarFile = Archive(File(fileLocation))
             val relativeDirDiffSeparator = relativeDirectory.replace(
                 CompressedHelper.SEPARATOR, "\\"
             )
-            for (rarArchive in zipfile.fileHeaders) {
+            for (rarArchive in rarFile.fileHeaders) {
                 val name = rarArchive.fileName
                 if (!CompressedHelper.isEntryPathValid(name)) {
                     continue

--- a/app/src/main/java/com/amaze/filemanager/filesystem/compressed/extractcontents/Extractor.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/compressed/extractcontents/Extractor.java
@@ -23,17 +23,17 @@ package com.amaze.filemanager.filesystem.compressed.extractcontents;
 import static com.amaze.filemanager.filesystem.compressed.CompressedHelper.SEPARATOR;
 import static com.amaze.filemanager.filesystem.compressed.CompressedHelper.SEPARATOR_CHAR;
 
+import android.content.Context;
+
+import androidx.annotation.NonNull;
+
+import com.amaze.filemanager.file_operations.utils.UpdatePosition;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
-
-import com.amaze.filemanager.file_operations.utils.UpdatePosition;
-
-import android.content.Context;
-
-import androidx.annotation.NonNull;
 
 public abstract class Extractor {
 
@@ -113,5 +113,11 @@ public abstract class Extractor {
     }
   }
 
-  public class EmptyArchiveNotice extends IOException {}
+  public static class EmptyArchiveNotice extends IOException {}
+
+  public static class BadArchiveNotice extends IOException {
+    public BadArchiveNotice(@NonNull Throwable reason) {
+      super(reason);
+    }
+  }
 }

--- a/app/src/main/java/com/amaze/filemanager/filesystem/compressed/extractcontents/helpers/AbstractCommonsCompressedFileExtractor.kt
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/compressed/extractcontents/helpers/AbstractCommonsCompressedFileExtractor.kt
@@ -60,30 +60,30 @@ abstract class AbstractCommonsCompressedFileExtractor(
 
     override fun extractWithFilter(filter: Filter) {
         val entryName = filePath.substringAfterLast('/').substringBeforeLast('.')
-        compressorInputStreamConstructor.newInstance(FileInputStream(filePath)).use { inputStream ->
-            val outputFile = File(outputPath, entryName)
-            if (false == outputFile.parentFile?.exists()) {
-                MakeDirectoryOperation.mkdir(outputFile.parentFile, context)
-            }
-            FileUtil.getOutputStream(outputFile, context)?.let { fileOutputStream ->
-                BufferedOutputStream(fileOutputStream).use {
-                    var len: Int
-                    val buf = ByteArray(GenericCopyUtil.DEFAULT_BUFFER_SIZE)
-                    while (inputStream.read(buf).also { len = it } != -1) {
-                        it.write(buf, 0, len)
-                        updatePosition.updatePosition(len.toLong())
-                    }
-                    listener.onFinish()
+        runCatching {
+            compressorInputStreamConstructor.newInstance(FileInputStream(filePath)).use { inputStream ->
+                val outputFile = File(outputPath, entryName)
+                if (false == outputFile.parentFile?.exists()) {
+                    MakeDirectoryOperation.mkdir(outputFile.parentFile, context)
                 }
-                outputFile.setLastModified(File(filePath).lastModified())
-            } ?: AppConfig.toast(
-                context,
-                context.getString(
-                    R.string.error_archive_cannot_extract,
-                    entryName,
-                    outputPath
+                FileUtil.getOutputStream(outputFile, context)?.let { fileOutputStream ->
+                    BufferedOutputStream(fileOutputStream).use {
+                        var len: Int
+                        val buf = ByteArray(GenericCopyUtil.DEFAULT_BUFFER_SIZE)
+                        while (inputStream.read(buf).also { len = it } != -1) {
+                            it.write(buf, 0, len)
+                            updatePosition.updatePosition(len.toLong())
+                        }
+                        listener.onFinish()
+                    }
+                    outputFile.setLastModified(File(filePath).lastModified())
+                } ?: AppConfig.toast(
+                    context,
+                    context.getString(R.string.error_archive_cannot_extract, entryName, outputPath)
                 )
-            )
+            }
+        }.onFailure {
+            throw BadArchiveNotice(it)
         }
     }
 }

--- a/app/src/main/java/com/amaze/filemanager/filesystem/compressed/extractcontents/helpers/AbstractCompressedTarArchiveExtractor.kt
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/compressed/extractcontents/helpers/AbstractCompressedTarArchiveExtractor.kt
@@ -54,6 +54,10 @@ abstract class AbstractCompressedTarArchiveExtractor(
     abstract fun getCompressorInputStreamClass(): Class<out CompressorInputStream>
 
     override fun createFrom(inputStream: InputStream): TarArchiveInputStream {
-        return TarArchiveInputStream(compressorInputStreamConstructor.newInstance(inputStream))
+        return runCatching {
+            TarArchiveInputStream(compressorInputStreamConstructor.newInstance(inputStream))
+        }.getOrElse {
+            throw BadArchiveNotice(it)
+        }
     }
 }

--- a/app/src/main/java/com/amaze/filemanager/filesystem/compressed/extractcontents/helpers/TarExtractor.kt
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/compressed/extractcontents/helpers/TarExtractor.kt
@@ -36,5 +36,9 @@ class TarExtractor(
 ) {
 
     override fun createFrom(inputStream: InputStream): TarArchiveInputStream =
-        TarArchiveInputStream(inputStream)
+        runCatching {
+            TarArchiveInputStream(inputStream)
+        }.getOrElse {
+            throw BadArchiveNotice(it)
+        }
 }

--- a/app/src/main/java/com/amaze/filemanager/filesystem/compressed/extractcontents/helpers/ZipExtractor.kt
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/compressed/extractcontents/helpers/ZipExtractor.kt
@@ -33,6 +33,7 @@ import com.amaze.filemanager.filesystem.files.GenericCopyUtil
 import net.lingala.zip4j.ZipFile
 import net.lingala.zip4j.exception.ZipException
 import net.lingala.zip4j.model.FileHeader
+import org.apache.commons.compress.PasswordRequiredException
 import java.io.BufferedInputStream
 import java.io.BufferedOutputStream
 import java.io.File
@@ -81,7 +82,14 @@ class ZipExtractor(
             }
             listener.onFinish()
         } catch (e: ZipException) {
-            throw IOException(e)
+            if (true == e.message?.lowercase()?.contains("password")) {
+                // Hack.
+                // zip4j uses ZipException for all problems, so we need to distinguish password
+                // related problems and throw PasswordRequiredException here
+                throw PasswordRequiredException(e.message)
+            } else {
+                throw BadArchiveNotice(e)
+            }
         }
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -720,6 +720,8 @@ You only need to do this once, until the next time you select a new location for
     <string name="ftp_server_fallback_path_reset_prompt">FTP server shared path had been resetted to internal storage as you are switching back to legacy filesystem implementation. Please select a new path using the menu on the top right as necessary.</string>
     <string name="compressed_explorer_fragment_error_open_uri">Error opening URI \"%s\" for reading.</string>
     <string name="error_empty_archive">\"%s\" is an empty archive.</string>
+    <string name="error_bad_archive_without_info">\"%s\" is a corrupted archive.</string>
+    <string name="error_bad_archive_with_info">\"%s\" is a corrupted archive.\nMessage from extractor: \"%s\"</string>
     <string name="security_error">File could not be opened using this app</string>
     <string name="cloud_drive_tooltip">Create a Google Drive™ connection for managing files from within Amaze File Manager.</string>
     <string name="signin_with_google_title">Authenticate to use Google Drive™</string>

--- a/app/src/test/java/com/amaze/filemanager/asynchronous/asynctasks/compress/AbstractCompressedHelperTaskArchiveTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/asynchronous/asynctasks/compress/AbstractCompressedHelperTaskArchiveTest.kt
@@ -20,8 +20,15 @@
 
 package com.amaze.filemanager.asynchronous.asynctasks.compress
 
-import org.junit.Assert.assertEquals
+import android.os.Environment
+import com.amaze.filemanager.test.randomBytes
+import com.amaze.filemanager.test.supportedArchiveExtensions
+import org.apache.commons.compress.archivers.ArchiveException
+import org.junit.Assert.*
 import org.junit.Test
+import java.io.ByteArrayInputStream
+import java.io.File
+import java.io.FileOutputStream
 import java.time.ZoneId
 import java.time.ZonedDateTime
 
@@ -38,6 +45,8 @@ abstract class AbstractCompressedHelperTaskArchiveTest : AbstractCompressedHelpe
         0,
         ZoneId.of("UTC")
     ).toInstant().toEpochMilli()
+
+    protected abstract val archiveFileName: String
 
     /**
      * Test browse archive top level.
@@ -58,7 +67,7 @@ abstract class AbstractCompressedHelperTaskArchiveTest : AbstractCompressedHelpe
     open fun testSublevels() {
         var task = createTask("test-archive")
         var result = task.doInBackground()
-        assertEquals(5, result.result.size.toLong())
+        assertEquals("Thrown from $javaClass.name", 5, result.result.size.toLong())
         assertEquals("1", result.result[0].name)
         assertEquals(EXPECTED_TIMESTAMP, result.result[0].date)
         assertEquals("2", result.result[1].name)
@@ -112,5 +121,8 @@ abstract class AbstractCompressedHelperTaskArchiveTest : AbstractCompressedHelpe
         // assertEquals(512, result.get(0).size);
     }
 
-    protected abstract fun createTask(relativePath: String): CompressedHelperTask
+    protected fun createTask(relativePath: String): CompressedHelperTask =
+        doCreateTask(File(Environment.getExternalStorageDirectory(), archiveFileName), relativePath)
+
+    protected abstract fun doCreateTask(archive: File, relativePath: String): CompressedHelperTask
 }

--- a/app/src/test/java/com/amaze/filemanager/asynchronous/asynctasks/compress/AbstractCompressedHelperTaskTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/asynchronous/asynctasks/compress/AbstractCompressedHelperTaskTest.kt
@@ -44,13 +44,6 @@ import kotlin.collections.ArrayList
 @Config(shadows = [ShadowMultiDex::class], sdk = [JELLY_BEAN, KITKAT, P])
 abstract class AbstractCompressedHelperTaskTest {
 
-    protected val emptyCallback = object :
-        OnAsyncTaskFinished<AsyncTaskResult<ArrayList<CompressedObjectParcelable>>> {
-        override fun onAsyncTaskFinished(
-            data: AsyncTaskResult<ArrayList<CompressedObjectParcelable>>
-        ) = Unit
-    }
-
     private lateinit var systemTz: TimeZone
 
     /**
@@ -81,6 +74,18 @@ abstract class AbstractCompressedHelperTaskTest {
                     File(Environment.getExternalStorageDirectory(), it.name)
                 )
             )
+        }
+    }
+
+    companion object {
+
+        @JvmStatic
+        // To ensure this is created only once and for all.
+        val emptyCallback = object :
+            OnAsyncTaskFinished<AsyncTaskResult<ArrayList<CompressedObjectParcelable>>> {
+            override fun onAsyncTaskFinished(
+                data: AsyncTaskResult<ArrayList<CompressedObjectParcelable>>
+            ) = Unit
         }
     }
 }

--- a/app/src/test/java/com/amaze/filemanager/asynchronous/asynctasks/compress/CompressedHelperForBadArchiveTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/asynchronous/asynctasks/compress/CompressedHelperForBadArchiveTest.kt
@@ -1,0 +1,72 @@
+package com.amaze.filemanager.asynchronous.asynctasks.compress
+
+import android.os.Build.VERSION_CODES.*
+import android.os.Environment
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.amaze.filemanager.filesystem.compressed.CompressedHelper
+import com.amaze.filemanager.shadows.ShadowMultiDex
+import com.amaze.filemanager.test.randomBytes
+import com.amaze.filemanager.test.supportedArchiveExtensions
+import org.apache.commons.compress.archivers.ArchiveException
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import java.io.ByteArrayInputStream
+import java.io.File
+import java.io.FileOutputStream
+
+/**
+ * Test behaviour of CompressedHelpers in handling corrupt archives.
+ */
+@RunWith(AndroidJUnit4::class)
+@Config(shadows = [ShadowMultiDex::class], sdk = [JELLY_BEAN, KITKAT, P])
+class CompressedHelperForBadArchiveTest {
+
+    /**
+     * Test handling of corrupt archive with random junk.
+     */
+    @Test
+    fun testCorruptArchive() {
+        doTestBadArchive(randomBytes())
+    }
+
+    /**
+     * Test handling of zero byte archive.
+     */
+    @Test
+    fun testZeroByteArchive() {
+        doTestBadArchive(ByteArray(0))
+    }
+
+    private fun doTestBadArchive(data: ByteArray) {
+        for (
+            archiveType in supportedArchiveExtensions().subtract(excludedArchiveTypes)
+        ) {
+            val badArchive = File(Environment.getExternalStorageDirectory(), "bad-archive.$archiveType")
+            ByteArrayInputStream(data).copyTo(FileOutputStream(badArchive))
+            val task = CompressedHelper.getCompressorInstance(
+                ApplicationProvider.getApplicationContext(), badArchive
+            ).changePath("", false, AbstractCompressedHelperTaskTest.emptyCallback)
+            val result = task.doInBackground()
+            Assert.assertNull("Thrown from ${task.javaClass}", result.result)
+            Assert.assertNotNull(result.exception)
+            Assert.assertTrue(
+                "Thrown from ${task.javaClass}: ${result.exception.javaClass} was thrown",
+                ArchiveException::class.java.isAssignableFrom(result.exception.javaClass)
+            )
+        }
+    }
+
+    companion object {
+
+        /*
+         * tar and rar currently will produce empty list.
+         * bz2, lzma, gz, xz by default must have one entry
+         * = filename without compressed extension. They won't throw exceptions, so excluded from
+         * list
+         */
+        private val excludedArchiveTypes = listOf("tar", "rar", "bz2", "lzma", "gz", "xz")
+    }
+}

--- a/app/src/test/java/com/amaze/filemanager/asynchronous/asynctasks/compress/CompressedHelperTaskTestSuite.kt
+++ b/app/src/test/java/com/amaze/filemanager/asynchronous/asynctasks/compress/CompressedHelperTaskTestSuite.kt
@@ -39,6 +39,8 @@ import org.junit.runners.Suite.SuiteClasses
     EncryptedRarHelperTaskTest::class,
     EncryptedZipHelperTaskTest::class,
     EncryptedSevenZipHelperTaskTest::class,
-    ListEncryptedSevenZipHelperTaskTest::class
+    ListEncryptedSevenZipHelperTaskTest::class,
+    UnknownCompressedHelperTaskTest::class,
+    CompressedHelperForBadArchiveTest::class
 )
 class CompressedHelperTaskTestSuite

--- a/app/src/test/java/com/amaze/filemanager/asynchronous/asynctasks/compress/EncryptedRarHelperTaskTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/asynchronous/asynctasks/compress/EncryptedRarHelperTaskTest.kt
@@ -20,18 +20,18 @@
 
 package com.amaze.filemanager.asynchronous.asynctasks.compress
 
-import android.os.Environment
 import java.io.File
 
 class EncryptedRarHelperTaskTest : AbstractCompressedHelperTaskArchiveTest() {
 
-    override fun createTask(relativePath: String): CompressedHelperTask = RarHelperTask(
-        File(
-            Environment.getExternalStorageDirectory(),
-            "test-archive-encrypted.rar"
-        ).absolutePath,
-        relativePath,
-        false,
-        emptyCallback
-    )
+    override val archiveFileName: String
+        get() = "test-archive-encrypted.rar"
+
+    override fun doCreateTask(archive: File, relativePath: String): CompressedHelperTask =
+        RarHelperTask(
+            archive.absolutePath,
+            relativePath,
+            false,
+            emptyCallback
+        )
 }

--- a/app/src/test/java/com/amaze/filemanager/asynchronous/asynctasks/compress/EncryptedSevenZipHelperTaskTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/asynchronous/asynctasks/compress/EncryptedSevenZipHelperTaskTest.kt
@@ -20,17 +20,18 @@
 
 package com.amaze.filemanager.asynchronous.asynctasks.compress
 
-import android.os.Environment
 import java.io.File
 
 class EncryptedSevenZipHelperTaskTest : AbstractCompressedHelperTaskArchiveTest() {
-    override fun createTask(relativePath: String): CompressedHelperTask = SevenZipHelperTask(
-        File(
-            Environment.getExternalStorageDirectory(),
-            "test-archive-encrypted.7z"
-        ).absolutePath,
-        relativePath,
-        false,
-        emptyCallback
-    )
+
+    override val archiveFileName: String
+        get() = "test-archive-encrypted.7z"
+
+    override fun doCreateTask(archive: File, relativePath: String): CompressedHelperTask =
+        SevenZipHelperTask(
+            archive.absolutePath,
+            relativePath,
+            false,
+            emptyCallback
+        )
 }

--- a/app/src/test/java/com/amaze/filemanager/asynchronous/asynctasks/compress/EncryptedZipHelperTaskTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/asynchronous/asynctasks/compress/EncryptedZipHelperTaskTest.kt
@@ -20,19 +20,20 @@
 
 package com.amaze.filemanager.asynchronous.asynctasks.compress
 
-import android.os.Environment
 import androidx.test.core.app.ApplicationProvider
 import java.io.File
 
 class EncryptedZipHelperTaskTest : AbstractCompressedHelperTaskArchiveTest() {
-    override fun createTask(relativePath: String): CompressedHelperTask = ZipHelperTask(
-        ApplicationProvider.getApplicationContext(),
-        File(
-            Environment.getExternalStorageDirectory(),
-            "test-archive-encrypted.zip"
-        ).absolutePath,
-        relativePath,
-        false,
-        emptyCallback
-    )
+
+    override val archiveFileName: String
+        get() = "test-archive-encrypted.zip"
+
+    override fun doCreateTask(archive: File, relativePath: String): CompressedHelperTask =
+        ZipHelperTask(
+            ApplicationProvider.getApplicationContext(),
+            archive.absolutePath,
+            relativePath,
+            false,
+            emptyCallback
+        )
 }

--- a/app/src/test/java/com/amaze/filemanager/asynchronous/asynctasks/compress/ListEncryptedSevenZipHelperTaskTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/asynchronous/asynctasks/compress/ListEncryptedSevenZipHelperTaskTest.kt
@@ -20,16 +20,16 @@
 
 package com.amaze.filemanager.asynchronous.asynctasks.compress
 
-import android.os.Environment
 import com.amaze.filemanager.file_operations.filesystem.compressed.ArchivePasswordCache
 import java.io.File
 
 class ListEncryptedSevenZipHelperTaskTest : AbstractCompressedHelperTaskArchiveTest() {
-    override fun createTask(relativePath: String): CompressedHelperTask {
-        File(
-            Environment.getExternalStorageDirectory(),
-            "test-archive-encrypted-list.7z"
-        ).absolutePath.let {
+
+    override val archiveFileName: String
+        get() = "test-archive-encrypted-list.7z"
+
+    override fun doCreateTask(archive: File, relativePath: String): CompressedHelperTask {
+        archive.absolutePath.let {
             ArchivePasswordCache.getInstance()[it] = "123456"
             return SevenZipHelperTask(it, relativePath, false, emptyCallback)
         }

--- a/app/src/test/java/com/amaze/filemanager/asynchronous/asynctasks/compress/RarHelperTaskTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/asynchronous/asynctasks/compress/RarHelperTaskTest.kt
@@ -29,6 +29,9 @@ import java.io.File
 
 class RarHelperTaskTest : AbstractCompressedHelperTaskArchiveTest() {
 
+    override val archiveFileName: String
+        get() = "test-archive.rar"
+
     /**
      * Test multi volume RAR (v4).
      */
@@ -75,8 +78,9 @@ class RarHelperTaskTest : AbstractCompressedHelperTaskArchiveTest() {
         assertEquals(UnsupportedRarV5Exception::class.java, result.exception.cause!!.javaClass)
     }
 
-    override fun createTask(relativePath: String): CompressedHelperTask = RarHelperTask(
-        File(Environment.getExternalStorageDirectory(), "test-archive.rar").absolutePath,
+    override fun doCreateTask(archive: File, relativePath: String): CompressedHelperTask =
+        RarHelperTask(
+        archive.absolutePath,
         relativePath,
         false,
         emptyCallback

--- a/app/src/test/java/com/amaze/filemanager/asynchronous/asynctasks/compress/SevenZipHelperTaskTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/asynchronous/asynctasks/compress/SevenZipHelperTaskTest.kt
@@ -20,17 +20,18 @@
 
 package com.amaze.filemanager.asynchronous.asynctasks.compress
 
-import android.os.Environment
 import java.io.File
 
 class SevenZipHelperTaskTest : AbstractCompressedHelperTaskArchiveTest() {
-    override fun createTask(relativePath: String): CompressedHelperTask = SevenZipHelperTask(
-        File(
-            Environment.getExternalStorageDirectory(),
-            "test-archive.7z"
-        ).absolutePath,
-        relativePath,
-        false,
-        emptyCallback
-    )
+
+    override val archiveFileName: String
+        get() = "test-archive.7z"
+
+    override fun doCreateTask(archive: File, relativePath: String): CompressedHelperTask =
+        SevenZipHelperTask(
+            archive.absolutePath,
+            relativePath,
+            false,
+            emptyCallback
+        )
 }

--- a/app/src/test/java/com/amaze/filemanager/asynchronous/asynctasks/compress/SevenZipHelperTaskTest2.kt
+++ b/app/src/test/java/com/amaze/filemanager/asynchronous/asynctasks/compress/SevenZipHelperTaskTest2.kt
@@ -20,7 +20,6 @@
 
 package com.amaze.filemanager.asynchronous.asynctasks.compress
 
-import android.os.Environment
 import org.junit.Assert
 import org.junit.Ignore
 import org.junit.Test
@@ -28,6 +27,9 @@ import java.io.File
 
 @Ignore("Test skipped due to problem at upstream library.")
 class SevenZipHelperTaskTest2 : AbstractCompressedHelperTaskArchiveTest() {
+
+    override val archiveFileName: String
+        get() = "compress.7z"
 
     @Test
     override fun testRoot() {
@@ -40,8 +42,9 @@ class SevenZipHelperTaskTest2 : AbstractCompressedHelperTaskArchiveTest() {
     @Ignore("Not testing this one")
     override fun testSublevels() = Unit
 
-    override fun createTask(relativePath: String): CompressedHelperTask = SevenZipHelperTask(
-        File(Environment.getExternalStorageDirectory(), "compress.7z").absolutePath,
+    override fun doCreateTask(archive: File, relativePath: String): CompressedHelperTask =
+        SevenZipHelperTask(
+        archive.absolutePath,
         relativePath,
         false,
         emptyCallback

--- a/app/src/test/java/com/amaze/filemanager/asynchronous/asynctasks/compress/TarBzip2HelperTaskTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/asynchronous/asynctasks/compress/TarBzip2HelperTaskTest.kt
@@ -20,20 +20,20 @@
 
 package com.amaze.filemanager.asynchronous.asynctasks.compress
 
-import android.os.Environment
 import androidx.test.core.app.ApplicationProvider
 import java.io.File
 
 class TarBzip2HelperTaskTest : AbstractCompressedHelperTaskArchiveTest() {
 
-    override fun createTask(relativePath: String): CompressedHelperTask = TarBzip2HelperTask(
-        ApplicationProvider.getApplicationContext(),
-        File(
-            Environment.getExternalStorageDirectory(),
-            "test-archive.tar.bz2"
-        ).absolutePath,
-        relativePath,
-        false,
-        emptyCallback
-    )
+    override val archiveFileName: String
+        get() = "test-archive.tar.bz2"
+
+    override fun doCreateTask(archive: File, relativePath: String): CompressedHelperTask =
+        TarBzip2HelperTask(
+            ApplicationProvider.getApplicationContext(),
+            archive.absolutePath,
+            relativePath,
+            false,
+            emptyCallback
+        )
 }

--- a/app/src/test/java/com/amaze/filemanager/asynchronous/asynctasks/compress/TarGzHelperTaskTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/asynchronous/asynctasks/compress/TarGzHelperTaskTest.kt
@@ -20,16 +20,20 @@
 
 package com.amaze.filemanager.asynchronous.asynctasks.compress
 
-import android.os.Environment
 import androidx.test.core.app.ApplicationProvider
 import java.io.File
 
 class TarGzHelperTaskTest : AbstractCompressedHelperTaskArchiveTest() {
-    override fun createTask(relativePath: String): CompressedHelperTask = TarGzHelperTask(
-        ApplicationProvider.getApplicationContext(),
-        File(Environment.getExternalStorageDirectory(), "test-archive.tar.gz").absolutePath,
-        relativePath,
-        false,
-        emptyCallback
-    )
+
+    override val archiveFileName: String
+        get() = "test-archive.tar.gz"
+
+    override fun doCreateTask(archive: File, relativePath: String): CompressedHelperTask =
+        TarGzHelperTask(
+            ApplicationProvider.getApplicationContext(),
+            archive.absolutePath,
+            relativePath,
+            false,
+            emptyCallback
+        )
 }

--- a/app/src/test/java/com/amaze/filemanager/asynchronous/asynctasks/compress/TarHelperTaskTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/asynchronous/asynctasks/compress/TarHelperTaskTest.kt
@@ -20,16 +20,20 @@
 
 package com.amaze.filemanager.asynchronous.asynctasks.compress
 
-import android.os.Environment
 import androidx.test.core.app.ApplicationProvider
 import java.io.File
 
 class TarHelperTaskTest : AbstractCompressedHelperTaskArchiveTest() {
-    override fun createTask(relativePath: String): CompressedHelperTask = TarHelperTask(
-        ApplicationProvider.getApplicationContext(),
-        File(Environment.getExternalStorageDirectory(), "test-archive.tar").absolutePath,
-        relativePath,
-        false,
-        emptyCallback
-    )
+
+    override val archiveFileName: String
+        get() = "test-archive.tar"
+
+    override fun doCreateTask(archive: File, relativePath: String): CompressedHelperTask =
+        TarHelperTask(
+            ApplicationProvider.getApplicationContext(),
+            archive.absolutePath,
+            relativePath,
+            false,
+            emptyCallback
+        )
 }

--- a/app/src/test/java/com/amaze/filemanager/asynchronous/asynctasks/compress/TarLzmaHelperTaskTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/asynchronous/asynctasks/compress/TarLzmaHelperTaskTest.kt
@@ -20,16 +20,20 @@
 
 package com.amaze.filemanager.asynchronous.asynctasks.compress
 
-import android.os.Environment
 import androidx.test.core.app.ApplicationProvider
 import java.io.File
 
 class TarLzmaHelperTaskTest : AbstractCompressedHelperTaskArchiveTest() {
-    override fun createTask(relativePath: String): CompressedHelperTask = TarLzmaHelperTask(
-        ApplicationProvider.getApplicationContext(),
-        File(Environment.getExternalStorageDirectory(), "test-archive.tar.lzma").absolutePath,
-        relativePath,
-        false,
-        emptyCallback
-    )
+
+    override val archiveFileName: String
+        get() = "test-archive.tar.lzma"
+
+    override fun doCreateTask(archive: File, relativePath: String): CompressedHelperTask =
+        TarLzmaHelperTask(
+            ApplicationProvider.getApplicationContext(),
+            archive.absolutePath,
+            relativePath,
+            false,
+            emptyCallback
+        )
 }

--- a/app/src/test/java/com/amaze/filemanager/asynchronous/asynctasks/compress/TarXzHelperTaskTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/asynchronous/asynctasks/compress/TarXzHelperTaskTest.kt
@@ -20,16 +20,20 @@
 
 package com.amaze.filemanager.asynchronous.asynctasks.compress
 
-import android.os.Environment
 import androidx.test.core.app.ApplicationProvider
 import java.io.File
 
 class TarXzHelperTaskTest : AbstractCompressedHelperTaskArchiveTest() {
-    override fun createTask(relativePath: String): CompressedHelperTask = TarXzHelperTask(
-        ApplicationProvider.getApplicationContext(),
-        File(Environment.getExternalStorageDirectory(), "test-archive.tar.xz").absolutePath,
-        relativePath,
-        false,
-        emptyCallback
-    )
+
+    override val archiveFileName: String
+        get() = "test-archive.tar.xz"
+
+    override fun doCreateTask(archive: File, relativePath: String): CompressedHelperTask =
+        TarXzHelperTask(
+            ApplicationProvider.getApplicationContext(),
+            archive.absolutePath,
+            relativePath,
+            false,
+            emptyCallback
+        )
 }

--- a/app/src/test/java/com/amaze/filemanager/asynchronous/asynctasks/compress/TarXzHelperTaskTest2.kt
+++ b/app/src/test/java/com/amaze/filemanager/asynchronous/asynctasks/compress/TarXzHelperTaskTest2.kt
@@ -20,13 +20,16 @@
 
 package com.amaze.filemanager.asynchronous.asynctasks.compress
 
-import android.os.Environment
 import androidx.test.core.app.ApplicationProvider
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import java.io.File
 
 class TarXzHelperTaskTest2 : AbstractCompressedHelperTaskArchiveTest() {
+
+    override val archiveFileName: String
+        get() = "compress.tar.xz"
+
     @Test
     override fun testRoot() {
         val task = createTask("")
@@ -54,9 +57,10 @@ class TarXzHelperTaskTest2 : AbstractCompressedHelperTaskArchiveTest() {
         assertEquals(6, result.result[0].size)
     }
 
-    override fun createTask(relativePath: String): CompressedHelperTask = TarXzHelperTask(
+    override fun doCreateTask(archive: File, relativePath: String): CompressedHelperTask =
+        TarXzHelperTask(
         ApplicationProvider.getApplicationContext(),
-        File(Environment.getExternalStorageDirectory(), "compress.tar.xz").absolutePath,
+        archive.absolutePath,
         relativePath,
         false,
         emptyCallback

--- a/app/src/test/java/com/amaze/filemanager/asynchronous/asynctasks/compress/UnknownCompressedHelperTaskTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/asynchronous/asynctasks/compress/UnknownCompressedHelperTaskTest.kt
@@ -25,7 +25,7 @@ import org.junit.Assert
 import org.junit.Test
 import java.io.File
 
-class GenericCompressedHelperTaskTest : AbstractCompressedHelperTaskTest() {
+class UnknownCompressedHelperTaskTest : AbstractCompressedHelperTaskTest() {
 
     /**
      * Test file decompression.

--- a/app/src/test/java/com/amaze/filemanager/asynchronous/asynctasks/compress/ZipHelperTaskTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/asynchronous/asynctasks/compress/ZipHelperTaskTest.kt
@@ -20,7 +20,6 @@
 
 package com.amaze.filemanager.asynchronous.asynctasks.compress
 
-import android.os.Environment
 import androidx.test.core.app.ApplicationProvider
 import org.apache.commons.compress.archivers.ArchiveException
 import org.junit.Assert.assertEquals
@@ -28,6 +27,9 @@ import org.junit.Test
 import java.io.File
 
 class ZipHelperTaskTest : AbstractCompressedHelperTaskArchiveTest() {
+
+    override val archiveFileName: String
+        get() = "test-archive.zip"
 
     /**
      * Verification on logic in [ZipHelperTask] assigning zip entry path.
@@ -66,11 +68,12 @@ class ZipHelperTaskTest : AbstractCompressedHelperTaskArchiveTest() {
         ).addElements(ArrayList())
     }
 
-    override fun createTask(relativePath: String): CompressedHelperTask = ZipHelperTask(
-        ApplicationProvider.getApplicationContext(),
-        File(Environment.getExternalStorageDirectory(), "test-archive.zip").absolutePath,
-        relativePath,
-        false,
-        emptyCallback
-    )
+    override fun doCreateTask(archive: File, relativePath: String): CompressedHelperTask =
+        ZipHelperTask(
+            ApplicationProvider.getApplicationContext(),
+            archive.absolutePath,
+            relativePath,
+            false,
+            emptyCallback
+        )
 }

--- a/app/src/test/java/com/amaze/filemanager/filesystem/compressed/extractcontents/PasswordProtectedRarTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/filesystem/compressed/extractcontents/PasswordProtectedRarTest.kt
@@ -22,6 +22,8 @@ package com.amaze.filemanager.filesystem.compressed.extractcontents
 
 import com.amaze.filemanager.filesystem.compressed.extractcontents.helpers.RarExtractor
 import org.apache.commons.compress.PasswordRequiredException
+import org.junit.Ignore
+import org.junit.Test
 import java.io.IOException
 
 open class PasswordProtectedRarTest : AbstractExtractorPasswordProtectedArchivesTest() {
@@ -32,4 +34,8 @@ open class PasswordProtectedRarTest : AbstractExtractorPasswordProtectedArchives
         arrayOf(IOException::class.java, PasswordRequiredException::class.java)
 
     override val archiveType: String = "rar"
+
+    @Test
+    @Ignore
+    override fun testExtractBadArchive() = Unit
 }

--- a/app/src/test/java/com/amaze/filemanager/filesystem/compressed/extractcontents/PasswordProtectedZipTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/filesystem/compressed/extractcontents/PasswordProtectedZipTest.kt
@@ -21,13 +21,13 @@
 package com.amaze.filemanager.filesystem.compressed.extractcontents
 
 import com.amaze.filemanager.filesystem.compressed.extractcontents.helpers.ZipExtractor
-import net.lingala.zip4j.exception.ZipException
+import org.apache.commons.compress.PasswordRequiredException
 
 class PasswordProtectedZipTest : AbstractExtractorPasswordProtectedArchivesTest() {
 
     override fun extractorClass(): Class<out Extractor?> = ZipExtractor::class.java
 
-    override fun expectedRootExceptionClass(): Array<Class<*>> = arrayOf(ZipException::class.java)
+    override fun expectedRootExceptionClass(): Array<Class<*>> = arrayOf(PasswordRequiredException::class.java)
 
     override val archiveType: String = "zip"
 }

--- a/app/src/test/java/com/amaze/filemanager/filesystem/compressed/extractcontents/RarExtractorTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/filesystem/compressed/extractcontents/RarExtractorTest.kt
@@ -27,6 +27,7 @@ import com.amaze.filemanager.asynchronous.management.ServiceWatcherUtil
 import com.amaze.filemanager.filesystem.compressed.extractcontents.helpers.RarExtractor
 import com.github.junrar.Archive
 import org.junit.Assert.assertEquals
+import org.junit.Ignore
 import org.junit.Test
 import java.io.File
 
@@ -80,4 +81,7 @@ class RarExtractorTest : AbstractArchiveExtractorTest() {
             assertEquals(2, this.length())
         }
     }
+
+    @Test @Ignore
+    override fun testExtractBadArchive() = Unit
 }

--- a/app/src/test/java/com/amaze/filemanager/filesystem/compressed/extractcontents/TarExtractorTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/filesystem/compressed/extractcontents/TarExtractorTest.kt
@@ -21,10 +21,15 @@
 package com.amaze.filemanager.filesystem.compressed.extractcontents
 
 import com.amaze.filemanager.filesystem.compressed.extractcontents.helpers.TarExtractor
+import org.junit.Ignore
+import org.junit.Test
 
 class TarExtractorTest : AbstractArchiveExtractorTest() {
 
     override val archiveType: String = "tar"
 
     override fun extractorClass(): Class<out Extractor?> = TarExtractor::class.java
+
+    @Test @Ignore
+    override fun testExtractBadArchive() = Unit
 }

--- a/app/src/test/java/com/amaze/filemanager/test/TestUtils.kt
+++ b/app/src/test/java/com/amaze/filemanager/test/TestUtils.kt
@@ -28,9 +28,36 @@ import android.os.UserHandle
 import android.os.storage.StorageManager
 import android.os.storage.StorageVolume
 import androidx.test.core.app.ApplicationProvider
+import com.amaze.filemanager.filesystem.compressed.CompressedHelper
 import org.robolectric.Shadows
 import java.lang.reflect.Field
 import java.lang.reflect.Modifier
+import kotlin.random.Random
+
+/**
+ * Generate random junk. If no size specified, default to 73 bytes.
+ *
+ * No need to use SecureRandom for tests IMO.
+ */
+fun randomBytes(size: Int = 73) = Random(System.currentTimeMillis()).nextBytes(size)
+
+/**
+ * Get supported archive extensions from [CompressedHelper] via reflection.
+ */
+fun supportedArchiveExtensions(): List<String> {
+    return CompressedHelper::class.java.declaredFields.filter { field ->
+        field.name.startsWith("fileExtension") &&
+            field.type == String::class.java &&
+            Modifier.isFinal(field.modifiers) &&
+            Modifier.isPublic(field.modifiers) &&
+            Modifier.isStatic(field.modifiers)
+    }.map {
+        it.isAccessible = true
+        it.get(null).toString()
+    }.filter {
+        it != "tar"
+    }
+}
 
 object TestUtils {
     /**

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
         fabSpeedDialVersion = '3.1.1'
         roomVersion = '2.4.0'
         bouncyCastleVersion = '1.68'
-        awaitilityVersion = "3.1.6"
+        awaitilityVersion = "4.1.1"
         androidMaterialVersion = "1.4.0"
         androidXFragmentVersion = "1.3.6"
         androidXAppCompatVersion = "1.3.1"


### PR DESCRIPTION
## Description
Trap `IOException`s thrown gracefully when attempt to extract archives to a Toast.

#### Issue tracker
Addresses #3149 

#### Automatic tests
<!-- remember to do manual testing when making UI changes! -->
- [x] Added test cases
  
#### Manual tests
- [x] Done  
  
- Device: Pixel 2 emulator
- OS: Android 11

Toast should pop up when attempt to open or extract corrupt archives.

Note however, since tar and rar would end up returning empty list instead of null, test cases would be skipped.

#### Build tasks success  
Successfully running following tasks on local:
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`