### PR TITLE
[bugfix] search view responding to active theme

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/ui/views/appbar/SearchView.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/views/appbar/SearchView.java
@@ -25,10 +25,12 @@ import static android.os.Build.VERSION.SDK_INT;
 
 import com.amaze.filemanager.R;
 import com.amaze.filemanager.ui.activities.MainActivity;
+import com.amaze.filemanager.utils.Utils;
 
 import android.animation.Animator;
 import android.animation.ObjectAnimator;
 import android.content.Context;
+import android.graphics.PorterDuff;
 import android.view.View;
 import android.view.ViewAnimationUtils;
 import android.view.animation.AccelerateDecelerateInterpolator;
@@ -38,6 +40,7 @@ import android.widget.ImageView;
 import android.widget.RelativeLayout;
 
 import androidx.appcompat.widget.AppCompatEditText;
+import androidx.core.content.ContextCompat;
 
 /**
  * SearchView, a simple view to search
@@ -80,6 +83,7 @@ public class SearchView {
           return false;
         });
 
+      initSearchViewColor(a);
     // searchViewEditText.setTextColor(Utils.getColor(this, android.R.color.black));
     // searchViewEditText.setHintTextColor(Color.parseColor(ThemedActivity.accentSkin));
   }
@@ -199,7 +203,30 @@ public class SearchView {
     return searchViewLayout.isShown();
   }
 
-  public interface SearchListener {
+    private void initSearchViewColor(MainActivity a ) {
+        switch (a.getAppTheme().getSimpleTheme(a)) {
+            case LIGHT:
+                searchViewLayout.setBackgroundResource(R.drawable.search_view_shape);
+                searchViewEditText.setTextColor(Utils.getColor(a, android.R.color.black));
+                clearImageView.setColorFilter(ContextCompat.getColor(a, android.R.color.black),
+                        PorterDuff.Mode.SRC_ATOP);
+                backImageView.setColorFilter(ContextCompat.getColor(a, android.R.color.black),
+                        PorterDuff.Mode.SRC_ATOP);
+                break;
+            case DARK:
+            case BLACK:
+                searchViewLayout.setBackgroundResource(R.drawable.search_view_shape_black);
+                searchViewEditText.setTextColor(Utils.getColor(a, android.R.color.white));
+                clearImageView.setColorFilter(ContextCompat.getColor(a, android.R.color.white),
+                        PorterDuff.Mode.SRC_ATOP);
+                backImageView.setColorFilter(ContextCompat.getColor(a, android.R.color.white),
+                        PorterDuff.Mode.SRC_ATOP);
+                break;
+        }
+    }
+
+
+    public interface SearchListener {
     void onSearch(String queue);
   }
 }

--- a/app/src/main/res/drawable/search_view_shape_black.xml
+++ b/app/src/main/res/drawable/search_view_shape_black.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+
+    <solid
+        android:color="@android:color/black">
+    </solid>
+
+    <corners
+        android:radius="2dp">
+    </corners>
+
+</shape>


### PR DESCRIPTION
## Description
Bugfix for issue  #3233  - search bar stays white even in dark themes.

#### Issue tracker   
Addresses issue at #3233 

#### Automatic tests
- [ ] Added test cases
  
#### Manual tests
- [x] Done  
  
 
- Device: Huawei p30 lite 
- OS: Android 10

https://user-images.githubusercontent.com/98877504/160116680-a14072c9-4759-47eb-b761-89ed11d22df1.mp4


#### Build tasks success  


<!-- run these! -->
Successfully running following tasks on local:
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`

