### PR TITLE
Fix at encrypt save as dialog, tapping the info button have no response

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/filesystem/PasteHelper.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/PasteHelper.java
@@ -20,9 +20,16 @@
 
 package com.amaze.filemanager.filesystem;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Objects;
+import static androidx.core.text.HtmlCompat.FROM_HTML_MODE_COMPACT;
+
+import android.os.AsyncTask;
+import android.os.Parcel;
+import android.os.Parcelable;
+import android.text.Spanned;
+import android.util.Log;
+
+import androidx.annotation.Nullable;
+import androidx.core.text.HtmlCompat;
 
 import com.amaze.filemanager.R;
 import com.amaze.filemanager.asynchronous.asynctasks.movecopy.PrepareCopyTask;
@@ -32,15 +39,9 @@ import com.amaze.filemanager.utils.Utils;
 import com.google.android.material.snackbar.BaseTransientBottomBar;
 import com.google.android.material.snackbar.Snackbar;
 
-import android.os.AsyncTask;
-import android.os.Build;
-import android.os.Parcel;
-import android.os.Parcelable;
-import android.text.Html;
-import android.text.Spanned;
-import android.util.Log;
-
-import androidx.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Objects;
 
 import io.reactivex.Single;
 import io.reactivex.SingleObserver;
@@ -209,10 +210,6 @@ public final class PasteHelper implements Parcelable {
         operationText.concat(
             mainActivity.getString(R.string.folderfilecount, foldersCount, filesCount));
 
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-      return Html.fromHtml(operationText, Html.FROM_HTML_MODE_COMPACT);
-    } else {
-      return Html.fromHtml(operationText);
-    }
+    return HtmlCompat.fromHtml(operationText, FROM_HTML_MODE_COMPACT);
   }
 }

