### PR TITLE
Implement cache for improved listing performance

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/asynchronous/handlers/FileHandler.kt
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/handlers/FileHandler.kt
@@ -101,6 +101,9 @@ class FileHandler(
             // there was no list view, means the directory was empty
             main.loadlist(main.currentPath, true, mainFragmentViewModel.openMode)
         }
+        main.currentPath?.let {
+            main.mainFragmentViewModel?.evictPathFromListCache(it)
+        }
         main.computeScroll()
     }
 }

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/handlers/FileHandler.kt
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/handlers/FileHandler.kt
@@ -102,7 +102,7 @@ class FileHandler(
             main.loadlist(main.currentPath, true, mainFragmentViewModel.openMode)
         }
         main.currentPath?.let {
-            main.mainFragmentViewModel?.evictPathFromListCache(it)
+            main.mainActivityViewModel?.evictPathFromListCache(it)
         }
         main.computeScroll()
     }

--- a/app/src/main/java/com/amaze/filemanager/filesystem/root/ListFilesCommand.kt
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/root/ListFilesCommand.kt
@@ -79,6 +79,9 @@ object ListFilesCommand : IRootCommand() {
         openModeCallback(mode)
     }
 
+    /**
+     * Get open mode for path if it's a root path or normal storage
+     */
     fun getOpenMode(
         path: String,
         root: Boolean

--- a/app/src/main/java/com/amaze/filemanager/filesystem/root/ListFilesCommand.kt
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/root/ListFilesCommand.kt
@@ -79,6 +79,20 @@ object ListFilesCommand : IRootCommand() {
         openModeCallback(mode)
     }
 
+    fun getOpenMode(
+        path: String,
+        root: Boolean
+    ): OpenMode {
+        val mode: OpenMode = if (root && FileUtils.isRunningAboveStorage(path)) {
+            OpenMode.ROOT
+        } else if (FileUtils.canListFiles(File(path))) {
+            OpenMode.FILE
+        } else {
+            OpenMode.FILE
+        }
+        return mode
+    }
+
     /**
      * executes list files root command directory and return each line item
      * returns pair with first denoting the result array and second if run with ls (true) or stat (false)

--- a/app/src/main/java/com/amaze/filemanager/filesystem/root/ListFilesCommand.kt
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/root/ListFilesCommand.kt
@@ -88,8 +88,6 @@ object ListFilesCommand : IRootCommand() {
     ): OpenMode {
         val mode: OpenMode = if (root && FileUtils.isRunningAboveStorage(path)) {
             OpenMode.ROOT
-        } else if (FileUtils.canListFiles(File(path))) {
-            OpenMode.FILE
         } else {
             OpenMode.FILE
         }

--- a/app/src/main/java/com/amaze/filemanager/ui/activities/MainActivityViewModel.kt
+++ b/app/src/main/java/com/amaze/filemanager/ui/activities/MainActivityViewModel.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2014-2022 Arpit Khurana <arpitkh96@gmail.com>, Vishal Nehra <vishalmeham2@gmail.com>,
+ * Emmanuel Messulam<emmanuelbendavid@gmail.com>, Raymond Lai <airwave209gt at gmail.com> and Contributors.
+ *
+ * This file is part of Amaze File Manager.
+ *
+ * Amaze File Manager is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.amaze.filemanager.ui.activities
+
+import android.app.Application
+import androidx.collection.LruCache
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import com.amaze.filemanager.adapters.data.LayoutElementParcelable
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+
+class MainActivityViewModel(val applicationContext: Application) :
+    AndroidViewModel(applicationContext) {
+
+    var mediaCacheHash: List<ArrayList<LayoutElementParcelable>?> = List(5) { null }
+    var listCache: LruCache<String, ArrayList<LayoutElementParcelable>> = LruCache(50)
+
+    companion object {
+        /**
+         * size of list to be cached for local files
+         */
+        val CACHE_LOCAL_LIST_THRESHOLD: Int = 100
+    }
+
+    /**
+     * Put list for a given path in cache
+     */
+    fun putInCache(path: String, listToCache: ArrayList<LayoutElementParcelable>) {
+        viewModelScope.launch(Dispatchers.Default) {
+            listCache.put(path, listToCache)
+        }
+    }
+
+    /**
+     * Removes cache for a given path
+     */
+    fun evictPathFromListCache(path: String) {
+        viewModelScope.launch(Dispatchers.Default) {
+            listCache.remove(path)
+        }
+    }
+
+    /**
+     * Get cache from a given path and updates files / folder count
+     */
+    fun getFromListCache(path: String): ArrayList<LayoutElementParcelable>? {
+        return listCache.get(path)
+    }
+
+    /**
+     * Get cache from a given path and updates files / folder count
+     */
+    fun getFromMediaFilesCache(mediaType: Int): ArrayList<LayoutElementParcelable>? {
+        return mediaCacheHash[mediaType]
+    }
+}

