### PR TITLE
Prevent Google Play release variant to be able to update itself via apk selection

### DIFF
--- a/app/src/fdroid/java/com/amaze/filemanager/utils/PackageInstallValidation.kt
+++ b/app/src/fdroid/java/com/amaze/filemanager/utils/PackageInstallValidation.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2014-2022 Arpit Khurana <arpitkh96@gmail.com>, Vishal Nehra <vishalmeham2@gmail.com>,
+ * Emmanuel Messulam<emmanuelbendavid@gmail.com>, Raymond Lai <airwave209gt at gmail.com> and Contributors.
+ *
+ * This file is part of Amaze File Manager.
+ *
+ * Amaze File Manager is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.amaze.filemanager.utils
+
+import java.io.File
+
+/**
+ * For non Google Play variant, this class does nothing. Just a stub.
+ */
+object PackageInstallValidation {
+
+    /**
+     * Do nothing.
+     */
+    @JvmStatic
+    @Throws(PackageCannotBeInstalledException::class, IllegalStateException::class)
+    fun validatePackageInstallability(f: File) = Unit
+
+    /**
+     * Exception indicating specified package cannot be installed
+     */
+    class PackageCannotBeInstalledException : Exception {
+        constructor(reason: Throwable) : super(reason)
+        constructor(reason: String) : super(reason)
+    }
+}

--- a/app/src/main/java/com/amaze/filemanager/filesystem/files/FileUtils.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/files/FileUtils.java
@@ -61,6 +61,7 @@ import com.amaze.filemanager.ui.theme.AppTheme;
 import com.amaze.filemanager.utils.DataUtils;
 import com.amaze.filemanager.utils.OTGUtil;
 import com.amaze.filemanager.utils.OnProgressUpdate;
+import com.amaze.filemanager.utils.PackageInstallValidation;
 import com.cloudrail.si.interfaces.CloudStorage;
 import com.cloudrail.si.types.CloudMetaData;
 import com.googlecode.concurrenttrees.radix.ConcurrentRadixTree;