--- a/app/src/main/java/com/amaze/filemanager/ui/activities/MainActivity.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/activities/MainActivity.java
@@ -2304,7 +2304,7 @@ public class MainActivity extends PermissionsActivity
         if (folder.exists() && folder.isDirectory()) {
           if (FileUtils.isRunningAboveStorage(folder.getAbsolutePath())) {
             if (!isRootExplorer()) {
-              AlertDialog.show(this, R.string.ftp_server_root_unavailable, R.string.error, android.R.string.ok, null);
+              AlertDialog.show(this, R.string.ftp_server_root_unavailable, R.string.error, android.R.string.ok, null, false);
             } else {
               MaterialDialog confirmDialog = GeneralDialogCreation.showBasicDialog(this, R.string.ftp_server_root_filesystem_warning,R.string.warning,  android.R.string.ok, android.R.string.cancel);
               confirmDialog.getActionButton(DialogAction.POSITIVE).setOnClickListener(v -> {

--- a/app/src/main/java/com/amaze/filemanager/ui/dialogs/AlertDialog.kt
+++ b/app/src/main/java/com/amaze/filemanager/ui/dialogs/AlertDialog.kt
@@ -22,11 +22,12 @@ object AlertDialog {
         @StringRes content: Int,
         @StringRes title: Int,
         @StringRes positiveButtonText: Int = android.R.string.ok,
-        @Nullable onPositive: MaterialDialog.SingleButtonCallback? = null
+        @Nullable onPositive: MaterialDialog.SingleButtonCallback? = null,
+        contentIsHtml: Boolean = false
     ) {
         val accentColor: Int = activity.accent
         val a = MaterialDialog.Builder(activity)
-            .content(content)
+            .content(content, contentIsHtml)
             .widgetColor(accentColor)
             .theme(
                 activity
@@ -37,7 +38,7 @@ object AlertDialog {
             .positiveText(positiveButtonText)
             .positiveColor(accentColor)
 
-        if(onPositive != null) {
+        if (onPositive != null) {
             a.onPositive(onPositive)
         }
         a.build().show()

--- a/app/src/main/java/com/amaze/filemanager/ui/dialogs/EncryptWithPresetPasswordSaveAsDialog.kt
+++ b/app/src/main/java/com/amaze/filemanager/ui/dialogs/EncryptWithPresetPasswordSaveAsDialog.kt
@@ -6,6 +6,7 @@ import android.content.Intent
 import android.view.LayoutInflater
 import android.view.View
 import android.widget.Toast
+import androidx.core.text.HtmlCompat
 import androidx.preference.PreferenceManager
 import com.afollestad.materialdialogs.DialogAction
 import com.afollestad.materialdialogs.MaterialDialog
@@ -65,6 +66,12 @@ object EncryptWithPresetPasswordSaveAsDialog {
                 }
             }
             val useAzeEncrypt = vb.checkboxUseAze
+            val usageTextInfo = vb.textViewCryptInfo.apply {
+                text = HtmlCompat.fromHtml(
+                    main.getString(R.string.encrypt_option_use_aescrypt_desc),
+                    HtmlCompat.FROM_HTML_MODE_LEGACY
+                )
+            }
             if (ENCRYPT_PASSWORD_FINGERPRINT != password) {
                 useAzeEncrypt.setOnCheckedChangeListener(
                     createUseAzeEncryptCheckboxOnCheckedChangeListener(
@@ -72,12 +79,13 @@ object EncryptWithPresetPasswordSaveAsDialog {
                         this,
                         preferences,
                         main,
-                        encryptSaveAsEditText
+                        encryptSaveAsEditText,
+                        usageTextInfo
                     )
                 )
             } else {
                 useAzeEncrypt.visibility = View.INVISIBLE
-                vb.textViewAzecryptInfo.visibility = View.INVISIBLE
+                usageTextInfo.visibility = View.INVISIBLE
             }
 
             val saveAsDialog = MaterialDialog.Builder(c)

--- a/app/src/main/java/com/amaze/filemanager/ui/fragments/ProcessViewerFragment.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/fragments/ProcessViewerFragment.java
@@ -20,7 +20,30 @@
 
 package com.amaze.filemanager.ui.fragments;
 
-import java.util.ArrayList;
+import static androidx.core.text.HtmlCompat.FROM_HTML_MODE_COMPACT;
+
+import android.content.ComponentName;
+import android.content.Intent;
+import android.content.ServiceConnection;
+import android.graphics.Color;
+import android.graphics.Typeface;
+import android.graphics.drawable.ColorDrawable;
+import android.os.Bundle;
+import android.os.IBinder;
+import android.text.Spanned;
+import android.text.format.Formatter;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ImageButton;
+import android.widget.ImageView;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import androidx.annotation.Nullable;
+import androidx.cardview.widget.CardView;
+import androidx.core.text.HtmlCompat;
+import androidx.fragment.app.Fragment;
 
 import com.amaze.filemanager.R;
 import com.amaze.filemanager.asynchronous.services.AbstractProgressiveService;
@@ -43,28 +66,7 @@ import com.github.mikephil.charting.data.LineData;
 import com.github.mikephil.charting.data.LineDataSet;
 import com.github.mikephil.charting.interfaces.datasets.ILineDataSet;
 
-import android.content.ComponentName;
-import android.content.Intent;
-import android.content.ServiceConnection;
-import android.graphics.Color;
-import android.graphics.Typeface;
-import android.graphics.drawable.ColorDrawable;
-import android.os.Bundle;
-import android.os.IBinder;
-import android.text.Html;
-import android.text.Spanned;
-import android.text.format.Formatter;
-import android.view.LayoutInflater;
-import android.view.View;
-import android.view.ViewGroup;
-import android.widget.ImageButton;
-import android.widget.ImageView;
-import android.widget.TextView;
-import android.widget.Toast;
-
-import androidx.annotation.Nullable;
-import androidx.cardview.widget.CardView;
-import androidx.fragment.app.Fragment;
+import java.util.ArrayList;
 
 public class ProcessViewerFragment extends Fragment {
 
@@ -214,7 +216,7 @@ public class ProcessViewerFragment extends Fragment {
       mProgressFileNameText.setText(name);
 
       Spanned bytesText =
-          Html.fromHtml(
+          HtmlCompat.fromHtml(
               getResources().getString(R.string.written)
                   + " <font color='"
                   + accentColor
@@ -224,11 +226,11 @@ public class ProcessViewerFragment extends Fragment {
                   + getResources().getString(R.string.out_of)
                   + " <i>"
                   + Formatter.formatFileSize(getContext(), total)
-                  + "</i>");
+                  + "</i>", FROM_HTML_MODE_COMPACT);
       mProgressBytesText.setText(bytesText);
 
       Spanned fileProcessedSpan =
-          Html.fromHtml(
+          HtmlCompat.fromHtml(
               getResources().getString(R.string.processing_file)
                   + " <font color='"
                   + accentColor
@@ -238,27 +240,27 @@ public class ProcessViewerFragment extends Fragment {
                   + getResources().getString(R.string.of)
                   + " <i>"
                   + dataPackage.getAmountOfSourceFiles()
-                  + "</i>");
+                  + "</i>", FROM_HTML_MODE_COMPACT);
       mProgressFileText.setText(fileProcessedSpan);
 
       Spanned speedSpan =
-          Html.fromHtml(
+          HtmlCompat.fromHtml(
               getResources().getString(R.string.current_speed)
                   + ": <font color='"
                   + accentColor
                   + "'><i>"
                   + Formatter.formatFileSize(getContext(), dataPackage.getSpeedRaw())
-                  + "/s</font></i>");
+                  + "/s</font></i>", FROM_HTML_MODE_COMPACT);
       mProgressSpeedText.setText(speedSpan);
 
       Spanned timerSpan =
-          Html.fromHtml(
+          HtmlCompat.fromHtml(
               getResources().getString(R.string.service_timer)
                   + ": <font color='"
                   + accentColor
                   + "'><i>"
                   + Utils.formatTimer(++looseTimeInSeconds)
-                  + "</font></i>");
+                  + "</font></i>", FROM_HTML_MODE_COMPACT);
 
       mProgressTimer.setText(timerSpan);
 

--- a/app/src/main/res/layout/dialog_encrypt_authenticate.xml
+++ b/app/src/main/res/layout/dialog_encrypt_authenticate.xml
@@ -8,6 +8,8 @@
         android:id="@+id/til_encrypt_password"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
         app:errorEnabled="true">
 
         <com.google.android.material.textfield.TextInputEditText
@@ -60,17 +62,17 @@
         android:text="@string/encrypt_option_use_aze"
         android:layout_gravity="center_vertical"
         android:id="@+id/checkbox_use_aze"
+        app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/til_encrypt_save_as"
         />
+
     <androidx.appcompat.widget.AppCompatTextView
         android:layout_width="wrap_content"
         android:layout_height="match_parent"
-        android:padding="5sp"
-        android:text="@string/info_glyph"
-        android:id="@+id/text_view_azecrypt_info"
+        android:text="@string/encrypt_option_use_aescrypt_desc"
+        android:id="@+id/text_view_crypt_info"
         android:layout_gravity="center_vertical"
-        android:textSize="22sp"
-        app:layout_constraintTop_toBottomOf="@id/til_encrypt_save_as"
-        app:layout_constraintStart_toEndOf="@+id/checkbox_use_aze" />
+        app:layout_constraintTop_toBottomOf="@id/checkbox_use_aze"
+        app:layout_constraintStart_toStartOf="parent" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/dialog_encrypt_with_master_password.xml
+++ b/app/src/main/res/layout/dialog_encrypt_with_master_password.xml
@@ -10,6 +10,8 @@
         android:id="@id/til_encrypt_save_as"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
         app:errorEnabled="true">
 
         <com.google.android.material.textfield.TextInputEditText
@@ -27,14 +29,15 @@
         android:text="@string/encrypt_option_use_aze"
         android:layout_gravity="center_vertical"
         android:id="@+id/checkbox_use_aze"
+        app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/til_encrypt_save_as"
         />
     <androidx.appcompat.widget.AppCompatTextView
         android:layout_width="wrap_content"
         android:layout_height="match_parent"
         android:padding="5sp"
-        android:text="@string/info_glyph"
-        android:id="@+id/text_view_azecrypt_info"
+        android:text="@string/encrypt_option_use_aescrypt_desc"
+        android:id="@+id/text_view_crypt_info"
         android:layout_gravity="center_vertical"
         android:textSize="22sp"
         app:layout_constraintTop_toBottomOf="@id/til_encrypt_save_as"

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -565,8 +565,11 @@
     <string name="encrypt_folder_save_as">將加密檔案夾儲存為&#8230;</string>
     <string name="encrypt_option_use_aze">使用 Amaze加密格式</string>
     <string name="encrypt_option_use_aescrypt_desc"><![CDATA[
-        <p>剔咗呢個剔，Amaze會用番原有嘅方法去加密檔案。呢個方法適合一啲只會喺呢部機上使用嘅檔案。</p>
-        <p>同 AESCrypt格式唔同，經 Amaze自有方法加密嘅檔案只能喺番呢部機上解密。而且你唔可以剷走 Amaze架，否則就算你記得個密碼，個檔案都救唔番架啦。</p>
+        <p>AESCrypt係基於 AES加密技術嘅開源檔案加密格式。佢可以喺任何平台上支援 AESCrypt嘅應用程式上解密。</p>
+        <p><a href="https://www.aescrypt.com" target="_blank>AESCrypt 官方網站</a></p>
+]]></string>
+    <string name="encrypt_option_use_azecrypt_desc"><![CDATA[
+        <p>Amaze自有加密方式亦都係以 AES加密技術為基礎。但係同 AESCrypt格式唔同，用呢個方法加密嘅檔案只能喺番呢部機上解密。而且你唔可以剷走 Amaze架，甚至連更改 lock screen設定都唔得，否則就算你記得個密碼，個檔案都救唔番架啦。</p>
     ]]></string>
     <string name="encrypt_file_must_end_with_aze">加密檔案一定要用“.aze”做檔案擴展名稱。</string>
     <string name="encrypt_file_must_end_with_aes">加密檔案一定要用“.aes”做檔案擴展名稱。</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -608,10 +608,12 @@
     <string name="encrypt_file_save_as">儲存加密檔案為……</string>
     <string name="encrypt_folder_save_as">儲存加密檔案夾為……</string>
     <string name="encrypt_option_use_aze">使用 Amaze加密格式</string>
-    <string name="encrypt_option_use_aescrypt_title">關於 Amaze加密格式</string>
     <string name="encrypt_option_use_aescrypt_desc"><![CDATA[
-        <p>剔取這個選項，Amaze會沿用原有的方法對檔案進行加密。此加密方式適合只會在這機器上使用的檔案。</p>
-        <p>跟 AESCrypt格式不同，使用 Amaze自有方式加密的檔案只能在此機器上進行解密。而且你絕不可以從此機器上移除 Amaze 檔案管理員，否則你將無法對檔案進行解密。</p>
+        <p>AESCrypt是基於 AES加密技術的開源檔案加密格式。它能在任何平台上支援 AESCrypt的應用程式上解密。</p>
+        <p><a href="https://www.aescrypt.com" target="_blank>AESCrypt 官方網站</a></p>]]>
+    </string>
+    <string name="encrypt_option_use_azecrypt_desc"><![CDATA[
+        <p>Amaze自有加密方式亦以 AES加密技術為基礎。但跟 AESCrypt格式不同，使用此方式加密的檔案只能在此機器上進行解密。而且你絕不可以從此機器上移除 Amaze 檔案管理員，甚至更改屏幕鎖定設定，否則你將無法對檔案進行解密。</p>
     ]]></string>
     <string name="encrypt_file_must_end_with_aze">加密檔案必須以“.aze”為檔案擴展名稱。</string>
     <string name="encrypt_file_must_end_with_aes">加密檔案必須以“.aes”為檔案擴展名稱。</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -628,10 +628,12 @@
     <string name="encrypt_file_save_as">Save Encrypted File As&#8230;</string>
     <string name="encrypt_folder_save_as">Save Encrypted Folder As&#8230;</string>
     <string name="encrypt_option_use_aze">Use Amaze Encryption Format</string>
-    <string name="encrypt_option_use_aescrypt_title">About Amaze Encryption Format</string>
     <string name="encrypt_option_use_aescrypt_desc"><![CDATA[
-        <p>Choosing this option, Amaze will encrypt the files using its own encryption format.</p>
-        <p>Different than AESCrypt format, Amaze\'s Encryption Format can only be decrypted by this device; also you must not uninstall Amaze File Manager from this device, otherwise you will have no way to recover the encrypted file.</p>
+        <p>AESCrypt is an open source file encryption format based on AES encryption. It is also portable, can be decrypted with AESCrypt programs on other platforms.</p>
+        <p><a href="https://www.aescrypt.com" target="_blank>AESCrypt website</a></p>]]>
+    </string>
+    <string name="encrypt_option_use_azecrypt_desc"><![CDATA[
+        <p>Amaze\'s Encryption Format is also based on AES encryption; but different from AESCrypt format, it can only be decrypted by this device; also you must not uninstall Amaze File Manager from this device nor change the way you lock screen, otherwise you will have no way to recover the encrypted file.</p>
     ]]></string>
     <string name="encrypt_file_must_end_with_aze">Encrypted files must use \".aze\" as the file extension.</string>
     <string name="encrypt_file_must_end_with_aes">Encrypted files must use \".aes\" as the file extension.</string>

--- a/app/src/test/java/com/amaze/filemanager/database/UtilsHandlerTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/database/UtilsHandlerTest.kt
@@ -15,7 +15,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.amaze.filemanager.application.AppConfig
 import com.amaze.filemanager.database.models.OperationData
 import com.amaze.filemanager.shadows.ShadowMultiDex
-import com.amaze.filemanager.test.ShadowCryptUtil
+import com.amaze.filemanager.test.ShadowPasswordUtil
 import com.amaze.filemanager.utils.SmbUtil
 import io.reactivex.android.plugins.RxAndroidPlugins
 import io.reactivex.plugins.RxJavaPlugins
@@ -33,7 +33,7 @@ import java.io.File
 
 @RunWith(AndroidJUnit4::class)
 @Config(
-    shadows = [ShadowMultiDex::class, ShadowCryptUtil::class],
+    shadows = [ShadowMultiDex::class, ShadowPasswordUtil::class],
     sdk = [JELLY_BEAN, KITKAT, P]
 )
 class UtilsHandlerTest {

--- a/app/src/test/java/com/amaze/filemanager/ui/dialogs/EncryptAuthenticateDialogTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/ui/dialogs/EncryptAuthenticateDialogTest.kt
@@ -3,6 +3,9 @@ package com.amaze.filemanager.ui.dialogs
 import android.content.Intent
 import android.os.Environment
 import androidx.appcompat.widget.AppCompatCheckBox
+import androidx.appcompat.widget.AppCompatTextView
+import androidx.core.text.HtmlCompat
+import androidx.core.text.HtmlCompat.FROM_HTML_MODE_COMPACT
 import androidx.preference.PreferenceManager
 import com.afollestad.materialdialogs.DialogAction
 import com.afollestad.materialdialogs.MaterialDialog
@@ -49,6 +52,7 @@ class EncryptAuthenticateDialogTest : AbstractEncryptDialogTests() {
     private lateinit var editTextEncryptPassword: TextInputEditText
     private lateinit var editTextEncryptPasswordConfirm: TextInputEditText
     private lateinit var checkboxUseAze: AppCompatCheckBox
+    private lateinit var textViewCryptInfo: AppCompatTextView
     private lateinit var okButton: MDButton
 
     /**
@@ -140,9 +144,15 @@ class EncryptAuthenticateDialogTest : AbstractEncryptDialogTests() {
             editTextEncryptPasswordConfirm.setText("")
             assertFalse(okButton.isEnabled)
             assertEquals(getString(R.string.field_empty), tilEncryptPassword.error)
+            editTextEncryptPassword.setText("     ")
+            editTextEncryptPasswordConfirm.setText("     ")
+            assertFalse(okButton.isEnabled)
+            assertEquals(getString(R.string.field_empty), tilEncryptPassword.error)
             editTextEncryptPassword.setText("abcdef")
             editTextEncryptPasswordConfirm.setText("abcdef")
             assertTrue(okButton.isEnabled)
+            editTextFileSaveAs.setText("")
+            assertFalse(okButton.isEnabled)
         })
     }
 
@@ -152,6 +162,8 @@ class EncryptAuthenticateDialogTest : AbstractEncryptDialogTests() {
     @Test
     fun testFilenameValidations() {
         performTest({ _, _, _ ->
+            editTextEncryptPassword.setText("abc")
+            editTextEncryptPasswordConfirm.setText("abc")
             editTextFileSaveAs.setText("${file.name}.error")
             assertFalse(okButton.isEnabled)
             assertEquals(
@@ -179,6 +191,18 @@ class EncryptAuthenticateDialogTest : AbstractEncryptDialogTests() {
                 getString(R.string.encrypt_file_must_end_with_aze),
                 tilFileSaveAs.error
             )
+            editTextFileSaveAs.setText("")
+            assertFalse(okButton.isEnabled)
+            assertEquals(
+                getString(R.string.field_empty),
+                tilFileSaveAs.error
+            )
+            editTextFileSaveAs.setText("          ")
+            assertFalse(okButton.isEnabled)
+            assertEquals(
+                getString(R.string.field_empty),
+                tilFileSaveAs.error
+            )
             editTextFileSaveAs.setText("${file.name}.aze")
             assertTrue(okButton.isEnabled)
             assertNull(tilFileSaveAs.error)
@@ -192,6 +216,14 @@ class EncryptAuthenticateDialogTest : AbstractEncryptDialogTests() {
     fun testAzeCryptDialog() {
         performTest({ _, _, _ ->
             checkboxUseAze.isChecked = true
+            assertEquals(
+                HtmlCompat.fromHtml(
+                    getString(R.string.encrypt_option_use_azecrypt_desc),
+                    FROM_HTML_MODE_COMPACT
+                )
+                    .toString(),
+                textViewCryptInfo.text.toString()
+            )
             assertTrue(ShadowDialog.getShownDialogs().size == 2)
             assertTrue(ShadowDialog.getLatestDialog() is MaterialDialog)
             (ShadowDialog.getLatestDialog() as MaterialDialog).run {
@@ -211,10 +243,26 @@ class EncryptAuthenticateDialogTest : AbstractEncryptDialogTests() {
             assertFalse(ShadowDialog.getLatestDialog().isShowing)
             assertTrue(true == editTextFileSaveAs.text?.endsWith(CRYPT_EXTENSION))
             checkboxUseAze.isChecked = false
+            assertEquals(
+                HtmlCompat.fromHtml(
+                    getString(R.string.encrypt_option_use_aescrypt_desc),
+                    FROM_HTML_MODE_COMPACT
+                )
+                    .toString(),
+                textViewCryptInfo.text.toString()
+            )
             assertEquals(2, ShadowDialog.getShownDialogs().size)
             assertFalse(ShadowDialog.getLatestDialog().isShowing)
             assertTrue(true == editTextFileSaveAs.text?.endsWith(AESCRYPT_EXTENSION))
             checkboxUseAze.isChecked = true
+            assertEquals(
+                HtmlCompat.fromHtml(
+                    getString(R.string.encrypt_option_use_azecrypt_desc),
+                    FROM_HTML_MODE_COMPACT
+                )
+                    .toString(),
+                textViewCryptInfo.text.toString()
+            )
             assertEquals(3, ShadowDialog.getShownDialogs().size)
             assertTrue(ShadowDialog.getLatestDialog().isShowing)
             assertTrue(true == editTextFileSaveAs.text?.endsWith(CRYPT_EXTENSION))
@@ -230,6 +278,21 @@ class EncryptAuthenticateDialogTest : AbstractEncryptDialogTests() {
             assertEquals(3, ShadowDialog.getShownDialogs().size) // no new dialog
             checkboxUseAze.isChecked = true
             assertEquals(3, ShadowDialog.getShownDialogs().size)
+        })
+    }
+
+    /**
+     * Test jump across textfields should keep button status.
+     */
+    @Test
+    fun testTextfieldFocusChanges() {
+        performTest({ _, _, _ ->
+            editTextFileSaveAs.requestFocus()
+            assertFalse(okButton.isEnabled)
+            editTextEncryptPasswordConfirm.requestFocus()
+            assertFalse(okButton.isEnabled)
+            editTextEncryptPassword.requestFocus()
+            assertFalse(okButton.isEnabled)
         })
     }
 
@@ -280,6 +343,9 @@ class EncryptAuthenticateDialogTest : AbstractEncryptDialogTests() {
                                 R.id.til_encrypt_password
                             )
                             checkboxUseAze = findViewById<AppCompatCheckBox>(R.id.checkbox_use_aze)
+                            textViewCryptInfo = findViewById<AppCompatTextView>(
+                                R.id.text_view_crypt_info
+                            )
                             okButton = getActionButton(DialogAction.POSITIVE)
                             assertFalse(okButton.isEnabled)
                             assertTrue(true == editTextFileSaveAs.text?.startsWith(file.name))

--- a/app/src/test/java/com/amaze/filemanager/ui/dialogs/EncryptWithPresetPasswordSaveAsDialogTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/ui/dialogs/EncryptWithPresetPasswordSaveAsDialogTest.kt
@@ -5,6 +5,8 @@ import android.os.Environment
 import android.view.View.INVISIBLE
 import android.view.View.VISIBLE
 import androidx.appcompat.widget.AppCompatCheckBox
+import androidx.appcompat.widget.AppCompatTextView
+import androidx.core.text.HtmlCompat
 import androidx.preference.PreferenceManager
 import com.afollestad.materialdialogs.DialogAction
 import com.afollestad.materialdialogs.MaterialDialog
@@ -46,6 +48,7 @@ class EncryptWithPresetPasswordSaveAsDialogTest : AbstractEncryptDialogTests() {
     private lateinit var tilFileSaveAs: WarnableTextInputLayout
     private lateinit var editTextFileSaveAs: TextInputEditText
     private lateinit var checkboxUseAze: AppCompatCheckBox
+    private lateinit var textViewCryptInfo: AppCompatTextView
     private lateinit var okButton: MDButton
 
     /**
@@ -90,6 +93,7 @@ class EncryptWithPresetPasswordSaveAsDialogTest : AbstractEncryptDialogTests() {
             testContent = { _, _, _ ->
                 assertEquals("${file.name}$CRYPT_EXTENSION", editTextFileSaveAs.text.toString())
                 assertEquals(INVISIBLE, checkboxUseAze.visibility)
+                assertEquals(INVISIBLE, textViewCryptInfo.visibility)
             },
             callback = object : EncryptDecryptUtils.EncryptButtonCallbackInterface {
                 override fun onButtonPressed(intent: Intent, password: String) {
@@ -180,6 +184,7 @@ class EncryptWithPresetPasswordSaveAsDialogTest : AbstractEncryptDialogTests() {
             testContent = { _, _, _ ->
                 assertEquals("${file.name}$AESCRYPT_EXTENSION", editTextFileSaveAs.text.toString())
                 assertEquals(VISIBLE, checkboxUseAze.visibility)
+                assertEquals(VISIBLE, textViewCryptInfo.visibility)
             },
             callback = object : EncryptDecryptUtils.EncryptButtonCallbackInterface {
                 override fun onButtonPressed(intent: Intent, password: String) {
@@ -219,6 +224,14 @@ class EncryptWithPresetPasswordSaveAsDialogTest : AbstractEncryptDialogTests() {
             password = ENCRYPT_PASSWORD_MASTER,
             testContent = { _, _, _ ->
                 checkboxUseAze.isChecked = true
+                assertEquals(
+                    HtmlCompat.fromHtml(
+                        getString(R.string.encrypt_option_use_azecrypt_desc),
+                        HtmlCompat.FROM_HTML_MODE_COMPACT
+                    )
+                        .toString(),
+                    textViewCryptInfo.text.toString()
+                )
                 assertTrue(ShadowDialog.getShownDialogs().size == 2)
                 assertTrue(ShadowDialog.getLatestDialog() is MaterialDialog)
                 (ShadowDialog.getLatestDialog() as MaterialDialog).run {
@@ -241,10 +254,26 @@ class EncryptWithPresetPasswordSaveAsDialogTest : AbstractEncryptDialogTests() {
                 assertFalse(ShadowDialog.getLatestDialog().isShowing)
                 assertTrue(true == editTextFileSaveAs.text?.endsWith(CRYPT_EXTENSION))
                 checkboxUseAze.isChecked = false
+                assertEquals(
+                    HtmlCompat.fromHtml(
+                        getString(R.string.encrypt_option_use_aescrypt_desc),
+                        HtmlCompat.FROM_HTML_MODE_COMPACT
+                    )
+                        .toString(),
+                    textViewCryptInfo.text.toString()
+                )
                 assertEquals(2, ShadowDialog.getShownDialogs().size)
                 assertFalse(ShadowDialog.getLatestDialog().isShowing)
                 assertTrue(true == editTextFileSaveAs.text?.endsWith(AESCRYPT_EXTENSION))
                 checkboxUseAze.isChecked = true
+                assertEquals(
+                    HtmlCompat.fromHtml(
+                        getString(R.string.encrypt_option_use_azecrypt_desc),
+                        HtmlCompat.FROM_HTML_MODE_COMPACT
+                    )
+                        .toString(),
+                    textViewCryptInfo.text.toString()
+                )
                 assertEquals(3, ShadowDialog.getShownDialogs().size)
                 assertTrue(ShadowDialog.getLatestDialog().isShowing)
                 assertTrue(true == editTextFileSaveAs.text?.endsWith(CRYPT_EXTENSION))
@@ -289,6 +318,7 @@ class EncryptWithPresetPasswordSaveAsDialogTest : AbstractEncryptDialogTests() {
                             R.id.til_encrypt_save_as
                         )
                         checkboxUseAze = findViewById<AppCompatCheckBox>(R.id.checkbox_use_aze)
+                        textViewCryptInfo = findViewById<AppCompatTextView>(R.id.text_view_crypt_info)
                         okButton = getActionButton(DialogAction.POSITIVE)
                         testContent.invoke(it, intent, activity)
                     }


### PR DESCRIPTION
Fix problem at #3182: https://github.com/TeamAmaze/AmazeFileManager/pull/3182#issuecomment-1077663402

Additionally, added a contentIsHtml flag at AlertDialog.show() as the aze encryption format description is composed of HTML.

## Description

#### Issue tracker   
Addresses problem at #3182

#### Automatic tests
- [x] Added test cases
  
#### Manual tests
- [x] Done  
  
- Device: Pixel 2 emulator
- OS: Android 11

#### Build tasks success  
<!-- run these! -->
Successfully running following tasks on local:
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`

#### Related PR  
Related to PR #3182