### PR TITLE
Fix cut/copy snackbar overlap with the cancel button

### DIFF
--- a/app/src/main/res/layout/snackbar_view.xml
+++ b/app/src/main/res/layout/snackbar_view.xml
@@ -47,11 +47,12 @@
 
             <TextView
                 android:id="@+id/snackBarTextTV"
-                android:layout_width="wrap_content"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_margin="8dp"
                 android:layout_marginStart="16dp"
                 android:layout_marginLeft="16dp"
+                android:gravity="start"
                 android:padding="8dp"
                 android:textColor="@color/vectors_white"
                 android:textSize="14sp"


### PR DESCRIPTION
## Description

#### Issue tracker   
Fixes #3348 

#### Automatic tests
- [ ] Added test cases
  
#### Manual tests
- [x] Done 

#### Build tasks success  
Successfully running following tasks on local:
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`

#### Related PR  
Related to PR #2377

#### Changes

Now the text would overflow to the bottom & not the sides. (could not find an emulator that overflows the text, hence hard-coded the text to test)

##### Old:

![Old](https://user-images.githubusercontent.com/50027064/173242951-d9a5c80d-cd55-4be3-8fa5-4ce6173657d1.jpg)

##### New:

![New](https://user-images.githubusercontent.com/50027064/173242950-03b04e90-2594-4869-ab8b-586a6d3c3c25.jpg)