### PR TITLE
Make Intent parameter at FtpService.onStartCommand() optional

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/asynchronous/services/ftp/FtpService.kt
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/services/ftp/FtpService.kt
@@ -91,8 +91,8 @@ class FtpService : Service(), Runnable {
     private var isStartedByTile = false
     private lateinit var wakeLock: PowerManager.WakeLock
 
-    override fun onStartCommand(intent: Intent, flags: Int, startId: Int): Int {
-        isStartedByTile = intent.getBooleanExtra(TAG_STARTED_BY_TILE, false)
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        isStartedByTile = true == intent?.getBooleanExtra(TAG_STARTED_BY_TILE, false)
         var attempts = 10
         while (serverThread != null) {
             if (attempts > 0) {


### PR DESCRIPTION
## Description

As said in Javadoc of [Service.onStartCommand()](https://developer.android.com/reference/android/app/Service#onStartCommand(android.content.Intent,%20int,%20int)), the Intent parameter can be null. So perhaps this is the culprit.

#### Issue tracker   
Fixes #3314

#### Build tasks success  
Successfully running following tasks on local:
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`