--- a/app/src/main/java/com/amaze/filemanager/ui/fragments/MainFragment.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/fragments/MainFragment.java
@@ -228,11 +228,13 @@ public class MainFragment extends Fragment
     mSwipeRefreshLayout = rootView.findViewById(R.id.activity_main_swipe_refresh_layout);
 
     mSwipeRefreshLayout.setOnRefreshListener(
-        () ->
-            loadlist(
-                (mainFragmentViewModel.getCurrentPath()),
-                false,
-                mainFragmentViewModel.getOpenMode()));
+        () -> {
+          //          loadlist(
+          //                  (mainFragmentViewModel.getCurrentPath()),
+          //                  false,
+          //                  mainFragmentViewModel.getOpenMode());
+          updateList();
+        });
 
     // String itemsstring = res.getString(R.string.items);// TODO: 23/5/2017 use or delete
     mToolbarContainer.setBackgroundColor(
@@ -380,7 +382,9 @@ public class MainFragment extends Fragment
           // load the list on a load broadcast
           // local file system don't need an explicit load, we've set an observer to
           // take actions on creation/moving/deletion/modification of file on current path
-
+          if (getCurrentPath() != null) {
+            mainFragmentViewModel.evictPathFromListCache(getCurrentPath());
+          }
           updateList();
         }
       };

--- a/app/src/main/java/com/amaze/filemanager/ui/fragments/MainFragment.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/fragments/MainFragment.java
@@ -227,14 +227,7 @@ public class MainFragment extends Fragment
 
     mSwipeRefreshLayout = rootView.findViewById(R.id.activity_main_swipe_refresh_layout);
 
