### PR TITLE
Truncate existing text files when writing.

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/texteditor/write/WriteTextFileCallable.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/texteditor/write/WriteTextFileCallable.java
@@ -84,13 +84,13 @@ public class WriteTextFileCallable implements Callable<Unit> {
           DocumentFile documentFile =
               DocumentFile.fromSingleUri(AppConfig.getInstance(), fileAbstraction.uri);
           if (documentFile != null && documentFile.exists() && documentFile.canWrite()) {
-            outputStream = contentResolver.openOutputStream(fileAbstraction.uri);
+            outputStream = contentResolver.openOutputStream(fileAbstraction.uri, "wt");
           } else {
             destFile = FileUtils.fromContentUri(fileAbstraction.uri);
             outputStream = openFile(destFile, context.get());
           }
         } else {
-          outputStream = contentResolver.openOutputStream(fileAbstraction.uri);
+          outputStream = contentResolver.openOutputStream(fileAbstraction.uri, "wt");
         }
         break;
       case FILE:

--- a/app/src/test/java/com/amaze/filemanager/shadows/ShadowContentResolver.kt
+++ b/app/src/test/java/com/amaze/filemanager/shadows/ShadowContentResolver.kt
@@ -1,0 +1,26 @@
+package com.amaze.filemanager.shadows
+
+import android.content.ContentResolver
+import android.net.Uri
+import org.robolectric.annotation.Implementation
+import org.robolectric.annotation.Implements
+import org.robolectric.shadows.ShadowContentResolver
+import java.io.OutputStream
+
+/**
+ * [ShadowContentResolver] implementation to include
+ * [ContentResolver.openOutputStream] with Uri and open mode arguments.
+ *
+ * @see ContentResolver.openOutputStream(uri, String)
+ */
+@Implements(ContentResolver::class)
+class ShadowContentResolver : ShadowContentResolver() {
+
+    /**
+     * Implements [ContentResolver.openOutputStream] with open mode parameter.
+     *
+     * Simply delegate to one without open mode.
+     */
+    @Implementation
+    fun openOutputStream(uri: Uri, mode: String): OutputStream? = super.openOutputStream(uri)
+}


### PR DESCRIPTION
Otherwise if the edit made the text shorter, the remaining content won't be truncated because ContentResolver.openOutputStream(Uri) defaults to "w" only.

This wasn't a problem until API 29 because previously the platform ParcelFileDescriptor.parseMode() (incorrectly) treated "w" to be the same as "wt" and added MODE_TRUNCATE. However, that has been fixed since API 29, while the default mode for ContentResolver.openOutputStream(Uri) remained "w", which resulted in such a bug.

See also https://stackoverflow.com/q/56902845 .

<!-- 
Read this first:
To open a pull request read this file,
uncomment the corresponding lines and 
complete them.
-->

## Description

#### Issue tracker   
<!-- Fixes will automatically close the related issue -->
<!-- Fixes # -->
<!-- Addresses won't automatically close the related issue -->
<!-- Addresses # -->

#### Automatic tests
<!-- remember to do manual testing when making UI changes! -->
- [ ] Added test cases
  
#### Manual tests
- [ ] Done  
  
<!-- If yes, -->
<!-- 
- Device:
- OS:
-->

#### Build tasks success  
<!-- run these! -->
Successfully running following tasks on local:
- [ ] `./gradlew assembledebug`
- [ ] `./gradlew spotlessCheck`

<!-- If there are related PRs please add them here -->
<!--
#### Related PR  
Related to PR #
-->