### PR TITLE
[bugfix] searching for hidden files crushes app

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/adapters/RecyclerAdapter.java
+++ b/app/src/main/java/com/amaze/filemanager/adapters/RecyclerAdapter.java
@@ -697,6 +697,7 @@ public class RecyclerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
         getItemsDigested().get(p).setAnimate(true);
       }
       final LayoutElementParcelable rowItem = getItemsDigested().get(p).elem;
+      if (rowItem == null) return;
       if (dragAndDropPreference != PreferencesConstants.PREFERENCE_DRAG_DEFAULT) {
         holder.rl.setOnDragListener(
             new RecyclerAdapterDragListener(this, holder, dragAndDropPreference, mainFrag));


### PR DESCRIPTION
## Description
- In response to issue #3207 , the app was crushing everytime  a user searches for a file/folder that is hidden.
- This happens when the adapter tries to access getters of a null `rowItem`.

#### Issue tracker   
Addresses #3207 

#### Automatic tests
<!-- remember to do manual testing when making UI changes! -->
- [ ] Added test cases
  
#### Manual tests
- [x] Done  
  
- Device: Huawei P30 lite
- OS: Android 10

#### Build tasks success  
Successfully running following tasks on local:
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`

<!-- If there are related PRs please add them here -->
<!--
#### Related PR  
Related to PR #
-->