### PR TITLE
Fix Android connected test compatibility with main code base

### DIFF
--- a/app/src/androidTest/java/com/amaze/filemanager/asynchronous/services/ftp/FtpServiceEspressoTest.kt
+++ b/app/src/androidTest/java/com/amaze/filemanager/asynchronous/services/ftp/FtpServiceEspressoTest.kt
@@ -34,16 +34,26 @@ import org.apache.commons.net.ftp.FTPClient
 import org.apache.commons.net.ftp.FTPSClient
 import org.awaitility.Awaitility.await
 import org.junit.After
-import org.junit.Assert.*
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-import java.io.*
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.io.FileInputStream
+import java.io.FileOutputStream
+import java.io.FileWriter
 import java.net.InetAddress
 import java.net.InetSocketAddress
 import java.net.Socket
 import java.net.SocketException
 import java.security.SecureRandom
+import java.util.concurrent.Callable
 import java.util.concurrent.TimeUnit
 
 @RunWith(AndroidJUnit4::class)
@@ -83,7 +93,7 @@ class FtpServiceEspressoTest {
                 .putExtra(FtpService.TAG_STARTED_BY_TILE, false)
         )
 
-        await().atMost(10, TimeUnit.SECONDS).until { FtpService.isRunning() }
+        await().atMost(10, TimeUnit.SECONDS).until(Callable { FtpService.isRunning() })
         waitForServer()
         FTPClient().run {
             loginAndVerifyWith(this)
@@ -109,7 +119,7 @@ class FtpServiceEspressoTest {
                 .putExtra(FtpService.TAG_STARTED_BY_TILE, false)
         )
 
-        await().atMost(10, TimeUnit.SECONDS).until { FtpService.isRunning() }
+        await().atMost(10, TimeUnit.SECONDS).until(Callable { FtpService.isRunning() })
         waitForServer()
 
         FTPSClient(true).run {

--- a/app/src/test/java/com/amaze/filemanager/asynchronous/services/ExtractServiceTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/asynchronous/services/ExtractServiceTest.kt
@@ -30,16 +30,14 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.amaze.filemanager.R
 import com.amaze.filemanager.file_operations.filesystem.compressed.ArchivePasswordCache
-import com.amaze.filemanager.filesystem.compressed.CompressedHelper
 import com.amaze.filemanager.shadows.ShadowMultiDex
 import com.amaze.filemanager.test.randomBytes
 import com.amaze.filemanager.test.supportedArchiveExtensions
 import org.awaitility.Awaitility.await
-import org.awaitility.core.ConditionEvaluationListener
-import org.awaitility.core.EvaluatedCondition
-import org.awaitility.core.TimeoutEvent
 import org.junit.After
-import org.junit.Assert.*
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.fail
 import org.junit.Before
 import org.junit.Ignore
 import org.junit.Test
@@ -55,12 +53,10 @@ import org.robolectric.shadows.ShadowToast
 import java.io.ByteArrayInputStream
 import java.io.File
 import java.io.FileOutputStream
-import java.lang.reflect.Modifier
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
 import java.util.concurrent.TimeUnit
-import kotlin.random.Random
 
 @RunWith(AndroidJUnit4::class)
 @Config(shadows = [ShadowMultiDex::class], sdk = [JELLY_BEAN, KITKAT, P])
@@ -417,12 +413,11 @@ class ExtractServiceTest {
             performTest(badArchive)
             ShadowLooper.idleMainLooper()
             await()
-                .conditionEvaluationListener(object : ConditionEvaluationListener<Any> {
-                    override fun conditionEvaluated(condition: EvaluatedCondition<Any>?) = Unit
-                    override fun onTimeout(timeoutEvent: TimeoutEvent?) {
+                .conditionEvaluationListener { condition ->
+                    if (condition.remainingTimeInMS <= 0 && !condition.isSatisfied) {
                         fail("Extractor unable to handle bad archive for $archiveType")
                     }
-                })
+                }
                 .atMost(10, TimeUnit.SECONDS)
                 .until {
                     ShadowToast.getLatestToast() != null

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
         fabSpeedDialVersion = '3.1.1'
         roomVersion = '2.4.0'
         bouncyCastleVersion = '1.68'
-        awaitilityVersion = "4.1.1"
+        awaitilityVersion = "3.1.6"
         androidMaterialVersion = "1.4.0"
         androidXFragmentVersion = "1.3.6"
         androidXAppCompatVersion = "1.3.1"


### PR DESCRIPTION
By downgrading awaitility to 3.1.6, the last version we had been using. 4.x series depends on Java 8 which we shall avoid.