### PR TITLE
Fix Github CI action again

### DIFF
--- a/.github/workflows/android-main.yml
+++ b/.github/workflows/android-main.yml
@@ -74,7 +74,7 @@ jobs:
           path: |
             ~/.gradle/caches
             ~/.gradle/wrapper
-          key: gradle-${ { runner.os } }-${ { hashFiles('**/*.gradle*') } }-${ { hashFiles('**/gradle/wrapper/gradle-wrapper.properties') } }-${ { hashFiles('**/buildSrc/**/*.kt') } }
+          key: gradle-${{ runner.os }}-${{ hashFiles('**/*.gradle*') }}-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}-${{ hashFiles('**/buildSrc/**/*.kt') }}
       - uses: actions/cache@v2
         id: avd-cache
         with:
@@ -82,17 +82,17 @@ jobs:
             ~/.android/avd/*
             ~/.android/adb*
             ~/.android/debug.keystore
-          key: avd-${ { matrix.api-level } }
+          key: avd-${{ matrix.api-level }}
       - name: create AVD and generate snapshot for caching
         if: steps.avd-cache.outputs.cache-hit != 'true'
         uses: reactivecircus/android-emulator-runner@v2
         with:
-          api-level: ${ { matrix.api-level } }
+          api-level: ${{ matrix.api-level }}
           force-avd-creation: false
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: false
           sdcard-path-or-size: 100M
-          arch: x86_64
+          arch: x86
           ram-size: 2048M
           channel: canary
           script: echo "Generated AVD snapshot for caching."
@@ -100,12 +100,12 @@ jobs:
       - name: run tests
         uses: reactivecircus/android-emulator-runner@v2
         with:
-          api-level: ${ { matrix.api-level } }
+          api-level: ${{ matrix.api-level }}
           force-avd-creation: false
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
           sdcard-path-or-size: 100M
-          arch: x86_64
+          arch: x86
           ram-size: 2048M
           channel: canary
           script: |


### PR DESCRIPTION
These are the changes I used to make `connectedCheck` to continue running after configuring the emulator at Github CI.

- Fix variable brackets
- Fix emulator architecture to all `x86` - `x86_64` emulators only exist for API >= 21