-    mSwipeRefreshLayout.setOnRefreshListener(
-        () -> {
-          //          loadlist(
-          //                  (mainFragmentViewModel.getCurrentPath()),
-          //                  false,
-          //                  mainFragmentViewModel.getOpenMode());
-          updateList();
-        });
+    mSwipeRefreshLayout.setOnRefreshListener(this::updateList);
 
     // String itemsstring = res.getString(R.string.items);// TODO: 23/5/2017 use or delete
     mToolbarContainer.setBackgroundColor(

--- a/app/src/main/java/com/amaze/filemanager/ui/fragments/MainFragment.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/fragments/MainFragment.java
@@ -63,6 +63,7 @@ import com.amaze.filemanager.filesystem.files.EncryptDecryptUtils;
 import com.amaze.filemanager.filesystem.files.FileListSorter;
 import com.amaze.filemanager.filesystem.files.FileUtils;
 import com.amaze.filemanager.ui.activities.MainActivity;
+import com.amaze.filemanager.ui.activities.MainActivityViewModel;
 import com.amaze.filemanager.ui.dialogs.GeneralDialogCreation;
 import com.amaze.filemanager.ui.drag.RecyclerAdapterDragListener;
 import com.amaze.filemanager.ui.drag.TabFragmentBottomDragListener;
@@ -160,6 +161,7 @@ public class MainFragment extends Fragment
   // private int mCurrentTab;
 
   private MainFragmentViewModel mainFragmentViewModel;
+  private MainActivityViewModel mainActivityViewModel;
 
   private ActivityResultLauncher<Intent> handleDocumentUriForRestrictedDirectories =
       registerForActivityResult(
@@ -181,6 +183,8 @@ public class MainFragment extends Fragment
   public void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
     mainFragmentViewModel = new ViewModelProvider(this).get(MainFragmentViewModel.class);
+    mainActivityViewModel =
+        new ViewModelProvider(requireMainActivity()).get(MainActivityViewModel.class);
 
     utilsProvider = getMainActivity().getUtilsProvider();
     sharedPref = PreferenceManager.getDefaultSharedPreferences(requireActivity());
@@ -376,7 +380,7 @@ public class MainFragment extends Fragment
           // local file system don't need an explicit load, we've set an observer to
           // take actions on creation/moving/deletion/modification of file on current path
           if (getCurrentPath() != null) {
-            mainFragmentViewModel.evictPathFromListCache(getCurrentPath());
+            mainActivityViewModel.evictPathFromListCache(getCurrentPath());
           }
           updateList();
         }
@@ -1555,7 +1559,23 @@ public class MainFragment extends Fragment
 
   public @Nullable MainFragmentViewModel getMainFragmentViewModel() {
     if (isAdded()) {
-      return new ViewModelProvider(this).get(MainFragmentViewModel.class);
+      if (mainFragmentViewModel == null) {
+        mainFragmentViewModel = new ViewModelProvider(this).get(MainFragmentViewModel.class);
+      }
+      return mainFragmentViewModel;
+    } else {
+      LOG.error("Failed to get viewmodel, fragment not yet added");
+      return null;
+    }
+  }
+
+  public @Nullable MainActivityViewModel getMainActivityViewModel() {
+    if (isAdded()) {
+      if (mainActivityViewModel == null) {
+        mainActivityViewModel =
+            new ViewModelProvider(requireMainActivity()).get(MainActivityViewModel.class);
+      }
+      return mainActivityViewModel;
     } else {
       LOG.error("Failed to get viewmodel, fragment not yet added");
       return null;

--- a/app/src/main/java/com/amaze/filemanager/ui/fragments/data/MainFragmentViewModel.kt
+++ b/app/src/main/java/com/amaze/filemanager/ui/fragments/data/MainFragmentViewModel.kt
@@ -22,7 +22,6 @@ package com.amaze.filemanager.ui.fragments.data
 
 import android.content.SharedPreferences
 import android.os.Bundle
-import androidx.collection.LruCache
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -47,13 +46,6 @@ class MainFragmentViewModel : ViewModel() {
 
     /** This is not an exact copy of the elements in the adapter  */
     var listElements = ArrayList<LayoutElementParcelable>()
-
-    var storageImages: ArrayList<LayoutElementParcelable>? = null
-    var storageVideos: ArrayList<LayoutElementParcelable>? = null
-    var storageAudios: ArrayList<LayoutElementParcelable>? = null
-    var storageDocs: ArrayList<LayoutElementParcelable>? = null
-    var storageApks: ArrayList<LayoutElementParcelable>? = null
-    var listCache: LruCache<String, ArrayList<LayoutElementParcelable>> = LruCache(50)
 
     var adapterListItems: ArrayList<RecyclerAdapter.ListItem>? = null
     var iconList: ArrayList<IconDataParcelable>? = null
@@ -102,13 +94,6 @@ class MainFragmentViewModel : ViewModel() {
     var primaryTwoColor = 0
     var stopAnims = true
 
-    companion object {
-        /**
-         * size of list to be cached for local files
-         */
-        val CACHE_LOCAL_LIST_THRESHOLD: Int = 100
-    }
-
     /**
      * Initialize arguemnts from bundle in MainFragment
      */
@@ -137,39 +122,6 @@ class MainFragmentViewModel : ViewModel() {
                 }
             }
         }
-    }
-
-    /**
-     * Put list for a given path in cache
-     */
-    fun putInCache(path: String, listToCache: ArrayList<LayoutElementParcelable>) {
-        viewModelScope.launch(Dispatchers.Default) {
-            listCache.put(path, listToCache)
-        }
-    }
-
-    /**
-     * Removes cache for a given path
-     */
-    fun evictPathFromListCache(path: String) {
-        viewModelScope.launch(Dispatchers.Default) {
-            listCache.remove(path)
-        }
-    }
-
-    /**
-     * Get cache from a given path and updates files / folder count
-     */
-    fun getFromListCache(path: String): ArrayList<LayoutElementParcelable>? {
-        val cacheList = listCache.get(path)
-        cacheList?.forEach {
-            if (it.isDirectory) {
-                folderCount++
-            } else {
-                fileCount++
-            }
-        }
-        return cacheList
     }
 
     /**

--- a/app/src/main/java/com/amaze/filemanager/ui/fragments/data/MainFragmentViewModel.kt
+++ b/app/src/main/java/com/amaze/filemanager/ui/fragments/data/MainFragmentViewModel.kt
@@ -139,18 +139,27 @@ class MainFragmentViewModel : ViewModel() {
         }
     }
 
+    /**
+     * Put list for a given path in cache
+     */
     fun putInCache(path: String, listToCache: ArrayList<LayoutElementParcelable>) {
         viewModelScope.launch(Dispatchers.Default) {
             listCache.put(path, listToCache)
         }
     }
 
+    /**
+     * Removes cache for a given path
+     */
     fun evictPathFromListCache(path: String) {
         viewModelScope.launch(Dispatchers.Default) {
             listCache.remove(path)
         }
     }
 
+    /**
+     * Get cache from a given path and updates files / folder count
+     */
     fun getFromListCache(path: String): ArrayList<LayoutElementParcelable>? {
         val cacheList = listCache.get(path)
         cacheList?.forEach {


### PR DESCRIPTION
<!-- 
Read this first:
To open a pull request read this file,
uncomment the corresponding lines and 
complete them.
-->

## Description
Adds a LruCache for local paths, document files, smb / sftp and cloud storages i.e. least recently visited path will be removed.
For local paths, adds to cache only if list size is > 100 files.
For all other open modes cache is added regardless of list size
Lru Cache size is 50 paths for now. 

Also builds separate cache for images / videos / music / documents / apks that are accessed from navigation drawer so that we don't spend time loading them again and again.

#### Issue tracker   
<!-- Fixes will automatically close the related issue -->
<!-- Fixes # -->
<!-- Addresses won't automatically close the related issue -->
<!-- Addresses # -->

#### Automatic tests
<!-- remember to do manual testing when making UI changes! -->
- [ ] Added test cases
  
#### Manual tests
- [x] Done  
  
<!-- If yes, -->
<!-- 
- Device:
- OS:
-->

#### Build tasks success  
<!-- run these! -->
Successfully running following tasks on local:
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`

<!-- If there are related PRs please add them here -->
<!--
#### Related PR  
Related to PR #
-->