### PR TITLE
Fix another leaked closeable violation for 7z

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/compress/SevenZipHelperTask.kt
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/compress/SevenZipHelperTask.kt
@@ -54,34 +54,35 @@ class SevenZipHelperTask(
         while (true) {
             if (paused) continue
             try {
-                val sevenzFile = if (ArchivePasswordCache.getInstance().containsKey(filePath)) {
+                if (ArchivePasswordCache.getInstance().containsKey(filePath)) {
                     SevenZFile(
                         File(filePath),
                         ArchivePasswordCache.getInstance()[filePath]!!.toCharArray()
                     )
                 } else {
                     SevenZFile(File(filePath))
-                }
-                for (entry in sevenzFile.entries) {
-                    val name = entry.name
-                    val isInBaseDir = (
-                        relativePath == "" &&
-                            !name.contains(CompressedHelper.SEPARATOR)
-                        )
-                    val isInRelativeDir = (
-                        name.contains(CompressedHelper.SEPARATOR) &&
-                            name.substring(0, name.lastIndexOf(CompressedHelper.SEPARATOR))
-                            == relativePath
-                        )
-                    if (isInBaseDir || isInRelativeDir) {
-                        elements.add(
-                            CompressedObjectParcelable(
-                                entry.name,
-                                entry.lastModifiedDate.time,
-                                entry.size,
-                                entry.isDirectory
+                }.use {
+                    for (entry in it.entries) {
+                        val name = entry.name
+                        val isInBaseDir = (
+                                relativePath == "" &&
+                                        !name.contains(CompressedHelper.SEPARATOR)
+                                )
+                        val isInRelativeDir = (
+                                name.contains(CompressedHelper.SEPARATOR) &&
+                                        name.substring(0, name.lastIndexOf(CompressedHelper.SEPARATOR))
+                                        == relativePath
+                                )
+                        if (isInBaseDir || isInRelativeDir) {
+                            elements.add(
+                                    CompressedObjectParcelable(
+                                            entry.name,
+                                            entry.lastModifiedDate.time,
+                                            entry.size,
+                                            entry.isDirectory
+                                    )
                             )
-                        )
+                        }
                     }
                 }
                 paused = false


### PR DESCRIPTION
## Description
Automatically close file handle by using Kotlins built-in `use` operator.

#### Issue tracker   
Fixes #3202 

#### Automatic tests
<!-- remember to do manual testing when making UI changes! -->
- [ ] Added test cases
  
#### Manual tests
- [x] Done  

- OS: Android 9

#### Build tasks success  
<!-- run these! -->
Successfully running following tasks on local:
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`