### PR TITLE
Fix CryptUtilEspressoTest and UtilsHandlerTests failures on new Androids

### DIFF
--- a/app/src/androidTest/java/com/amaze/filemanager/database/UtilsHandlerTest.java
+++ b/app/src/androidTest/java/com/amaze/filemanager/database/UtilsHandlerTest.java
@@ -23,18 +23,6 @@ package com.amaze.filemanager.database;
 import static org.awaitility.Awaitility.await;
 import static org.junit.Assert.assertEquals;
 
-import java.io.File;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
-
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-
-import com.amaze.filemanager.database.models.OperationData;
-import com.amaze.filemanager.filesystem.ssh.SshClientUtils;
-
 import android.content.Context;
 import android.os.Environment;
 
@@ -42,6 +30,18 @@ import androidx.annotation.NonNull;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.filters.Suppress;
 import androidx.test.platform.app.InstrumentationRegistry;
+
+import com.amaze.filemanager.database.models.OperationData;
+import com.amaze.filemanager.filesystem.ssh.SshClientUtils;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.File;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 @RunWith(AndroidJUnit4.class)
 public class UtilsHandlerTest {
@@ -61,7 +61,10 @@ public class UtilsHandlerTest {
 
   @After
   public void tearDown() {
-    if (utilitiesDatabase.isOpen()) utilitiesDatabase.close();
+    if (utilitiesDatabase.isOpen()) {
+      utilitiesDatabase.clearAllTables();
+      utilitiesDatabase.close();
+    }
   }
 
   @Test
@@ -128,16 +131,14 @@ public class UtilsHandlerTest {
 
     await()
         .atMost(10, TimeUnit.SECONDS)
-        .until(
-            () -> {
-              List<String[]> result = utilsHandler.getSftpList();
-              assertEquals(1, result.size());
-              assertEquals("Test", result.get(0)[0]);
-              assertEquals(encryptedPath, result.get(0)[1]);
-              assertEquals(
-                  "00:11:22:33:44:55:66:77:88:99:aa:bb:cc:dd:ee:ff",
-                  utilsHandler.getSshHostKey(encryptedPath));
-              return true;
-            });
+        .until(() -> utilsHandler.getSftpList().size() > 0);
+
+    List<String[]> result = utilsHandler.getSftpList();
+    assertEquals(1, result.size());
+    assertEquals("Test", result.get(0)[0]);
+    assertEquals(encryptedPath, result.get(0)[1]);
+    assertEquals(
+            "00:11:22:33:44:55:66:77:88:99:aa:bb:cc:dd:ee:ff",
+            utilsHandler.getSshHostKey(encryptedPath));
   }
 }

--- a/app/src/androidTest/java/com/amaze/filemanager/utils/CryptUtilEspressoTest.kt
+++ b/app/src/androidTest/java/com/amaze/filemanager/utils/CryptUtilEspressoTest.kt
@@ -5,11 +5,13 @@ import android.os.Build.VERSION_CODES.JELLY_BEAN_MR2
 import android.os.Environment
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.SmallTest
+import androidx.test.rule.GrantPermissionRule
 import com.amaze.filemanager.application.AppConfig
 import com.amaze.filemanager.filesystem.HybridFileParcelable
 import com.amaze.filemanager.filesystem.files.CryptUtil
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertTrue
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import java.io.ByteArrayInputStream
@@ -25,6 +27,10 @@ import kotlin.random.Random
 @RunWith(AndroidJUnit4::class)
 @Suppress("StringLiteralDuplication")
 class CryptUtilEspressoTest {
+
+    @Rule @JvmField
+    val storagePermissionRule: GrantPermissionRule = GrantPermissionRule
+        .grant(android.Manifest.permission.WRITE_EXTERNAL_STORAGE)
 
     /**
      * Sanity test of CryptUtil legacy method, to ensure refactoring won't break


### PR DESCRIPTION
## Description

Third in the series. :(

#### Issue tracker   
for #3282

#### Automatic tests
- [ ] Added test cases
  
- Device: Pixel 2 emulator
- OS: Android 11, Android 9
- Device: Galaxy Nexus emulator
- OS: Android 4.1.2, 4.3.1, 4.4.2
`gradlew connectedCheck` were ran on above Android emulators with results pasted below.

```bash
> Task :app:connectedFdroidDebugAndroidTest
additionalTestOutput is not supported on this device running API level 16 because the additional test output directory could not be found
additionalTestOutput is not supported on this device running API level 18 because the additional test output directory could not be found
Starting 33 tests on Pixel_2_API_28(AVD) - 9
Starting 33 tests on Galaxy_Nexus_API_16(AVD) - 4.1.2
Starting 33 tests on Galaxy_Nexus_API_18(AVD) - 4.3.1
Starting 33 tests on Galaxy_Nexus_API_19(AVD) - 4.4.2
Starting 33 tests on Pixel_2_API_30(AVD) - 11

Test results saved as file:/home/airwave/git/AmazeFileManager/app/build/outputs/androidTest-results/connected/flavors/fdroid/Galaxy_Nexus_API_19(AVD)%20-%204.4.2/test-result.pb. Inspect these results in Android Studio by selecting Run > Import Tests From File from the menu bar and importing test-result.pb.

Test results saved as file:/home/airwave/git/AmazeFileManager/app/build/outputs/androidTest-results/connected/flavors/fdroid/Pixel_2_API_28(AVD)%20-%209/test-result.pb. Inspect these results in Android Studio by selecting Run > Import Tests From File from the menu bar and importing test-result.pb.

Test results saved as file:/home/airwave/git/AmazeFileManager/app/build/outputs/androidTest-results/connected/flavors/fdroid/Pixel_2_API_30(AVD)%20-%2011/test-result.pb. Inspect these results in Android Studio by selecting Run > Import Tests From File from the menu bar and importing test-result.pb.

Test results saved as file:/home/airwave/git/AmazeFileManager/app/build/outputs/androidTest-results/connected/flavors/fdroid/Galaxy_Nexus_API_16(AVD)%20-%204.1.2/test-result.pb. Inspect these results in Android Studio by selecting Run > Import Tests From File from the menu bar and importing test-result.pb.

Test results saved as file:/home/airwave/git/AmazeFileManager/app/build/outputs/androidTest-results/connected/flavors/fdroid/Galaxy_Nexus_API_18(AVD)%20-%204.3.1/test-result.pb. Inspect these results in Android Studio by selecting Run > Import Tests From File from the menu bar and importing test-result.pb.

> Task :app:connectedPlayDebugAndroidTest
additionalTestOutput is not supported on this device running API level 16 because the additional test output directory could not be found
additionalTestOutput is not supported on this device running API level 18 because the additional test output directory could not be found
Starting 33 tests on Pixel_2_API_30(AVD) - 11
Starting 33 tests on Pixel_2_API_28(AVD) - 9
Starting 33 tests on Galaxy_Nexus_API_16(AVD) - 4.1.2
Starting 33 tests on Galaxy_Nexus_API_18(AVD) - 4.3.1
Starting 33 tests on Galaxy_Nexus_API_19(AVD) - 4.4.2

Test results saved as file:/home/airwave/git/AmazeFileManager/app/build/outputs/androidTest-results/connected/flavors/play/Galaxy_Nexus_API_19(AVD)%20-%204.4.2/test-result.pb. Inspect these results in Android Studio by selecting Run > Import Tests From File from the menu bar and importing test-result.pb.

Test results saved as file:/home/airwave/git/AmazeFileManager/app/build/outputs/androidTest-results/connected/flavors/play/Galaxy_Nexus_API_16(AVD)%20-%204.1.2/test-result.pb. Inspect these results in Android Studio by selecting Run > Import Tests From File from the menu bar and importing test-result.pb.

Test results saved as file:/home/airwave/git/AmazeFileManager/app/build/outputs/androidTest-results/connected/flavors/play/Galaxy_Nexus_API_18(AVD)%20-%204.3.1/test-result.pb. Inspect these results in Android Studio by selecting Run > Import Tests From File from the menu bar and importing test-result.pb.

Test results saved as file:/home/airwave/git/AmazeFileManager/app/build/outputs/androidTest-results/connected/flavors/play/Pixel_2_API_28(AVD)%20-%209/test-result.pb. Inspect these results in Android Studio by selecting Run > Import Tests From File from the menu bar and importing test-result.pb.

Test results saved as file:/home/airwave/git/AmazeFileManager/app/build/outputs/androidTest-results/connected/flavors/play/Pixel_2_API_30(AVD)%20-%2011/test-result.pb. Inspect these results in Android Studio by selecting Run > Import Tests From File from the menu bar and importing test-result.pb.

Deprecated Gradle features were used in this build, making it incompatible with Gradle 8.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

See https://docs.gradle.org/7.2/userguide/command_line_interface.html#sec:command_line_warnings

Execution optimizations have been disabled for 4 invalid unit(s) of work during this build to ensure correctness.
Please consult deprecation warnings for more details.

BUILD SUCCESSFUL in 4m 23s
237 actionable tasks: 229 executed, 8 up-to-date
```


#### Build tasks success  
Successfully running following tasks on local:
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`

#### Related PR  
Related to PR #3282