### PR TITLE
Fix LTR check that crashes on old android versions

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/ui/dialogs/GeneralDialogCreation.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/dialogs/GeneralDialogCreation.java
@@ -31,6 +31,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
@@ -113,6 +114,8 @@ import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
 import androidx.annotation.StringRes;
 import androidx.appcompat.widget.AppCompatButton;
+import androidx.core.text.TextUtilsCompat;
+import androidx.core.view.ViewCompat;
 import androidx.preference.PreferenceManager;
 
 /**
@@ -541,7 +544,8 @@ public class GeneralDialogCreation {
 
     /*Chart creation and data loading*/
     {
-      boolean isRightToLeft = c.getResources().getBoolean(R.bool.is_right_to_left);
+      int layoutDirection = TextUtilsCompat.getLayoutDirectionFromLocale(Locale.getDefault());
+      boolean isRightToLeft = layoutDirection == ViewCompat.LAYOUT_DIRECTION_RTL;
       boolean isDarkTheme = appTheme.getMaterialDialogTheme(c) == Theme.DARK;
       PieChart chart = v.findViewById(R.id.chart);
 

--- a/app/src/main/res/values-ldltr/bools.xml
+++ b/app/src/main/res/values-ldltr/bools.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <bool name="is_right_to_left">false</bool>
-</resources>

--- a/app/src/main/res/values-ldrtl/bools.xml
+++ b/app/src/main/res/values-ldrtl/bools.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <bool name="is_right_to_left">true</bool>
-</resources>


### PR DESCRIPTION
<!-- 
Read this first:
To open a pull request read this file,
uncomment the corresponding lines and 
complete them.
-->

## Description

#### Issue tracker   
<!-- Fixes will automatically close the related issue -->
Fixes #2066
<!-- Addresses won't automatically close the related issue -->
<!-- Addresses # -->

#### Automatic tests
<!-- remember to do manual testing when making UI changes! -->
- [ ] Added test cases
  
#### Manual tests
- [ ] Done  
  
<!-- If yes, -->
<!-- 
- Device:
- OS:
-->

#### Build tasks success  
<!-- run these! -->
Successfully running following tasks on local:
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`

<!-- If there are related PRs please add them here -->
<!--
#### Related PR  
Related to PR #
-->