### PR TITLE
FTP server improvements

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -183,11 +183,11 @@ dependencies {
 
     //implementation files('libs/ftplet-api-1.1.0-SNAPSHOT.jar')
     // https://mvnrepository.com/artifact/org.apache.ftpserver/ftplet-api
-    implementation group: 'org.apache.ftpserver', name: 'ftplet-api', version: '1.1.0'
+    implementation group: 'org.apache.ftpserver', name: 'ftplet-api', version: '1.1.4'
 
     //implementation files('libs/ftpserver-core-1.1.0-SNAPSHOT.jar')
     // https://mvnrepository.com/artifact/org.apache.ftpserver/ftpserver-core
-    implementation group: 'org.apache.ftpserver', name: 'ftpserver-core', version: '1.1.0'
+    implementation group: 'org.apache.ftpserver', name: 'ftpserver-core', version: '1.1.4'
 
     implementation 'org.greenrobot:eventbus:3.3.1'
 

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/services/ftp/CommandFactoryFactory.kt
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/services/ftp/CommandFactoryFactory.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2014-2022 Arpit Khurana <arpitkh96@gmail.com>, Vishal Nehra <vishalmeham2@gmail.com>,
+ * Emmanuel Messulam<emmanuelbendavid@gmail.com>, Raymond Lai <airwave209gt at gmail.com> and Contributors.
+ *
+ * This file is part of Amaze File Manager.
+ *
+ * Amaze File Manager is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.amaze.filemanager.asynchronous.services.ftp
+
+import com.amaze.filemanager.filesystem.ftpserver.AndroidFtpFileSystemView
+import com.amaze.filemanager.filesystem.ftpserver.commands.AVBL
+import com.amaze.filemanager.filesystem.ftpserver.commands.FEAT
+import com.amaze.filemanager.filesystem.ftpserver.commands.PWD
+import org.apache.ftpserver.command.CommandFactory
+import org.apache.ftpserver.command.CommandFactoryFactory
+
+/**
+ * Custom [CommandFactory] factory with custom commands.
+ */
+object CommandFactoryFactory {
+
+    /**
+     * Encapsulate custom [CommandFactory] construction logic. Append custom AVBL and PWD command,
+     * as well as feature flag in FEAT command if not using [AndroidFtpFileSystemView].
+     */
+    fun create(useAndroidFileSystem: Boolean): CommandFactory {
+        val cf = CommandFactoryFactory()
+        if (!useAndroidFileSystem) {
+            cf.addCommand("AVBL", AVBL())
+            cf.addCommand("FEAT", FEAT())
+            cf.addCommand("PWD", PWD())
+        }
+        return cf.createCommandFactory()
+    }
+}

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/services/ftp/FtpService.kt
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/services/ftp/FtpService.kt
@@ -54,6 +54,7 @@ import com.amaze.filemanager.utils.PasswordUtil
 import org.apache.ftpserver.ConnectionConfigFactory
 import org.apache.ftpserver.FtpServer
 import org.apache.ftpserver.FtpServerFactory
+import org.apache.ftpserver.filesystem.nativefs.NativeFileSystemFactory
 import org.apache.ftpserver.listener.ListenerFactory
 import org.apache.ftpserver.ssl.ClientAuth
 import org.apache.ftpserver.ssl.impl.DefaultSslConfiguration
@@ -129,13 +130,17 @@ class FtpService : Service(), Runnable {
         val preferences = PreferenceManager.getDefaultSharedPreferences(this)
         FtpServerFactory().run {
             val connectionConfigFactory = ConnectionConfigFactory()
-            if (SDK_INT >= KITKAT &&
+            val shouldUseAndroidFileSystem =
                 preferences.getBoolean(KEY_PREFERENCE_SAF_FILESYSTEM, false)
-            ) {
+            if (SDK_INT >= KITKAT && shouldUseAndroidFileSystem) {
                 fileSystem = AndroidFileSystemFactory(applicationContext)
             } else if (preferences.getBoolean(PREFERENCE_ROOTMODE, false)) {
                 fileSystem = RootFileSystemFactory()
+            } else {
+                fileSystem = NativeFileSystemFactory()
             }
+
+            commandFactory = CommandFactoryFactory.create(shouldUseAndroidFileSystem)
 
             val usernamePreference = preferences.getString(
                 KEY_PREFERENCE_USERNAME,

--- a/app/src/main/java/com/amaze/filemanager/filesystem/ftpserver/commands/AVBL.kt
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/ftpserver/commands/AVBL.kt
@@ -1,0 +1,131 @@
+/*
+ * Copyright (C) 2014-2022 Arpit Khurana <arpitkh96@gmail.com>, Vishal Nehra <vishalmeham2@gmail.com>,
+ * Emmanuel Messulam<emmanuelbendavid@gmail.com>, Raymond Lai <airwave209gt at gmail.com> and Contributors.
+ *
+ * This file is part of Amaze File Manager.
+ *
+ * Amaze File Manager is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.amaze.filemanager.filesystem.ftpserver.commands
+
+import com.amaze.filemanager.application.AppConfig
+import com.amaze.filemanager.filesystem.ftpserver.AndroidFileSystemFactory
+import org.apache.ftpserver.command.AbstractCommand
+import org.apache.ftpserver.ftplet.DefaultFtpReply
+import org.apache.ftpserver.ftplet.FtpFile
+import org.apache.ftpserver.ftplet.FtpReply.REPLY_213_FILE_STATUS
+import org.apache.ftpserver.ftplet.FtpReply.REPLY_502_COMMAND_NOT_IMPLEMENTED
+import org.apache.ftpserver.ftplet.FtpReply.REPLY_550_REQUESTED_ACTION_NOT_TAKEN
+import org.apache.ftpserver.ftplet.FtpRequest
+import org.apache.ftpserver.impl.FtpIoSession
+import org.apache.ftpserver.impl.FtpServerContext
+import org.apache.ftpserver.usermanager.impl.WriteRequest
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import java.io.File
+
+/**
+ * Implements FTP extension AVBL command, to answer device remaining space in FTP command.
+ *
+ * Only supports [com.amaze.filemanager.filesystem.ftpserver.RootFileSystemFactory] and
+ * [org.apache.ftpserver.filesystem.nativefs.NativeFileSystemFactory]. Otherwise will simply return
+ * 550 Access Denied.
+ *
+ * See [Draft spec](https://www.ietf.org/archive/id/draft-peterson-streamlined-ftp-command-extensions-10.txt)
+ */
+class AVBL : AbstractCommand() {
+
+    companion object {
+        private val LOG: Logger = LoggerFactory.getLogger(AVBL::class.java)
+    }
+
+    override fun execute(session: FtpIoSession, context: FtpServerContext, request: FtpRequest) {
+        // argument check
+        val fileName: String? = request.argument
+        if (context.fileSystemManager is AndroidFileSystemFactory) {
+            doWriteReply(
+                session,
+                REPLY_502_COMMAND_NOT_IMPLEMENTED,
+                "AVBL.notimplemented"
+            )
+        } else {
+            val ftpFile: FtpFile? = if (true == fileName?.isNotBlank()) {
+                runCatching {
+                    session.fileSystemView.getFile(fileName)
+                }.getOrNull()
+            } else {
+                session.fileSystemView.homeDirectory
+            }
+            if (ftpFile != null) {
+                if (session.user.authorize(
+                        if (true == fileName?.isNotBlank()) {
+                            WriteRequest(fileName)
+                        } else {
+                            WriteRequest()
+                        }
+                    ) != null ||
+                    !(ftpFile.physicalFile as File).canWrite()
+                ) {
+                    (ftpFile.physicalFile as File).apply {
+                        if (this.isDirectory) {
+                            runCatching {
+                                freeSpace.let {
+                                    session.write(
+                                        DefaultFtpReply(REPLY_213_FILE_STATUS, it.toString())
+                                    )
+                                }
+                            }.onFailure {
+                                LOG.error("Error getting directory free space", it)
+                                replyError(session, "AVBL.accessdenied")
+                                return
+                            }
+                        } else {
+                            replyError(session, "AVBL.isafile")
+                        }
+                    }
+                } else {
+                    replyError(session, "AVBL.accessdenied")
+                }
+            } else {
+                replyError(session, "AVBL.missing", fileName)
+            }
+        }
+    }
+
+    private fun replyError(
+        session: FtpIoSession,
+        subId: String,
+        fileName: String? = null
+    ) = doWriteReply(session, REPLY_550_REQUESTED_ACTION_NOT_TAKEN, subId, fileName)
+
+    private fun doWriteReply(
+        session: FtpIoSession,
+        code: Int,
+        subId: String,
+        fileName: String? = null
+    ) {
+        val packageName = AppConfig.getInstance().packageName
+        val resources = AppConfig.getInstance().resources
+        session.write(
+            DefaultFtpReply(
+                code,
+                resources.getString(
+                    resources.getIdentifier("$packageName:string/ftp_error_$subId", null, null),
+                    fileName
+                )
+            )
+        )
+    }
+}

--- a/app/src/main/java/com/amaze/filemanager/filesystem/ftpserver/commands/FEAT.kt
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/ftpserver/commands/FEAT.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2014-2022 Arpit Khurana <arpitkh96@gmail.com>, Vishal Nehra <vishalmeham2@gmail.com>,
+ * Emmanuel Messulam<emmanuelbendavid@gmail.com>, Raymond Lai <airwave209gt at gmail.com> and Contributors.
+ *
+ * This file is part of Amaze File Manager.
+ *
+ * Amaze File Manager is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.amaze.filemanager.filesystem.ftpserver.commands
+
+import com.amaze.filemanager.R
+import com.amaze.filemanager.application.AppConfig
+import org.apache.ftpserver.command.AbstractCommand
+import org.apache.ftpserver.ftplet.DefaultFtpReply
+import org.apache.ftpserver.ftplet.FtpReply
+import org.apache.ftpserver.ftplet.FtpRequest
+import org.apache.ftpserver.impl.FtpIoSession
+import org.apache.ftpserver.impl.FtpServerContext
+
+/**
+ * Custom [org.apache.ftpserver.command.impl.FEAT] to add [AVBL] command to the list.
+ */
+class FEAT : AbstractCommand() {
+    override fun execute(session: FtpIoSession, context: FtpServerContext, request: FtpRequest) {
+        session.resetState()
+        session.write(
+            DefaultFtpReply(
+                FtpReply.REPLY_211_SYSTEM_STATUS_REPLY,
+                AppConfig.getInstance().getString(R.string.ftp_command_FEAT)
+            )
+        )
+    }
+}

--- a/app/src/main/java/com/amaze/filemanager/filesystem/ftpserver/commands/PWD.kt
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/ftpserver/commands/PWD.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2014-2022 Arpit Khurana <arpitkh96@gmail.com>, Vishal Nehra <vishalmeham2@gmail.com>,
+ * Emmanuel Messulam<emmanuelbendavid@gmail.com>, Raymond Lai <airwave209gt at gmail.com> and Contributors.
+ *
+ * This file is part of Amaze File Manager.
+ *
+ * Amaze File Manager is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.amaze.filemanager.filesystem.ftpserver.commands
+
+import org.apache.ftpserver.command.AbstractCommand
+import org.apache.ftpserver.ftplet.FtpException
+import org.apache.ftpserver.ftplet.FtpReply
+import org.apache.ftpserver.ftplet.FtpRequest
+import org.apache.ftpserver.impl.FtpIoSession
+import org.apache.ftpserver.impl.FtpServerContext
+import org.apache.ftpserver.impl.LocalizedFtpReply
+import java.io.IOException
+
+/**
+ * Monkey-patch [org.apache.ftpserver.command.impl.PWD] to prevent true path exposed to end user.
+ */
+class PWD : AbstractCommand() {
+
+    @Throws(IOException::class, FtpException::class)
+    override fun execute(
+        session: FtpIoSession,
+        context: FtpServerContext,
+        request: FtpRequest
+    ) {
+        session.resetState()
+        val fsView = session.fileSystemView
+        var currDir = fsView.workingDirectory.absolutePath
+            .substringAfter(fsView.homeDirectory.absolutePath)
+        if (currDir.isEmpty()) {
+            currDir = "/"
+        }
+        if (!currDir.startsWith("/")) {
+            currDir = "/$currDir"
+        }
+        session.write(
+            LocalizedFtpReply.translate(
+                session,
+                request,
+                context,
+                FtpReply.REPLY_257_PATHNAME_CREATED,
+                "PWD",
+                currDir
+            )
+        )
+    }
+}

--- a/app/src/main/res/values/ftpserver.xml
+++ b/app/src/main/res/values/ftpserver.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:tools="http://schemas.android.com/tools"
+    tools:ignore="MissingTranslation"
+    xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="ftp_error_AVBL.notimplemented" translatable="false">Command not implemented for AndroidFileSystem.</string>
+    <string name="ftp_error_AVBL.isafile" translatable="false">Is a File.</string>
+    <string name="ftp_error_AVBL.missing" translatable="false">Path not found.</string>
+    <string name="ftp_error_AVBL.accessdenied" translatable="false">Access denied.</string>
+    <string name="ftp_command_FEAT" translatable="false">Extensions supported\n SIZE\n MDTM\n REST STREAM\n LANG en;zh-tw;ja;is\n MLST Size;Modify;Type;Perm\n AUTH SSL\n AUTH TLS\n MODE Z\n UTF8\n TVFS\n MD5\n MMD5\n MFMT\n AVBL\nEnd</string>
+</resources>

--- a/app/src/test/java/com/amaze/filemanager/filesystem/ftpserver/commands/AVBLCommandTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/filesystem/ftpserver/commands/AVBLCommandTest.kt
@@ -1,0 +1,223 @@
+/*
+ * Copyright (C) 2014-2022 Arpit Khurana <arpitkh96@gmail.com>, Vishal Nehra <vishalmeham2@gmail.com>,
+ * Emmanuel Messulam<emmanuelbendavid@gmail.com>, Raymond Lai <airwave209gt at gmail.com> and Contributors.
+ *
+ * This file is part of Amaze File Manager.
+ *
+ * Amaze File Manager is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.amaze.filemanager.filesystem.ftpserver.commands
+
+import android.os.Environment
+import com.amaze.filemanager.R
+import com.amaze.filemanager.application.AppConfig
+import com.amaze.filemanager.filesystem.ftpserver.AndroidFileSystemFactory
+import org.apache.ftpserver.filesystem.nativefs.NativeFileSystemFactory
+import org.apache.ftpserver.filesystem.nativefs.impl.NativeFileSystemView
+import org.apache.ftpserver.ftplet.Authority
+import org.apache.ftpserver.ftplet.FileSystemFactory
+import org.apache.ftpserver.ftplet.FtpFile
+import org.apache.ftpserver.impl.DefaultFtpRequest
+import org.apache.ftpserver.impl.FtpIoSession
+import org.apache.ftpserver.impl.FtpServerContext
+import org.apache.ftpserver.usermanager.impl.BaseUser
+import org.apache.ftpserver.usermanager.impl.WritePermission
+import org.junit.Assert.assertEquals
+import org.junit.BeforeClass
+import org.junit.Test
+import org.mockito.ArgumentMatchers.any
+import org.mockito.ArgumentMatchers.anyString
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import java.io.File
+
+/**
+ * Unit test for [AVBL].
+ */
+class AVBLCommandTest : AbstractFtpserverCommandTest() {
+
+    companion object {
+
+        private lateinit var fsFactory: FileSystemFactory
+
+        private lateinit var fsView: NativeFileSystemView
+
+        /**
+         * Mock [NativeFileSystemView] for testing.
+         */
+        @JvmStatic
+        @BeforeClass
+        fun bootstrap() {
+            fsFactory = mock(NativeFileSystemFactory::class.java)
+            fsView = mock(NativeFileSystemView::class.java)
+            val physicalFile1 = mock(File::class.java)
+            val physicalFile2 = mock(File::class.java)
+            val physicalFile3 = mock(File::class.java)
+            val physicalFile4 = mock(File::class.java)
+            val ftpFile1 = mock(FtpFile::class.java)
+            val ftpFile2 = mock(FtpFile::class.java)
+            val ftpFile3 = mock(FtpFile::class.java)
+            val ftpFile4 = mock(FtpFile::class.java)
+            `when`(physicalFile1.isDirectory).thenReturn(true)
+            `when`(physicalFile2.isDirectory).thenReturn(true)
+            `when`(physicalFile3.isDirectory).thenReturn(true)
+            `when`(physicalFile4.isDirectory).thenReturn(false)
+            `when`(physicalFile4.isFile).thenReturn(true)
+            `when`(physicalFile1.freeSpace).thenReturn(12345L)
+            `when`(physicalFile2.freeSpace).thenReturn(131072L)
+            `when`(physicalFile3.freeSpace).thenThrow(SecurityException())
+            `when`(ftpFile1.physicalFile).thenReturn(physicalFile1)
+            `when`(ftpFile2.physicalFile).thenReturn(physicalFile2)
+            `when`(ftpFile3.physicalFile).thenReturn(physicalFile3)
+            `when`(ftpFile4.physicalFile).thenReturn(physicalFile4)
+            `when`(fsView.homeDirectory).thenReturn(ftpFile1)
+            `when`(fsView.getFile(anyString())).thenReturn(null)
+            `when`(fsView.getFile("/")).thenReturn(ftpFile1)
+            `when`(fsView.getFile("/incoming")).thenReturn(ftpFile2)
+            `when`(fsView.getFile("/secure")).thenReturn(ftpFile3)
+            `when`(fsView.getFile("/test.txt")).thenReturn(ftpFile4)
+            `when`(fsFactory.createFileSystemView(any())).thenReturn(fsView)
+        }
+    }
+
+    /**
+     * Command should return 502 not implemented if FTP server is using [AndroidFileSystemFactory].
+     */
+    @Test
+    fun testWithAndroidFileSystem() {
+        executeRequest(
+            "AVBL",
+            listOf(WritePermission()),
+            mock(AndroidFileSystemFactory::class.java)
+        )
+        assertEquals(1, logger.messages.size)
+        assertEquals(502, logger.messages[0].code)
+        assertEquals(
+            AppConfig.getInstance().getString(R.string.ftp_error_AVBL_notimplemented),
+            logger.messages[0].message
+        )
+    }
+
+    /**
+     * No path argument should return home directory size.
+     */
+    @Test
+    fun testHomeDirectory() {
+        executeRequest("AVBL", listOf(WritePermission()))
+        assertEquals(1, logger.messages.size)
+        assertEquals(213, logger.messages[0].code)
+        assertEquals("12345", logger.messages[0].message)
+    }
+
+    /**
+     * Root (/) argument test.
+     */
+    @Test
+    fun testRoot() {
+        executeRequest("AVBL /", listOf(WritePermission()))
+        assertEquals(1, logger.messages.size)
+        assertEquals(213, logger.messages[0].code)
+        assertEquals("12345", logger.messages[0].message)
+    }
+
+    /**
+     * Test specified path.
+     */
+    @Test
+    fun testGetPath() {
+        executeRequest("AVBL /incoming", listOf(WritePermission()))
+        assertEquals(1, logger.messages.size)
+        assertEquals(213, logger.messages[0].code)
+        assertEquals("131072", logger.messages[0].message)
+    }
+
+    /**
+     * Command should return 550 if path not found.
+     */
+    @Test
+    fun testPathNotFound() {
+        executeRequest("AVBL /foobar", listOf(WritePermission()))
+        assertEquals(1, logger.messages.size)
+        assertEquals(550, logger.messages[0].code)
+        assertEquals(
+            AppConfig.getInstance().getString(R.string.ftp_error_AVBL_missing),
+            logger.messages[0].message
+        )
+    }
+
+    /**
+     * Command should return 550 too if user does not have access to directory.
+     */
+    @Test
+    fun testAccessDenied() {
+        executeRequest("AVBL /secure", emptyList())
+        assertEquals(1, logger.messages.size)
+        assertEquals(550, logger.messages[0].code)
+        assertEquals(
+            AppConfig.getInstance().getString(R.string.ftp_error_AVBL_accessdenied),
+            logger.messages[0].message
+        )
+    }
+
+    /**
+     * Command should return 550 if [SecurityException] was thrown when calling
+     * [File.getFreeSpace].
+     */
+    @Test
+    fun testSecurityException() {
+        executeRequest("AVBL /secure", listOf(WritePermission()))
+        assertEquals(1, logger.messages.size)
+        assertEquals(550, logger.messages[0].code)
+        assertEquals(
+            AppConfig.getInstance().getString(R.string.ftp_error_AVBL_accessdenied),
+            logger.messages[0].message
+        )
+    }
+
+    /**
+     * Command should return 550 if user tried to get free space from a file.
+     */
+    @Test
+    fun testFile() {
+        executeRequest("AVBL /test.txt", listOf(WritePermission()))
+        assertEquals(1, logger.messages.size)
+        assertEquals(550, logger.messages[0].code)
+        assertEquals(
+            AppConfig.getInstance().getString(R.string.ftp_error_AVBL_isafile),
+            logger.messages[0].message
+        )
+    }
+
+    private fun executeRequest(
+        commandLine: String,
+        permissions: List<Authority>,
+        fileSystemFactory: FileSystemFactory = fsFactory
+    ) {
+        val context = mock(FtpServerContext::class.java)
+        val ftpSession = FtpIoSession(session, context)
+        ftpSession.user = BaseUser().also {
+            it.homeDirectory = Environment.getExternalStorageDirectory().absolutePath
+            it.authorities = permissions
+        }
+        ftpSession.setLogin(fsView)
+        `when`(context.fileSystemManager).thenReturn(fileSystemFactory)
+        val command = AVBL()
+        command.execute(
+            session = ftpSession,
+            context = context,
+            request = DefaultFtpRequest(commandLine)
+        )
+    }
+}

--- a/app/src/test/java/com/amaze/filemanager/filesystem/ftpserver/commands/AbstractFtpserverCommandTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/filesystem/ftpserver/commands/AbstractFtpserverCommandTest.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2014-2022 Arpit Khurana <arpitkh96@gmail.com>, Vishal Nehra <vishalmeham2@gmail.com>,
+ * Emmanuel Messulam<emmanuelbendavid@gmail.com>, Raymond Lai <airwave209gt at gmail.com> and Contributors.
+ *
+ * This file is part of Amaze File Manager.
+ *
+ * Amaze File Manager is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.amaze.filemanager.filesystem.ftpserver.commands
+
+import android.os.Build.VERSION_CODES.JELLY_BEAN
+import android.os.Build.VERSION_CODES.KITKAT
+import android.os.Build.VERSION_CODES.P
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.amaze.filemanager.shadows.ShadowMultiDex
+import org.apache.mina.core.session.DummySession
+import org.apache.mina.core.session.IoSession
+import org.junit.After
+import org.junit.Before
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+/**
+ * Base class for ftpserver command unit tests.
+ */
+@RunWith(AndroidJUnit4::class)
+@Config(
+    shadows = [ShadowMultiDex::class],
+    sdk = [JELLY_BEAN, KITKAT, P]
+)
+abstract class AbstractFtpserverCommandTest {
+
+    protected lateinit var logger: LogMessageFilter
+
+    protected lateinit var session: IoSession
+
+    /**
+     * Test setup. Create dummy [IoSession] and bind logging filter to it.
+     */
+    @Before
+    open fun setUp() {
+        logger = LogMessageFilter()
+        session = DummySession()
+        session.filterChain.addFirst("logging", logger)
+    }
+
+    /**
+     * Post test cleanup
+     */
+    @After
+    open fun tearDown() {
+        session.closeNow()
+        logger.reset()
+    }
+}

--- a/app/src/test/java/com/amaze/filemanager/filesystem/ftpserver/commands/FEATCommandTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/filesystem/ftpserver/commands/FEATCommandTest.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2014-2022 Arpit Khurana <arpitkh96@gmail.com>, Vishal Nehra <vishalmeham2@gmail.com>,
+ * Emmanuel Messulam<emmanuelbendavid@gmail.com>, Raymond Lai <airwave209gt at gmail.com> and Contributors.
+ *
+ * This file is part of Amaze File Manager.
+ *
+ * Amaze File Manager is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.amaze.filemanager.filesystem.ftpserver.commands
+
+import com.amaze.filemanager.R
+import com.amaze.filemanager.application.AppConfig
+import org.apache.ftpserver.impl.DefaultFtpRequest
+import org.apache.ftpserver.impl.FtpIoSession
+import org.apache.ftpserver.impl.FtpServerContext
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.mockito.Mockito
+
+/**
+ * Unit test for [FEAT].
+ */
+class FEATCommandTest : AbstractFtpserverCommandTest() {
+
+    /**
+     * Test command output. Expect AVBL is among list of extensions implemented.
+     */
+    @Test
+    fun testCommand() {
+        val context = Mockito.mock(FtpServerContext::class.java)
+        val ftpSession = FtpIoSession(session, context)
+        val command = FEAT()
+        command.execute(
+            session = ftpSession,
+            context = context,
+            request = DefaultFtpRequest("FEAT")
+        )
+        assertEquals(1, logger.messages.size)
+        assertEquals(211, logger.messages[0].code)
+        assertEquals(
+            AppConfig.getInstance().getString(R.string.ftp_command_FEAT),
+            logger.messages[0].message
+        )
+        assertTrue(logger.messages[0].message.contains("AVBL"))
+    }
+}

--- a/app/src/test/java/com/amaze/filemanager/filesystem/ftpserver/commands/LogMessageFilter.kt
+++ b/app/src/test/java/com/amaze/filemanager/filesystem/ftpserver/commands/LogMessageFilter.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2014-2022 Arpit Khurana <arpitkh96@gmail.com>, Vishal Nehra <vishalmeham2@gmail.com>,
+ * Emmanuel Messulam<emmanuelbendavid@gmail.com>, Raymond Lai <airwave209gt at gmail.com> and Contributors.
+ *
+ * This file is part of Amaze File Manager.
+ *
+ * Amaze File Manager is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.amaze.filemanager.filesystem.ftpserver.commands
+
+import org.apache.ftpserver.ftplet.FtpReply
+import org.apache.mina.core.filterchain.IoFilter
+import org.apache.mina.core.filterchain.IoFilterAdapter
+import org.apache.mina.core.session.IoSession
+import org.apache.mina.core.write.WriteRequest
+
+/**
+ * [IoFilter] to store messages written in an [IoSession]. Test use only.
+ */
+class LogMessageFilter : IoFilterAdapter() {
+    val messages = mutableListOf<FtpReply>()
+
+    override fun messageSent(
+        nextFilter: IoFilter.NextFilter,
+        session: IoSession,
+        writeRequest: WriteRequest
+    ) {
+        writeRequest.message.run {
+            messages.add(this as FtpReply)
+        }
+        super.messageSent(nextFilter, session, writeRequest)
+    }
+
+    /**
+     * Expunge all messages sent to this filter.
+     */
+    fun reset() {
+        messages.clear()
+    }
+}

--- a/app/src/test/java/com/amaze/filemanager/filesystem/ftpserver/commands/PWDCommandTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/filesystem/ftpserver/commands/PWDCommandTest.kt
@@ -1,0 +1,145 @@
+/*
+ * Copyright (C) 2014-2022 Arpit Khurana <arpitkh96@gmail.com>, Vishal Nehra <vishalmeham2@gmail.com>,
+ * Emmanuel Messulam<emmanuelbendavid@gmail.com>, Raymond Lai <airwave209gt at gmail.com> and Contributors.
+ *
+ * This file is part of Amaze File Manager.
+ *
+ * Amaze File Manager is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.amaze.filemanager.filesystem.ftpserver.commands
+
+import android.os.Environment
+import org.apache.ftpserver.filesystem.nativefs.impl.NativeFileSystemView
+import org.apache.ftpserver.ftplet.User
+import org.apache.ftpserver.impl.DefaultFtpRequest
+import org.apache.ftpserver.impl.FtpIoSession
+import org.apache.ftpserver.impl.FtpServerContext
+import org.apache.ftpserver.message.MessageResourceFactory
+import org.apache.ftpserver.usermanager.impl.BaseUser
+import org.apache.ftpserver.usermanager.impl.WritePermission
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.BeforeClass
+import org.junit.Test
+import org.mockito.Mockito
+import org.mockito.Mockito.`when`
+import java.io.File
+
+/**
+ * Unit test for [PWD].
+ */
+@Suppress("StringLiteralDuplication")
+class PWDCommandTest : AbstractFtpserverCommandTest() {
+
+    private lateinit var fsView: NativeFileSystemView
+
+    private lateinit var user: User
+
+    private lateinit var ftpSession: FtpIoSession
+
+    companion object {
+
+        // Nobody is interested in this, nor asking it any question.
+        // Of course in reality FtpServerContext will never be static
+        private lateinit var context: FtpServerContext
+
+        /**
+         * Mock [FtpServerContext] for test, with custom logic to skip effort to create
+         * [MessageResource].
+         */
+        @JvmStatic
+        @BeforeClass
+        fun bootstrap() {
+            context = Mockito.mock(FtpServerContext::class.java)
+            val messages = MessageResourceFactory().createMessageResource()
+            `when`(context.messageResource).thenReturn(messages)
+        }
+    }
+
+    /**
+     * Setup before test.
+     */
+    @Before
+    override fun setUp() {
+        super.setUp()
+        File(Environment.getExternalStorageDirectory(), "Music").mkdirs()
+        user = BaseUser().also {
+            it.homeDirectory = Environment.getExternalStorageDirectory().absolutePath
+            it.authorities = listOf(WritePermission())
+        }
+        fsView = NativeFileSystemView(user, false)
+
+        ftpSession = FtpIoSession(session, context)
+        ftpSession.user = user
+        ftpSession.setLogin(fsView)
+    }
+
+    /**
+     * PWD should never expose device real path to user.
+     */
+    @Test
+    fun testRootDir() {
+        executeRequest()
+        assertEquals(1, logger.messages.size)
+        assertEquals(257, logger.messages[0].code)
+        assertEquals("\"/\" is current directory.", logger.messages[0].message)
+    }
+
+    /**
+     * Test scenario after changing working directory.
+     */
+    @Test
+    fun testChangeDirDown() {
+        executeRequest()
+        assertEquals(1, logger.messages.size)
+        assertEquals(257, logger.messages.last().code)
+        assertEquals("\"/\" is current directory.", logger.messages.last().message)
+        ftpSession.fileSystemView.changeWorkingDirectory("/Music")
+        executeRequest()
+        assertEquals(2, logger.messages.size)
+        assertEquals(257, logger.messages.last().code)
+        assertEquals("\"/Music\" is current directory.", logger.messages.last().message)
+    }
+
+    /**
+     * Test scenario after a CDUP.
+     */
+    @Test
+    fun testChangeDirUp() {
+        executeRequest()
+        assertEquals(1, logger.messages.size)
+        assertEquals(257, logger.messages.last().code)
+        assertEquals("\"/\" is current directory.", logger.messages.last().message)
+        ftpSession.fileSystemView.changeWorkingDirectory("/Music")
+        executeRequest()
+        assertEquals(2, logger.messages.size)
+        assertEquals(257, logger.messages.last().code)
+        assertEquals("\"/Music\" is current directory.", logger.messages.last().message)
+        ftpSession.fileSystemView.changeWorkingDirectory("/")
+        executeRequest()
+        assertEquals(3, logger.messages.size)
+        assertEquals(257, logger.messages.last().code)
+        assertEquals("\"/\" is current directory.", logger.messages.last().message)
+    }
+
+    private fun executeRequest() {
+        val command = PWD()
+        command.execute(
+            session = ftpSession,
+            context = context,
+            request = DefaultFtpRequest("PWD")
+        )
+    }
+}


### PR DESCRIPTION
## Description
- Implement [AVBL](https://datatracker.ietf.org/doc/html/draft-peterson-streamlined-ftp-command-extensions-10#section-4) command, to allow supporting FTP clients to get server storage space information. However, this command does not support AndroidFileSystem (which uses SAF as backend) as Android cannot correctly report free space available via its DocumentFile API
- Patched FEAT command to report AVBL is implemented
- Fix stock PWD command in Apache ftpserver that the true device path is exposed to user

#### Automatic tests
- [x] Added test cases
  
#### Manual tests
- [x] Done  
  
Devices:
- Oneplus 2, running LineageOS 18 (11)
- GPD XD 1, running LegacyROM (4.4.4)
When using WinSCP to connect to FTP server, device free space can been seen at its Protocol Information dialog.

#### Build tasks success  
Successfully running following tasks on local:
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`

#### Related
Related to #1570 - although most FTP servers won't report storage space left, but I think it's still worthwhile to implement one at our side.