### PR TITLE
Add `hotfix/*` as a target branch

### DIFF
--- a/.github/workflows/android-main.yml
+++ b/.github/workflows/android-main.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - 'master'
       - 'release/*'
+      - 'hotfix/*'
 
 concurrency:
   group: build-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
## Description

The current workflow file doesn't run when a commit is being made to `hotfix/*` branches. This is why the continuous builds on Telegram wasn't getting shown up for a while now.