### PR TITLE
Bugfix/status bar color

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/ui/activities/AboutActivity.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/activities/AboutActivity.java
@@ -20,8 +20,6 @@
 
 package com.amaze.filemanager.ui.activities;
 
-import static android.os.Build.VERSION.SDK_INT;
-import static android.os.Build.VERSION_CODES.LOLLIPOP;
 import static com.amaze.filemanager.ui.fragments.preference_fragments.PreferencesConstants.PREFERENCE_COLORED_NAVIGATION;
 import static com.amaze.filemanager.utils.Utils.openURL;
 
@@ -45,7 +43,6 @@ import android.util.Log;
 import android.view.MenuItem;
 import android.view.View;
 import android.widget.TextView;
-import android.widget.Toast;
 
 import androidx.annotation.Nullable;
 import androidx.appcompat.widget.Toolbar;

--- a/app/src/main/java/com/amaze/filemanager/ui/activities/AboutActivity.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/activities/AboutActivity.java
@@ -20,6 +20,9 @@
 
 package com.amaze.filemanager.ui.activities;
 
+import static android.os.Build.VERSION.SDK_INT;
+import static android.os.Build.VERSION_CODES.LOLLIPOP;
+import static com.amaze.filemanager.ui.fragments.preference_fragments.PreferencesConstants.PREFERENCE_COLORED_NAVIGATION;
 import static com.amaze.filemanager.utils.Utils.openURL;
 
 import com.amaze.filemanager.LogHelper;
@@ -27,6 +30,7 @@ import com.amaze.filemanager.R;
 import com.amaze.filemanager.ui.activities.superclasses.ThemedActivity;
 import com.amaze.filemanager.ui.theme.AppTheme;
 import com.amaze.filemanager.utils.Billing;
+import com.amaze.filemanager.utils.PreferenceUtils;
 import com.amaze.filemanager.utils.Utils;
 import com.google.android.material.appbar.AppBarLayout;
 import com.google.android.material.appbar.CollapsingToolbarLayout;
@@ -41,6 +45,7 @@ import android.util.Log;
 import android.view.MenuItem;
 import android.view.View;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import androidx.annotation.Nullable;
 import androidx.appcompat.widget.Toolbar;
