### PR TITLE
Fix build errors on Github Actions

### DIFF
--- a/.github/workflows/android-main.yml
+++ b/.github/workflows/android-main.yml
@@ -60,55 +60,55 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        api-level: [ 23 ]#[ 16, 19, 28 ]
-            steps:
-              - name: checkout
-                uses: actions/checkout@v2
-              - name: Java 15
-                uses: actions/setup-java@v1
-                with:
-                  java-version: 15
-              - name: Gradle cache
-                uses: actions/cache@v2
-                with:
-                  path: |
-                    ~/.gradle/caches
-                    ~/.gradle/wrapper
-                  key: gradle-${ { runner.os } }-${ { hashFiles('**/*.gradle*') } }-${ { hashFiles('**/gradle/wrapper/gradle-wrapper.properties') } }-${ { hashFiles('**/buildSrc/**/*.kt') } }
-              - uses: actions/cache@v2
-                id: avd-cache
-                with:
-                  path: |
-                    ~/.android/avd/*
-                    ~/.android/adb*
-                    ~/.android/debug.keystore
-                  key: avd-${ { matrix.api-level } }
-              - name: create AVD and generate snapshot for caching
-                if: steps.avd-cache.outputs.cache-hit != 'true'
-                uses: reactivecircus/android-emulator-runner@v2
-                with:
-                  api-level: ${ { matrix.api-level } }
-                  force-avd-creation: false
-                  emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
-                  disable-animations: false
-                  sdcard-path-or-size: 100M
-                  arch: x86_64
-                  ram-size: 2048M
-                  channel: canary
-                  script: echo "Generated AVD snapshot for caching."
+        api-level: [ 16, 19, 28 ]
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: Java 15
+        uses: actions/setup-java@v1
+        with:
+          java-version: 15
+      - name: Gradle cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: gradle-${ { runner.os } }-${ { hashFiles('**/*.gradle*') } }-${ { hashFiles('**/gradle/wrapper/gradle-wrapper.properties') } }-${ { hashFiles('**/buildSrc/**/*.kt') } }
+      - uses: actions/cache@v2
+        id: avd-cache
+        with:
+          path: |
+            ~/.android/avd/*
+            ~/.android/adb*
+            ~/.android/debug.keystore
+          key: avd-${ { matrix.api-level } }
+      - name: create AVD and generate snapshot for caching
+        if: steps.avd-cache.outputs.cache-hit != 'true'
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: ${ { matrix.api-level } }
+          force-avd-creation: false
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: false
+          sdcard-path-or-size: 100M
+          arch: x86_64
+          ram-size: 2048M
+          channel: canary
+          script: echo "Generated AVD snapshot for caching."
 
-              - name: run tests
-                uses: reactivecircus/android-emulator-runner@v2
-                with:
-                  api-level: ${ { matrix.api-level } }
-                  force-avd-creation: false
-                  emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
-                  disable-animations: true
-                  sdcard-path-or-size: 100M
-                  arch: x86_64
-                  ram-size: 2048M
-                  channel: canary
-                  script: |
-                    adb logcat -c
-                    adb logcat *:E &
-                    ./gradlew :app:connectedCheck
+      - name: run tests
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: ${ { matrix.api-level } }
+          force-avd-creation: false
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: true
+          sdcard-path-or-size: 100M
+          arch: x86_64
+          ram-size: 2048M
+          channel: canary
+          script: |
+            adb logcat -c
+            adb logcat *:E &
+            ./gradlew :app:connectedCheck

--- a/app/.gitignore
+++ b/app/.gitignore
@@ -1,1 +1,2 @@
 /build
+.attach_pid*

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -255,6 +255,9 @@ configurations.all {
         dependencySubstitution {
             substitute module("commons-logging:commons-logging-api:1.1") with module("commons-logging:commons-logging:1.1.1")
             substitute module("com.android.support:support-annotations:27.1.1") with module("com.android.support:support-annotations:27.0.2")
+            // These two lines are added to prevent possible class clashes between awaitility (which uses hamcrest 2.1) and junit (which uses hamcrest 1.3).
+            substitute module('org.hamcrest:hamcrest-core:1.3') with module("org.hamcrest:hamcrest:2.1")
+            substitute module('org.hamcrest:hamcrest-library:1.3') with module("org.hamcrest:hamcrest:2.1")
         }
     }
 }


### PR DESCRIPTION
Seems the indentation in android-main.yml is different than docs I found... so I'm trying this first.

Also
- fixes awaitility and junit hamcrest dependency differences causing class conflict error reported during build
- little tweak in `.gitignore` to ignore `.attach_pid` files

