### PR TITLE
Fix Robolectric test failure

### DIFF
--- a/app/src/androidTest/java/com/amaze/filemanager/utils/security/SecretKeygenEspressoTest.kt
+++ b/app/src/androidTest/java/com/amaze/filemanager/utils/security/SecretKeygenEspressoTest.kt
@@ -1,5 +1,7 @@
 package com.amaze.filemanager.utils.security
 
+import android.os.Build.VERSION.SDK_INT
+import android.os.Build.VERSION_CODES.ICE_CREAM_SANDWICH
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.SmallTest
 import org.junit.Assert.assertEquals
@@ -18,12 +20,17 @@ class SecretKeygenEspressoTest {
 
     /**
      * Test [SecretKeygen.getSecretKey].
+     *
+     * Officially our lowest supported SDK is 14, hence we will throw exception
+     * if the device is so.
      */
     @Test
     fun testGetSecretKey() {
         SecretKeygen.getSecretKey()?.run {
             assertNotNull(this)
             assertEquals("aes", this.algorithm.lowercase())
-        } ?: fail("Unable to obtain secret key")
+        } ?: if (SDK_INT < ICE_CREAM_SANDWICH) {
+            fail("Android version not supported")
+        }
     }
 }


### PR DESCRIPTION
## Description
Our lowest supported version is SDK 14, while SecretKeygen.getSecretKey() lowest supported is SDK 18. This changes verification to allow nulls to pass through for devices lower than API 18.

Still throw failure if using devices below SDK 14.

#### Issue tracker   

Fixes #3282

#### Build tasks success  
Successfully running following tasks on local:
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`

#### Related PR  
Related to PR #3282