@@ -79,15 +84,15 @@ public class AboutActivity extends ThemedActivity implements View.OnClickListene
   @Override
   public void onCreate(@Nullable Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
-
-    if (getAppTheme().equals(AppTheme.DARK)) {
-      setTheme(R.style.aboutDark);
-    } else if (getAppTheme().equals(AppTheme.BLACK)) {
-      setTheme(R.style.aboutBlack);
-    } else {
-      setTheme(R.style.aboutLight);
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+      if (getAppTheme().equals(AppTheme.DARK)) {
+        setTheme(R.style.aboutDark);
+      } else if (getAppTheme().equals(AppTheme.BLACK)) {
+        setTheme(R.style.aboutBlack);
+      } else {
+        setTheme(R.style.aboutLight);
+      }
     }
-
     setContentView(R.layout.activity_about);
 
     mAppBarLayout = findViewById(R.id.appBarLayout);
@@ -133,6 +138,19 @@ public class AboutActivity extends ThemedActivity implements View.OnClickListene
         (v, hasFocus) -> {
           mAppBarLayout.setExpanded(hasFocus, true);
         });
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+      if (getBoolean(PREFERENCE_COLORED_NAVIGATION)) {
+        getWindow().setNavigationBarColor(PreferenceUtils.getStatusColor(getPrimary()));
+      } else {
+        if (getAppTheme().equals(AppTheme.LIGHT)) {
+          getWindow().setNavigationBarColor(Utils.getColor(this, android.R.color.white));
+        } else if (getAppTheme().equals(AppTheme.BLACK)) {
+          getWindow().setNavigationBarColor(Utils.getColor(this, android.R.color.black));
+        } else {
+          getWindow().setNavigationBarColor(Utils.getColor(this, R.color.holo_dark_background));
+        }
+      }
+    }
   }
 
   /**

--- a/app/src/main/java/com/amaze/filemanager/ui/activities/MainActivity.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/activities/MainActivity.java
@@ -158,6 +158,7 @@ import com.amaze.filemanager.ui.fragments.SearchWorkerFragment;
 import com.amaze.filemanager.ui.fragments.TabFragment;
 import com.amaze.filemanager.ui.fragments.preference_fragments.PreferencesConstants;
 import com.amaze.filemanager.ui.strings.StorageNamingHelper;
+import com.amaze.filemanager.ui.theme.AppTheme;
 import com.amaze.filemanager.ui.views.CustomZoomFocusChange;
 import com.amaze.filemanager.ui.views.appbar.AppBar;
 import com.amaze.filemanager.ui.views.drawer.Drawer;
@@ -1677,10 +1678,22 @@ public class MainActivity extends PermissionsActivity
     if (SDK_INT >= LOLLIPOP) {
       // for lollipop devices, the status bar color
       mainActivity.getWindow().setStatusBarColor(colorDrawable.getColor());
-      if (getBoolean(PREFERENCE_COLORED_NAVIGATION))
+      if (getBoolean(PREFERENCE_COLORED_NAVIGATION)) {
         mainActivity
             .getWindow()
             .setNavigationBarColor(PreferenceUtils.getStatusColor(colorDrawable.getColor()));
+      } else {
+        if (getAppTheme().equals(AppTheme.LIGHT)) {
+          mainActivity
+                  .getWindow().setNavigationBarColor(Utils.getColor(this, android.R.color.white));
+        } else if (getAppTheme().equals(AppTheme.BLACK)) {
+          mainActivity
+                  .getWindow().setNavigationBarColor(Utils.getColor(this, android.R.color.black));
+        } else {
+          mainActivity
+                  .getWindow().setNavigationBarColor(Utils.getColor(this, R.color.holo_dark_background));
+        }
+      }
     } else if (SDK_INT == KITKAT_WATCH || SDK_INT == KITKAT) {
 
       // for kitkat devices, the status bar color

--- a/app/src/main/java/com/amaze/filemanager/ui/activities/PreferencesActivity.kt
+++ b/app/src/main/java/com/amaze/filemanager/ui/activities/PreferencesActivity.kt
@@ -155,6 +155,9 @@ class PreferencesActivity : ThemedActivity(), FolderChooserDialog.FolderCallback
                 appTheme == AppTheme.DARK  -> {
                     window.navigationBarColor = Utils.getColor(this, R.color.holo_dark_background)
                 }
+                appTheme == AppTheme.LIGHT  -> {
+                    window.navigationBarColor = Color.WHITE
+                }
             }
         }
         if (appTheme == AppTheme.BLACK) {

--- a/app/src/main/java/com/amaze/filemanager/ui/activities/PreferencesActivity.kt
+++ b/app/src/main/java/com/amaze/filemanager/ui/activities/PreferencesActivity.kt
@@ -145,10 +145,16 @@ class PreferencesActivity : ThemedActivity(), FolderChooserDialog.FolderCallback
             window.clearFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS)
             val tabStatusColor = PreferenceUtils.getStatusColor(primaryColor)
             window.statusBarColor = tabStatusColor
-            if (colouredNavigation) {
-                window.navigationBarColor = tabStatusColor
-            } else if (window.navigationBarColor != Color.BLACK) {
-                window.navigationBarColor = Color.BLACK
+            when {
+                colouredNavigation         -> {
+                    window.navigationBarColor = tabStatusColor
+                }
+                appTheme == AppTheme.BLACK -> {
+                    window.navigationBarColor = Color.BLACK
+                }
+                appTheme == AppTheme.DARK  -> {
+                    window.navigationBarColor = Utils.getColor(this, R.color.holo_dark_background)
+                }
             }
         }
         if (appTheme == AppTheme.BLACK) {

--- a/app/src/main/java/com/amaze/filemanager/ui/activities/superclasses/ThemedActivity.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/activities/superclasses/ThemedActivity.java
@@ -105,22 +105,21 @@ public class ThemedActivity extends PreferenceActivity {
       } else {
         window.addFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS);
       }
+      if (getBoolean(PREFERENCE_COLORED_NAVIGATION)) {
+        window.setNavigationBarColor(PreferenceUtils.getStatusColor(getPrimary()));
+      } else {
+        if (getAppTheme().equals(AppTheme.LIGHT)) {
+          window.setNavigationBarColor(Utils.getColor(this, android.R.color.white));
+        } else if (getAppTheme().equals(AppTheme.BLACK)) {
+          window.setNavigationBarColor(Utils.getColor(this, android.R.color.black));
+        } else {
+          window.setNavigationBarColor(Utils.getColor(this, R.color.holo_dark_background));
+        }
+      }
     } else if (SDK_INT == Build.VERSION_CODES.KITKAT_WATCH
         || SDK_INT == Build.VERSION_CODES.KITKAT) {
       setKitkatStatusBarMargin(parentView);
       setKitkatStatusBarTint();
-    }
-
-    if (getBoolean(PREFERENCE_COLORED_NAVIGATION) && SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-      window.setNavigationBarColor(PreferenceUtils.getStatusColor(getPrimary()));
-    } else if (!getBoolean(PREFERENCE_COLORED_NAVIGATION) && SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-      if (getAppTheme().equals(AppTheme.LIGHT)) {
-        window.setNavigationBarColor(Utils.getColor(this, android.R.color.white));
-      } else if (getAppTheme().equals(AppTheme.BLACK)) {
-        window.setNavigationBarColor(Utils.getColor(this, android.R.color.black));
-      } else {
-        window.setNavigationBarColor(Utils.getColor(this, R.color.holo_dark_background));
-      }
     }
   }
 

--- a/app/src/main/java/com/amaze/filemanager/ui/activities/superclasses/ThemedActivity.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/activities/superclasses/ThemedActivity.java
@@ -30,6 +30,7 @@ import com.amaze.filemanager.ui.dialogs.ColorPickerDialog;
 import com.amaze.filemanager.ui.fragments.preference_fragments.PreferencesConstants;
 import com.amaze.filemanager.ui.theme.AppTheme;
 import com.amaze.filemanager.utils.PreferenceUtils;
+import com.amaze.filemanager.utils.Utils;
 import com.readystatesoftware.systembartint.SystemBarTintManager;
 
 import android.app.ActivityManager;
@@ -112,6 +113,14 @@ public class ThemedActivity extends PreferenceActivity {
 
     if (getBoolean(PREFERENCE_COLORED_NAVIGATION) && SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
       window.setNavigationBarColor(PreferenceUtils.getStatusColor(getPrimary()));
+    } else if (!getBoolean(PREFERENCE_COLORED_NAVIGATION) && SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+      if (getAppTheme().equals(AppTheme.LIGHT)) {
+        window.setNavigationBarColor(Utils.getColor(this, android.R.color.white));
+      } else if (getAppTheme().equals(AppTheme.BLACK)) {
+        window.setNavigationBarColor(Utils.getColor(this, android.R.color.black));
+      } else {
+        window.setNavigationBarColor(Utils.getColor(this, R.color.holo_dark_background));
+      }
     }
   }
 


### PR DESCRIPTION


## Description
In response to the issue reported in #3234:
- upon unticking `Colorize Navigation Bar` in `settings -> Apperance ` the navigation bar turns black no matter the current theme.
- upon returning to the main activity it turns white no matter the current theme.
- upon opening the about page the navigation bar is always inconsistent with the selected theme.

#### Issue tracker   
Addresses issue at #3234
- if `Colorize Navigation Bar` is ticked in settings, navigation bar color is consistent with primary color(blue) in all activities.
- if `Colorize Navigation Bar` is unticked in settings, navigation bar color always follows the current theme.

#### Automatic tests
- [ ] Added test cases
  
#### Manual tests
- [x] Done  
  
- Device: Huawei p30 lite
- OS: Android 10
- Device: Sharp Aquos 803SH
- OS: Android 10
- Device: Redmi Note 7 
- OS: Android 10

#### Build tasks success  
Successfully running following tasks on local:
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`

<!-- If there are related PRs please add them here -->
<!--
#### Related PR  
Related to PR #
-->