### PR TITLE
Fix CryptUtil behaviour for SDK < 18

### DIFF
--- a/app/src/androidTest/java/com/amaze/filemanager/utils/CryptUtilEspressoTest.kt
+++ b/app/src/androidTest/java/com/amaze/filemanager/utils/CryptUtilEspressoTest.kt
@@ -1,5 +1,7 @@
 package com.amaze.filemanager.utils
 
+import android.os.Build.VERSION.SDK_INT
+import android.os.Build.VERSION_CODES.JELLY_BEAN_MR2
 import android.os.Environment
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.SmallTest
@@ -44,7 +46,18 @@ class CryptUtilEspressoTest {
         )
         val targetFile = File(Environment.getExternalStorageDirectory(), "test.bin${CryptUtil.CRYPT_EXTENSION}")
         assertTrue(targetFile.exists())
-        assertTrue("Source size = ${source.size} target file size = ${targetFile.length()}", targetFile.length() > source.size)
+        if (SDK_INT < JELLY_BEAN_MR2) {
+            // Quirks for SDK < 18. File is not encrypted at all.
+            assertTrue(
+                "Source and target file size should be the same = ${source.size}",
+                source.size.toLong() == targetFile.length()
+            )
+        } else {
+            assertTrue(
+                "Source size = ${source.size} target file size = ${targetFile.length()}",
+                targetFile.length() > source.size
+            )
+        }
         sourceFile.delete()
         CryptUtil(
             AppConfig.getInstance(),


### PR DESCRIPTION
## Description
At SDK < 18, no AES key can be obtained from keystore, hence causing CryptUtilEspressoTest.testEncryptDecryptLegacyMethod() to fail. This fixes the problem by adding quirk to ensure plain I/O is still in place without causing crashes.

`gradle connectedCheck` with Galaxy Nexus emulator running SDK 16 results below (output at build step skipped)

```bash
> Task :app:connectedFdroidDebugAndroidTest
Starting 33 tests on Galaxy_Nexus_API_16(AVD) - 4.1.2
4月 26, 2022 12:44:50 午後 com.android.tools.utp.plugins.host.additionaltestoutput.AndroidAdditionalTestOutputPlugin deviceShellAndCheckSuccess
警告: Shell command failed (255): rm -rf "/mnt/sdcard/Android/data/com.amaze.filemanager.debug/files/test_data"
rm failed for -rf, Read-only file system



Test results saved as file:/home/airwave/git/AmazeFileManager/app/build/outputs/androidTest-results/connected/flavors/fdroid/Galaxy_Nexus_API_16(AVD)%20-%204.1.2/test-result.pb. Inspect these results in Android Studio by selecting Run > Import Tests From File from the menu bar and importing test-result.pb.

> Task :app:connectedPlayDebugAndroidTest
Starting 33 tests on Galaxy_Nexus_API_16(AVD) - 4.1.2
4月 26, 2022 12:45:12 午後 com.android.tools.utp.plugins.host.additionaltestoutput.AndroidAdditionalTestOutputPlugin deviceShellAndCheckSuccess
警告: Shell command failed (255): rm -rf "/mnt/sdcard/Android/data/com.amaze.filemanager.debug/files/test_data"
rm failed for -rf, Read-only file system



Test results saved as file:/home/airwave/git/AmazeFileManager/app/build/outputs/androidTest-results/connected/flavors/play/Galaxy_Nexus_API_16(AVD)%20-%204.1.2/test-result.pb. Inspect these results in Android Studio by selecting Run > Import Tests From File from the menu bar and importing test-result.pb.

Deprecated Gradle features were used in this build, making it incompatible with Gradle 8.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

See https://docs.gradle.org/7.2/userguide/command_line_interface.html#sec:command_line_warnings

Execution optimizations have been disabled for 4 invalid unit(s) of work during this build to ensure correctness.
Please consult deprecation warnings for more details.

BUILD SUCCESSFUL in 1m 52s
```
#### Issue tracker   
For #3282

#### Build tasks success  
Successfully running following tasks on local:
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`

#### Related PR  
Related to PR #3282