@@ -416,6 +417,25 @@ public class FileUtils {
    */
   public static void installApk(
       final @NonNull File f, final @NonNull PermissionsActivity permissionsActivity) {
+
+    try {
+      PackageInstallValidation.validatePackageInstallability(f);
+    } catch (PackageInstallValidation.PackageCannotBeInstalledException e) {
+      Toast.makeText(
+              permissionsActivity,
+              R.string.error_google_play_cannot_update_myself,
+              Toast.LENGTH_LONG)
+          .show();
+      return;
+    } catch (IllegalStateException e) {
+      Toast.makeText(
+              permissionsActivity,
+              permissionsActivity.getString(
+                  R.string.error_cannot_get_package_info, f.getAbsolutePath()),
+              Toast.LENGTH_LONG)
+          .show();
+    }
+
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O
         && !permissionsActivity.getPackageManager().canRequestPackageInstalls()) {
       permissionsActivity.requestInstallApkPermission(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -778,5 +778,7 @@ You only need to do this once, until the next time you select a new location for
     <string name="open_with_amaze">Open with Amaze</string>
     <string name="confirmation">Confirmation</string>
     <string name="open_file_confirmation">Are you sure you want to open following file?\n\nName:\n%s\n\nLocation:\n%s\n\nSize:\n%s\n\nMD5:\n%s\n\nSHA256:\n%s\n\n</string>
+    <string name="error_google_play_cannot_update_myself">Per Google Play policy mandates, apps are not allowed to update itself on its own. Please update app from Google Play.</string>
+    <string name="error_cannot_get_package_info">Unable to get package info from file \"%s\". Either the specified file is not an APK, or the package file is corrupt.</string>
 </resources>
 

--- a/app/src/play/java/com/amaze/filemanager/utils/PackageInstallValidation.kt
+++ b/app/src/play/java/com/amaze/filemanager/utils/PackageInstallValidation.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2014-2022 Arpit Khurana <arpitkh96@gmail.com>, Vishal Nehra <vishalmeham2@gmail.com>,
+ * Emmanuel Messulam<emmanuelbendavid@gmail.com>, Raymond Lai <airwave209gt at gmail.com> and Contributors.
+ *
+ * This file is part of Amaze File Manager.
+ *
+ * Amaze File Manager is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.amaze.filemanager.utils
+
+import android.content.pm.PackageInfo
+import android.content.pm.PackageManager
+import com.amaze.filemanager.application.AppConfig
+import com.amaze.filemanager.filesystem.files.FileUtils
+import java.io.File
+
+/**
+ * Additional checks for package validity for installation via Amaze.
+ *
+ */
+object PackageInstallValidation {
+
+    /**
+     * Perform validation by getting [PackageInfo] of file at specified path, then see if it's us.
+     * If yes, throw [PackageCannotBeInstalledException] and [FileUtils.installApk] should exit
+     * with Toast.
+     */
+    @JvmStatic
+    @Throws(PackageCannotBeInstalledException::class, IllegalStateException::class)
+    fun validatePackageInstallability(f: File) {
+        AppConfig.getInstance().run {
+            val packageInfo: PackageInfo? =
+                packageManager.getPackageArchiveInfo(
+                    f.absolutePath,
+                    PackageManager.GET_ACTIVITIES
+                )
+            if (packageInfo == null) {
+                throw IllegalStateException("Cannot get package info")
+            } else {
+                if (packageInfo.packageName == this.packageName) {
+                    throw PackageCannotBeInstalledException(
+                        "Cannot update myself per Google Play policy"
+                    )
+                }
+            }
+        }
+    }
+
+    /**
+     * Exception indicating specified package cannot be installed
+     */
+    class PackageCannotBeInstalledException : Exception {
+        constructor(reason: Throwable) : super(reason)
+        constructor(reason: String) : super(reason)
+    }
+}

--- a/app/src/testPlayRelease/java/com/amaze/filemanager/utils/PackageInstallValidationTest.kt
+++ b/app/src/testPlayRelease/java/com/amaze/filemanager/utils/PackageInstallValidationTest.kt
@@ -1,0 +1,227 @@
+/*
+ * Copyright (C) 2014-2022 Arpit Khurana <arpitkh96@gmail.com>, Vishal Nehra <vishalmeham2@gmail.com>,
+ * Emmanuel Messulam<emmanuelbendavid@gmail.com>, Raymond Lai <airwave209gt at gmail.com> and Contributors.
+ *
+ * This file is part of Amaze File Manager.
+ *
+ * Amaze File Manager is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.amaze.filemanager.utils
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.content.pm.PackageInfo
+import android.os.Build.VERSION.SDK_INT
+import android.os.Build.VERSION_CODES.JELLY_BEAN
+import android.os.Build.VERSION_CODES.KITKAT
+import android.os.Build.VERSION_CODES.N
+import android.os.Build.VERSION_CODES.P
+import android.os.storage.StorageManager
+import androidx.lifecycle.Lifecycle
+import androidx.test.core.app.ActivityScenario
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.amaze.filemanager.R
+import com.amaze.filemanager.application.AppConfig
+import com.amaze.filemanager.filesystem.files.FileUtils
+import com.amaze.filemanager.shadows.ShadowMultiDex
+import com.amaze.filemanager.test.ShadowTabHandler
+import com.amaze.filemanager.test.TestUtils.initializeInternalStorage
+import com.amaze.filemanager.ui.activities.MainActivity
+import io.reactivex.android.plugins.RxAndroidPlugins
+import io.reactivex.plugins.RxJavaPlugins
+import io.reactivex.schedulers.Schedulers
+import org.awaitility.Awaitility.await
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.fail
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowLooper
+import org.robolectric.shadows.ShadowPackageManager
+import org.robolectric.shadows.ShadowSQLiteConnection
+import org.robolectric.shadows.ShadowToast
+import java.io.File
+import java.util.concurrent.TimeUnit
+
+/**
+ * Unit test for [PackageInstallValidation].
+ */
+@SuppressLint("SdCardPath")
+@RunWith(AndroidJUnit4::class)
+@Config(
+    sdk = [JELLY_BEAN, KITKAT, P],
+    shadows = [ShadowPackageManager::class, ShadowMultiDex::class, ShadowTabHandler::class]
+)
+class PackageInstallValidationTest {
+
+    companion object {
+        private const val GOOD_PACKAGE = "/sdcard/good-package.apk"
+        private const val MY_PACKAGE = "/sdcard/my-package.apk"
+        private const val INVALID_PACKAGE = "/sdcard/bad-package.apk"
+    }
+
+    /**
+     * Prepare [ShadowPackageManager].
+     */
+    @Before
+    fun setUp() {
+        val packageManager = shadowOf(AppConfig.getInstance().packageManager)
+        packageManager.setPackageArchiveInfo(
+            GOOD_PACKAGE,
+            PackageInfo().also {
+                it.packageName = "foo.bar.abc"
+            }
+        )
+        packageManager.setPackageArchiveInfo(
+            MY_PACKAGE,
+            PackageInfo().also {
+                it.packageName = AppConfig.getInstance().packageName
+            }
+        )
+        packageManager.setPackageArchiveInfo(
+            INVALID_PACKAGE,
+            null
+        )
+        if (SDK_INT >= N) initializeInternalStorage()
+        RxJavaPlugins.reset()
+        RxJavaPlugins.setIoSchedulerHandler {
+            Schedulers.trampoline()
+        }
+        RxAndroidPlugins.reset()
+        RxAndroidPlugins.setInitMainThreadSchedulerHandler {
+            Schedulers.trampoline()
+        }
+        ShadowSQLiteConnection.reset()
+    }
+
+    /**
+     * Post test cleanup.
+     */
+    @After
+    fun tearDown() {
+        if (SDK_INT >= N) shadowOf(
+            ApplicationProvider.getApplicationContext<Context>().getSystemService(
+                StorageManager::class.java
+            )
+        ).resetStorageVolumeList()
+    }
+
+    /**
+     * If package is good, nothing happens.
+     */
+    @Test
+    fun testGoodPackage() {
+        PackageInstallValidation.validatePackageInstallability(
+            File(GOOD_PACKAGE)
+        )
+        assertEquals(2, 1 + 1)
+    }
+
+    /**
+     * If package name matches us, should throw PackageCannotBeInstalledException.
+     */
+    @Test(expected = PackageInstallValidation.PackageCannotBeInstalledException::class)
+    fun testMyPackage() {
+        PackageInstallValidation.validatePackageInstallability(
+            File(MY_PACKAGE)
+        )
+        fail("PackageCannotBeInstalledException not thrown")
+    }
+
+    /**
+     * If package is bad, IllegalStateException is thrown.
+     */
+    @Test(expected = IllegalStateException::class)
+    fun testInvalidPackage() {
+        PackageInstallValidation.validatePackageInstallability(
+            File(INVALID_PACKAGE)
+        )
+        fail("PackageCannotBeInstalledException not thrown")
+    }
+
+    /**
+     * Test [FileUtils.installApk] success scenario.
+     */
+    @Test
+    fun testInstallApkSuccess() {
+        val scenario = ActivityScenario.launch(MainActivity::class.java)
+
+        ShadowLooper.idleMainLooper()
+        scenario.moveToState(Lifecycle.State.STARTED)
+        scenario.onActivity { activity ->
+            FileUtils.installApk(File(GOOD_PACKAGE), activity)
+            shadowOf(activity).nextStartedActivityForResult?.run {
+                assertNotNull(this)
+                assertNotNull(this.intent)
+            } ?: fail("Cannot get next started activity for result as Intent")
+        }.also {
+            scenario.moveToState(Lifecycle.State.DESTROYED)
+            scenario.close()
+        }
+    }
+
+    /**
+     * Test [FileUtils.installApk] failure scenario.
+     */
+    @Test
+    fun testInstallApkFailure() {
+        val scenario = ActivityScenario.launch(MainActivity::class.java)
+
+        ShadowLooper.idleMainLooper()
+        scenario.moveToState(Lifecycle.State.STARTED)
+        scenario.onActivity { activity ->
+            FileUtils.installApk(File(MY_PACKAGE), activity)
+            await().atMost(10, TimeUnit.SECONDS).until {
+                ShadowToast.getLatestToast() != null
+            }
+            assertEquals(
+                activity.getString(R.string.error_google_play_cannot_update_myself),
+                ShadowToast.getTextOfLatestToast()
+            )
+        }.also {
+            scenario.moveToState(Lifecycle.State.DESTROYED)
+            scenario.close()
+        }
+    }
+
+    /**
+     * Test invalid package specified for installation.
+     */
+    @Test
+    fun testInstallApkInvalidPackage() {
+        val scenario = ActivityScenario.launch(MainActivity::class.java)
+
+        ShadowLooper.idleMainLooper()
+        scenario.moveToState(Lifecycle.State.STARTED)
+        scenario.onActivity { activity ->
+            FileUtils.installApk(File(INVALID_PACKAGE), activity)
+            await().atMost(10, TimeUnit.SECONDS).until {
+                ShadowToast.getLatestToast() != null
+            }
+            assertEquals(
+                activity.getString(R.string.error_cannot_get_package_info, INVALID_PACKAGE),
+                ShadowToast.getTextOfLatestToast()
+            )
+        }.also {
+            scenario.moveToState(Lifecycle.State.DESTROYED)
+            scenario.close()
+        }
+    }
+}


### PR DESCRIPTION
## Description

Latest Google Play policy requires apps to block any attempts to update itself, either via online update or even allow user to install update over itself by allowing user to specify the apk to install. This change implements this restriction.

Details [here](https://www.androidpolice.com/google-firms-up-play-store-rules-for-which-apps-can-install-other-apps/).

Only Google Play release variant is affected; F-Droid variant can still do this.

Thanks to our user for the tipping!

#### Automatic tests
<!-- remember to do manual testing when making UI changes! -->
- [x] Added test cases (Should only run with play release variant builds)
  
#### Manual tests
- [x] Done  
  
- Device: Pixel 2 emulator
- OS: Android 11
Toast should pop up if attempt to install Amaze's own apk from within Amaze (Play release variant)

#### Build tasks success  
Successfully running following tasks on local:
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`