### PR TITLE
App backup: add support for apps that have multiple APK files

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/adapters/AppsRecyclerAdapter.kt
+++ b/app/src/main/java/com/amaze/filemanager/adapters/AppsRecyclerAdapter.kt
@@ -461,10 +461,9 @@ class AppsRecyclerAdapter(
         intent.putExtra(CopyService.TAG_COPY_TARGET, dst.path)
         intent.putExtra(CopyService.TAG_COPY_OPEN_MODE, 0)
 
-        val dest = Environment.getExternalStorageDirectory().path + "/app_backup"
         Toast.makeText(
                 fragment.context,
-                fragment.getString(R.string.copyingapks, filesToCopyList.size, dest),
+                fragment.getString(R.string.copyingapks, filesToCopyList.size, dst.path),
                 Toast.LENGTH_LONG
         )
                 .show()

--- a/app/src/main/java/com/amaze/filemanager/adapters/data/AppDataParcelable.kt
+++ b/app/src/main/java/com/amaze/filemanager/adapters/data/AppDataParcelable.kt
@@ -26,13 +26,14 @@ import kotlinx.parcelize.Parcelize
 @Parcelize
 @Suppress("LongParameterList")
 class AppDataParcelable(
-    var label: String,
-    var path: String,
-    var packageName: String,
-    var data: String,
-    var fileSize: String,
-    var size: Long,
-    var lastModification: Long,
-    var isSystemApp: Boolean,
-    var openFileParcelable: OpenFileParcelable?
+        var label: String,
+        var path: String,
+        var splitPathList: List<String>?,
+        var packageName: String,
+        var data: String,
+        var fileSize: String,
+        var size: Long,
+        var lastModification: Long,
+        var isSystemApp: Boolean,
+        var openFileParcelable: OpenFileParcelable?
 ) : Parcelable

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/loaders/AppListLoader.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/loaders/AppListLoader.java
@@ -100,10 +100,9 @@ public class AppListLoader extends AsyncTaskLoader<List<AppDataParcelable>> {
       boolean isSystemApp = isAppInSystemPartition(object) || isSignedBySystem(info, androidInfo);
 
       List<String> splitPathList = null;
-      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-        if (object.splitPublicSourceDirs != null) {
-          splitPathList = Arrays.asList(object.splitPublicSourceDirs);
-        }
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP
+          && object.splitPublicSourceDirs != null) {
+        splitPathList = Arrays.asList(object.splitPublicSourceDirs);
       }
 
       AppDataParcelable elem =

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/loaders/AppListLoader.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/loaders/AppListLoader.java
@@ -22,6 +22,7 @@ package com.amaze.filemanager.asynchronous.loaders;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -34,6 +35,7 @@ import android.content.Context;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
+import android.os.Build;
 import android.text.format.Formatter;
 
 import androidx.loader.content.AsyncTaskLoader;
@@ -96,10 +98,19 @@ public class AppListLoader extends AsyncTaskLoader<List<AppDataParcelable>> {
         info = null;
       }
       boolean isSystemApp = isAppInSystemPartition(object) || isSignedBySystem(info, androidInfo);
+
+      List<String> splitPathList = null;
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+        if (object.splitPublicSourceDirs != null) {
+          splitPathList = Arrays.asList(object.splitPublicSourceDirs);
+        }
+      }
+
       AppDataParcelable elem =
           new AppDataParcelable(
               label == null ? object.packageName : label,
               object.sourceDir,
+              splitPathList,
               object.packageName,
               object.flags + "_" + (info != null ? info.versionName : ""),
               Formatter.formatFileSize(getContext(), sourceDir.length()),

--- a/app/src/main/java/com/amaze/filemanager/ui/dialogs/OpenFileDialogFragment.kt
+++ b/app/src/main/java/com/amaze/filemanager/ui/dialogs/OpenFileDialogFragment.kt
@@ -369,6 +369,7 @@ class OpenFileDialogFragment : BaseBottomSheetFragment(), AdjustListViewForTv<Ap
                 AppDataParcelable(
                     if (label.isNotEmpty()) label else it.activityInfo.packageName,
                     "",
+                    null,
                     it.activityInfo.packageName,
                     "",
                     "",

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -36,7 +36,6 @@
     <string name="uninstall">الغاء تركيب </string>
     <string name="play">تشغيل المتجر </string>
     <string name="properties">خصائص </string>
-    <string name="copyingapk">\"\نسخ APK الى\"\ </string>
     <string name="delbook">حذف علامة توقف </string>
     <string name="add_to_bookmarks">اضافة الى علامات التوقف </string>
     <string name="enterpath">ادخال المسار </string>

--- a/app/src/main/res/values-ast-rES/strings.xml
+++ b/app/src/main/res/values-ast-rES/strings.xml
@@ -36,7 +36,6 @@
     <string name="uninstall">Desinstalar</string>
     <string name="play">Play Store</string>
     <string name="properties">Propiedaes</string>
-    <string name="copyingapk">Copiando APK en</string>
     <string name="delbook">Desaniciar marcador</string>
     <string name="add_to_bookmarks">Amestar a marcadores</string>
     <string name="enterpath">Introducir camín</string>

--- a/app/src/main/res/values-be-rBY/strings.xml
+++ b/app/src/main/res/values-be-rBY/strings.xml
@@ -33,7 +33,6 @@
   <string name="uninstall">Выдаліць</string>
   <string name="play">Play store</string>
   <string name="properties">Уласцівасці</string>
-  <string name="copyingapk">Капіяваць Apk у </string>
     <string name="delbook">Выдаліць закладку</string>
   <string name="add_to_bookmarks">Дадаць у закладкі</string>
   <string name="enterpath">Увядзіце шлях</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -36,7 +36,6 @@
     <string name="uninstall">Деинсталирай</string>
     <string name="play">Play Store</string>
     <string name="properties">Свойства</string>
-    <string name="copyingapk">Копиране на apk към </string>
     <string name="delbook">Изтрий отметка</string>
     <string name="add_to_bookmarks">Добави в отметки</string>
     <string name="enterpath">Въведете път</string>

--- a/app/src/main/res/values-bn/strings.xml
+++ b/app/src/main/res/values-bn/strings.xml
@@ -59,8 +59,6 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
     <string name="properties">বিস্তারিত</string>
 
-    <string name="copyingapk">এপিকে কপি করা হচ্ছে এ</string>
-
     <string name="add_to_bookmarks">বুকমার্কে সংযুক্ত করুন</string>
 
     <string name="enterpath">পাথটি লিখুন</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -36,7 +36,6 @@
     <string name="uninstall">Odinstalovat</string>
     <string name="play">Obchod Play</string>
     <string name="properties">Předvolby</string>
-    <string name="copyingapk">Kopírování aplikace do </string>
     <string name="delbook">Odstranit záložku</string>
     <string name="add_to_bookmarks">Přidat do záložek</string>
     <string name="enterpath">Zadejte cestu</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -36,7 +36,6 @@
     <string name="uninstall">Deinstallieren</string>
     <string name="play">Play Store</string>
     <string name="properties">Eigenschaften</string>
-    <string name="copyingapk">Kopiere apk nach </string>
     <string name="delbook">Lesezeichen löschen</string>
     <string name="add_to_bookmarks">Zu Lesezeichen hinzufügen</string>
     <string name="enterpath">Pfad eingeben</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -36,7 +36,6 @@
     <string name="uninstall">Απεγκατάσταση</string>
     <string name="play">Play store</string>
     <string name="properties">Ιδιότητες</string>
-    <string name="copyingapk">Αντιγραφή του apk σε </string>
     <string name="delbook">Διαγραφή σελιδοδείκτη</string>
     <string name="add_to_bookmarks">Προσθήκη σε σελιδοδείκτη</string>
     <string name="enterpath">Εισάγετε διαδρομή</string>

--- a/app/src/main/res/values-eo/strings.xml
+++ b/app/src/main/res/values-eo/strings.xml
@@ -36,7 +36,6 @@
     <string name="uninstall">Malinstali</string>
     <string name="play">Play Store</string>
     <string name="properties">Ecujo</string>
-    <string name="copyingapk">Copianta APK al </string>
     <string name="delbook">Forigi legosignon</string>
     <string name="add_to_bookmarks">Aldoni al legosignujo</string>
     <string name="enterpath">Enigi la dosierindikon</string>

--- a/app/src/main/res/values-es-rCO/strings.xml
+++ b/app/src/main/res/values-es-rCO/strings.xml
@@ -33,7 +33,6 @@
   <string name="uninstall">Desinstalar</string>
   <string name="play">Play Store</string>
   <string name="properties">Propiedades</string>
-  <string name="copyingapk">Copiando apk a </string>
     <string name="delbook">Borrar marcador</string>
   <string name="add_to_bookmarks">Añadir a Favoritos</string>
   <string name="enterpath">Escribe la ruta</string>

--- a/app/src/main/res/values-es-rMX/strings.xml
+++ b/app/src/main/res/values-es-rMX/strings.xml
@@ -33,7 +33,6 @@
   <string name="uninstall">Desinstalar</string>
   <string name="play">Play Store</string>
   <string name="properties">Propiedades</string>
-  <string name="copyingapk">Copiando apk a </string>
     <string name="delbook">Borrar marcador</string>
   <string name="add_to_bookmarks">Añadir a Favoritos</string>
   <string name="enterpath">Escribe la ruta</string>

--- a/app/src/main/res/values-es-rUS/strings.xml
+++ b/app/src/main/res/values-es-rUS/strings.xml
@@ -33,7 +33,6 @@
   <string name="uninstall">Desinstalar</string>
   <string name="play">Play Store</string>
   <string name="properties">Propiedades</string>
-  <string name="copyingapk">Copiando apk a </string>
     <string name="delbook">Borrar marcador</string>
   <string name="add_to_bookmarks">Añadir a Marcadores</string>
   <string name="enterpath">Escribe la ruta</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -36,7 +36,6 @@
     <string name="uninstall">Desinstalar</string>
     <string name="play">Play Store</string>
     <string name="properties">Propiedades</string>
-    <string name="copyingapk">Copiando APK a </string>
     <string name="delbook">Borrar marcador</string>
     <string name="add_to_bookmarks">Añadir a Favoritos</string>
     <string name="enterpath">Escribe la ruta</string>

--- a/app/src/main/res/values-eu-rES/strings.xml
+++ b/app/src/main/res/values-eu-rES/strings.xml
@@ -36,7 +36,6 @@
     <string name="uninstall">Desinstalatu</string>
     <string name="play">Play store</string>
     <string name="properties">Propietateak</string>
-    <string name="copyingapk">apk hona kopiatzen </string>
     <string name="delbook">Ezabatu laster-marka</string>
     <string name="add_to_bookmarks">Gehitu laster-marka</string>
     <string name="enterpath">Sartu bidea</string>

--- a/app/src/main/res/values-eu/strings.xml
+++ b/app/src/main/res/values-eu/strings.xml
@@ -36,7 +36,6 @@
     <string name="uninstall">Desinstalatu</string>
     <string name="play">Play store</string>
     <string name="properties">Propietateak</string>
-    <string name="copyingapk">apk hona kopiatzen </string>
     <string name="delbook">Ezabatu laster-marka</string>
     <string name="add_to_bookmarks">Gehitu laster-marka</string>
     <string name="enterpath">Sartu bidea</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -33,7 +33,6 @@
   <string name="uninstall">حذف</string>
   <string name="play">پلی استور</string>
   <string name="properties">مشخصات</string>
-  <string name="copyingapk">به apk کپی</string>
     <string name="add_to_bookmarks">به نشانه گذاری ها اضافه کنید</string>
   <string name="enterpath">مسیر را وارد کنید</string>
   <string name="cancel">لغو</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -36,7 +36,6 @@
     <string name="uninstall">Asennuksen poisto</string>
     <string name="play">Play-kauppa</string>
     <string name="properties">Ominaisuudet</string>
-    <string name="copyingapk">Kopioi APK-tiedostoa </string>
     <string name="delbook">Poista kirjanmerkki</string>
     <string name="add_to_bookmarks">Lisää kirjanmerkkeihin</string>
     <string name="enterpath">Kirjoita polku</string>

--- a/app/src/main/res/values-fr-rCA/strings.xml
+++ b/app/src/main/res/values-fr-rCA/strings.xml
@@ -33,7 +33,6 @@
   <string name="uninstall">Désinstaller</string>
   <string name="play">Google Play</string>
   <string name="properties">Propriétés</string>
-  <string name="copyingapk">Copier l\'APK vers</string>
     <string name="delbook">Supprimer le favori</string>
   <string name="add_to_bookmarks">Ajouter aux favoris</string>
   <string name="enterpath">Entrer le chemin</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -36,7 +36,6 @@
     <string name="uninstall">Désinstaller</string>
     <string name="play">Play store</string>
     <string name="properties">Propriétés</string>
-    <string name="copyingapk">Copier l\'APK vers</string>
     <string name="delbook">Supprimer le favori</string>
     <string name="add_to_bookmarks">Ajouter aux favoris</string>
     <string name="enterpath">Entrer le chemin d\'accès</string>

--- a/app/src/main/res/values-he/strings.xml
+++ b/app/src/main/res/values-he/strings.xml
@@ -36,7 +36,6 @@
     <string name="uninstall">הסרת התקנה</string>
     <string name="play">חנות Play</string>
     <string name="properties">מאפיינים</string>
-    <string name="copyingapk">ה־APK מועתק אל</string>
     <string name="delbook">מחיקת סימנייה</string>
     <string name="add_to_bookmarks">הוספה לסימניות</string>
     <string name="enterpath">נא להקליד נתיב</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -36,7 +36,6 @@
     <string name="uninstall">Eltávolítás</string>
     <string name="play">Play áruház</string>
     <string name="properties">Tulajdonságok</string>
-    <string name="copyingapk">Apk másolása ide:</string>
     <string name="delbook">Könyvjelző törlése</string>
     <string name="add_to_bookmarks">Hozzáadás a könyvjelzőkhöz</string>
     <string name="enterpath">Adja meg az elérési útvonalat</string>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -36,7 +36,6 @@
     <string name="uninstall">Copot</string>
     <string name="play">Play store</string>
     <string name="properties">Properti</string>
-    <string name="copyingapk">Menyalin apk ke </string>
     <string name="delbook">Hapus Markah</string>
     <string name="add_to_bookmarks">Tambah ke Markah</string>
     <string name="enterpath">Masukkan Jalur</string>

--- a/app/src/main/res/values-is/strings.xml
+++ b/app/src/main/res/values-is/strings.xml
@@ -36,7 +36,6 @@
     <string name="uninstall">Taka út</string>
     <string name="play">Play Store</string>
     <string name="properties">Eiginleikar</string>
-    <string name="copyingapk">Afrita APK í</string>
     <string name="delbook">Eyða bókamerki</string>
     <string name="add_to_bookmarks">Bæta við bókamerki</string>
     <string name="enterpath">Settu inn slóð</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -36,7 +36,6 @@
     <string name="uninstall">Disinstalla</string>
     <string name="play">Play Store</string>
     <string name="properties">Proprietà</string>
-    <string name="copyingapk">Copia APK in corso in</string>
     <string name="delbook">Elimina Preferito</string>
     <string name="add_to_bookmarks">Aggiungi a segnalibro</string>
     <string name="enterpath">Inserisci percorso</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -36,7 +36,6 @@
     <string name="uninstall">アンインストール</string>
     <string name="play">Play ストア</string>
     <string name="properties">プロパティ</string>
-    <string name="copyingapk">APK のコピー中 </string>
     <string name="delbook">ブックマークを削除する</string>
     <string name="add_to_bookmarks">ブックマークに追加</string>
     <string name="enterpath">パスを入力</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -36,7 +36,6 @@
     <string name="uninstall">삭제</string>
     <string name="play">플레이 스토어</string>
     <string name="properties">상세정보</string>
-    <string name="copyingapk">애플리케이션이 다음 경로에 복사됩니다.</string>
     <string name="delbook">북마크 삭제</string>
     <string name="add_to_bookmarks">북마크에 추가</string>
     <string name="enterpath">경로를 입력해 주세요</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -33,7 +33,6 @@
   <string name="uninstall">Išinstaliuoti</string>
   <string name="play">Play parduotuvė</string>
   <string name="properties">Ypatybės</string>
-  <string name="copyingapk">Kopijuoja apk į </string>
     <string name="add_to_bookmarks">Pridėti į žymą</string>
   <string name="enterpath">Įvesti kelią</string>
   <string name="cancel">ATŠAUKTI</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -36,7 +36,6 @@
     <string name="uninstall">Deïnstalleren</string>
     <string name="play">Play Store</string>
     <string name="properties">Eigenschappen</string>
-    <string name="copyingapk">Apk-bestand kopiëren naar </string>
     <string name="delbook">Bladwijzer verwijderen</string>
     <string name="add_to_bookmarks">Toevoegen aan bladwijzers</string>
     <string name="enterpath">Pad invoeren</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -36,7 +36,6 @@
     <string name="uninstall">Odinstaluj</string>
     <string name="play">Sklep Play</string>
     <string name="properties">Właściwości</string>
-    <string name="copyingapk">Kopiowanie aplikacji do </string>
     <string name="delbook">Usuń zakładkę</string>
     <string name="add_to_bookmarks">Dodaj do zakładek</string>
     <string name="enterpath">Wprowadź ścieżkę</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -36,7 +36,6 @@
     <string name="uninstall">Desinstalar</string>
     <string name="play">Play Store</string>
     <string name="properties">Propriedades</string>
-    <string name="copyingapk">Copiando apk para </string>
     <string name="delbook">Excluir favorito</string>
     <string name="add_to_bookmarks">Adicionar aos Favoritos</string>
     <string name="enterpath">Insira o caminho</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -36,7 +36,6 @@
     <string name="uninstall">Desinstalar</string>
     <string name="play">Google Play</string>
     <string name="properties">Propriedades</string>
-    <string name="copyingapk">A copiar apk para </string>
     <string name="delbook">Apagar Marcador</string>
     <string name="add_to_bookmarks">Adicionar aos marcadores</string>
     <string name="enterpath">Digite o caminho</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -30,8 +30,7 @@
   <string name="uninstall">Dezinstalaţi</string>
   <string name="play">Magazin Play</string>
   <string name="properties">Proprietăţi</string>
-  <string name="copyingapk">Copiere apk în </string>
-  <string name="add_to_bookmarks">Adăugaţi în marcaje</string>
+    <string name="add_to_bookmarks">Adăugaţi în marcaje</string>
   <string name="enterpath">Introduceţi calea</string>
   <string name="cancel">ANULAŢI</string>
   <string name="create">CREAŢI</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -36,7 +36,6 @@
     <string name="uninstall">Удалить</string>
     <string name="play">Открыть в Play Store</string>
     <string name="properties">Свойства</string>
-    <string name="copyingapk">Копирование apk в </string>
     <string name="delbook">Удалить закладку</string>
     <string name="add_to_bookmarks">Добавить в закладки</string>
     <string name="enterpath">Введите путь</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -36,7 +36,6 @@
     <string name="uninstall">Odinštalovať</string>
     <string name="play">Obchod Play</string>
     <string name="properties">Vlastnosti</string>
-    <string name="copyingapk">Kopírovanie aplikácie na </string>
     <string name="delbook">Odstrániť záložku</string>
     <string name="add_to_bookmarks">Pridať do záložiek</string>
     <string name="enterpath">Zadajte cestu</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -36,7 +36,6 @@
     <string name="uninstall">Odstrani</string>
     <string name="play">Trgovina play</string>
     <string name="properties">Lastnosti</string>
-    <string name="copyingapk">Kopiranje apk v </string>
     <string name="delbook">Izbriši zaznamek</string>
     <string name="add_to_bookmarks">Dodaj med zaznamke</string>
     <string name="enterpath">Vnesite pot</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -36,7 +36,6 @@
     <string name="uninstall">Уклони</string>
     <string name="play">Плеј продавница</string>
     <string name="properties">Својства</string>
-    <string name="copyingapk">Копирам апк у </string>
     <string name="delbook">Обриши обележивач</string>
     <string name="add_to_bookmarks">Додај у обележиваче</string>
     <string name="enterpath">Унесите путању</string>

--- a/app/src/main/res/values-sv-rSE/strings.xml
+++ b/app/src/main/res/values-sv-rSE/strings.xml
@@ -36,7 +36,6 @@
     <string name="uninstall">Avinstallera</string>
     <string name="play">Play butik</string>
     <string name="properties">Egenskaper</string>
-    <string name="copyingapk">Kopierar apk till</string>
     <string name="add_to_bookmarks">Lägg till till Bokmärke</string>
     <string name="enterpath">Ange sökväg</string>
     <string name="cancel">AVBRYT</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -36,7 +36,6 @@
     <string name="uninstall">Avinstallera</string>
     <string name="play">Play Store</string>
     <string name="properties">Egenskaper</string>
-    <string name="copyingapk">Kopierar APK till </string>
     <string name="delbook">Ta bort bokmärke</string>
     <string name="add_to_bookmarks">Lägg till bokmärke</string>
     <string name="enterpath">Ange sökväg</string>

--- a/app/src/main/res/values-ta/strings.xml
+++ b/app/src/main/res/values-ta/strings.xml
@@ -36,7 +36,6 @@
     <string name="uninstall">நிறுவல் நீக்கம்</string>
     <string name="play">ப்ளே ஸ்டோர்</string>
     <string name="properties">பண்புகள்</string>
-    <string name="copyingapk">ஏபிகே வை நகலெடுத்துக்கொண்டிருக்கிறது</string>
     <string name="delbook">புத்தகக்குறியை அழி</string>
     <string name="add_to_bookmarks">புத்தகக்குறியில் சேர்</string>
     <string name="enterpath">பாதையை உள்ளீடு</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -36,7 +36,6 @@
     <string name="uninstall">Kaldır</string>
     <string name="play">Play store</string>
     <string name="properties">Özellikler</string>
-    <string name="copyingapk">Apk kopyalanıyor</string>
     <string name="delbook">Yer işaretini sil</string>
     <string name="add_to_bookmarks">Yer işaretlerine ekle</string>
     <string name="enterpath">Yolu gir</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -36,7 +36,6 @@
     <string name="uninstall">Видалити</string>
     <string name="play">Відкрити в Маркеті</string>
     <string name="properties">Властивості</string>
-    <string name="copyingapk">apk-файл скопійований в:</string>
     <string name="delbook">Видалити закладку</string>
     <string name="add_to_bookmarks">Додати у закладки</string>
     <string name="enterpath">Введіть шлях</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -36,7 +36,6 @@
     <string name="uninstall">Gỡ bỏ</string>
     <string name="play">Cửa hàng Play</string>
     <string name="properties">Thuộc tính</string>
-    <string name="copyingapk">Đang sao chép apk đến </string>
     <string name="delbook">Xoá dấu trang</string>
     <string name="add_to_bookmarks">Thêm vào Bookmark</string>
     <string name="enterpath">Nhập đường dẫn</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -36,7 +36,6 @@
     <string name="uninstall">卸载</string>
     <string name="play">在应用商店中查看</string>
     <string name="properties">属性</string>
-    <string name="copyingapk">将 APK 复制到</string>
     <string name="delbook">删除书签</string>
     <string name="add_to_bookmarks">添加到书签</string>
     <string name="enterpath">请输入路径</string>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -36,7 +36,6 @@
     <string name="uninstall">卸載</string>
     <string name="play">入 Google Play睇</string>
     <string name="properties">屬性</string>
-    <string name="copyingapk">將 APK 複製到</string>
     <string name="delbook">刪除書籤</string>
     <string name="add_to_bookmarks">添加到書籤</string>
     <string name="enterpath">輸入路徑</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -36,7 +36,6 @@
     <string name="uninstall">解除安裝</string>
     <string name="play">在 Play 商店中檢視</string>
     <string name="properties">屬性</string>
-    <string name="copyingapk">將 APK 複製到</string>
     <string name="delbook">刪除書籤</string>
     <string name="add_to_bookmarks">新增至書籤</string>
     <string name="enterpath">輸入路徑</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -36,7 +36,7 @@
     <string name="uninstall">Uninstall</string>
     <string name="play">Play store</string>
     <string name="properties">Properties</string>
-    <string name="copyingapk">"Copying APK to "</string>
+    <string name="copyingapks">Copying %d APK files to %s</string>
     <string name="delbook">Delete Bookmark</string>
     <string name="add_to_bookmarks">Add to Bookmarks</string>
     <string name="enterpath">Enter Path</string>


### PR DESCRIPTION
As described in #3184 the app backup function of Amaze does only copy the main APK file of an app even if it is a split APK that consists of multiple APK files.

This PR adds the necessary functionality to copy all APK files that belong to an app when the user makes an app backup using Amaze.

Fixes #3184 