### PR TITLE
Fix failing Espresso tests

### DIFF
--- a/app/src/androidTest/java/com/amaze/filemanager/database/UtilsHandlerTest.java
+++ b/app/src/androidTest/java/com/amaze/filemanager/database/UtilsHandlerTest.java
@@ -137,6 +137,6 @@ public class UtilsHandlerTest {
     assertEquals(encryptedPath, result.get(0)[1]);
     assertEquals(
         "00:11:22:33:44:55:66:77:88:99:aa:bb:cc:dd:ee:ff",
-        utilsHandler.getSshHostKey(encryptedPath));
+        utilsHandler.getRemoteHostKey(encryptedPath));
   }
 }

--- a/app/src/androidTest/java/com/amaze/filemanager/filesystem/files/CryptUtilTest.java
+++ b/app/src/androidTest/java/com/amaze/filemanager/filesystem/files/CryptUtilTest.java
@@ -30,6 +30,7 @@ import com.amaze.filemanager.BuildConfig;
 import com.amaze.filemanager.utils.PasswordUtil;
 
 import android.content.Context;
+import android.util.Base64;
 
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.platform.app.InstrumentationRegistry;
@@ -52,7 +53,8 @@ public class CryptUtilTest {
   @Test
   public void testEncryptDecrypt() throws Exception {
     String password = "hackme";
-    String encrypted = PasswordUtil.INSTANCE.encryptPassword(context, password);
-    assertEquals(password, PasswordUtil.INSTANCE.decryptPassword(context, encrypted));
+    String encrypted = PasswordUtil.INSTANCE.encryptPassword(context, password, Base64.URL_SAFE);
+    assertEquals(
+        password, PasswordUtil.INSTANCE.decryptPassword(context, encrypted, Base64.URL_SAFE));
   }
 }

--- a/app/src/androidTest/java/com/amaze/filemanager/ssh/SshClientUtilTest.java
+++ b/app/src/androidTest/java/com/amaze/filemanager/ssh/SshClientUtilTest.java
@@ -46,7 +46,7 @@ public class SshClientUtilTest {
     String result = NetCopyClientUtils.INSTANCE.encryptFtpPathAsNecessary(uri);
     assertTrue(result.contains("ssh://testuser:"));
     assertTrue(result.contains("@127.0.0.1:22"));
-    String verify = NetCopyClientUtils.INSTANCE.encryptFtpPathAsNecessary(result);
+    String verify = NetCopyClientUtils.INSTANCE.decryptFtpPathAsNecessary(result);
     assertEquals(uri, verify);
   }
 
@@ -56,7 +56,7 @@ public class SshClientUtilTest {
     String result = NetCopyClientUtils.INSTANCE.encryptFtpPathAsNecessary(uri);
     assertTrue(result.contains("ssh://testuser:"));
     assertTrue(result.contains("@127.0.0.1:22"));
-    String verify = NetCopyClientUtils.INSTANCE.encryptFtpPathAsNecessary(result);
+    String verify = NetCopyClientUtils.INSTANCE.decryptFtpPathAsNecessary(result);
     assertEquals(uri, verify);
   }
 
@@ -66,7 +66,7 @@ public class SshClientUtilTest {
     String result = NetCopyClientUtils.INSTANCE.encryptFtpPathAsNecessary(uri);
     assertTrue(result.contains("ssh://testuser:"));
     assertTrue(result.contains("@127.0.0.1:22"));
-    String verify = NetCopyClientUtils.INSTANCE.encryptFtpPathAsNecessary(result);
+    String verify = NetCopyClientUtils.INSTANCE.decryptFtpPathAsNecessary(result);
     assertEquals(uri, verify);
   }
 
@@ -76,7 +76,7 @@ public class SshClientUtilTest {
     String result = NetCopyClientUtils.INSTANCE.encryptFtpPathAsNecessary(uri);
     assertTrue(result.contains("ssh://testuser:"));
     assertTrue(result.contains("@127.0.0.1:22"));
-    String verify = NetCopyClientUtils.INSTANCE.encryptFtpPathAsNecessary(result);
+    String verify = NetCopyClientUtils.INSTANCE.decryptFtpPathAsNecessary(result);
     assertEquals(uri, verify);
   }
 }


### PR DESCRIPTION
## Description

Fix current `hotfix/3.8.1` branch (#3485).

Also fix NetCopyClientUtils.encryptFtpPathAsNecessary() detection of encrypted passwords using Base64-encoded string suffix.

#### Issue tracker   
Addresses #3485
  
#### Manual tests
- [x] Done  

- Device: Pixel 2 emulator
- OS: Android 9

`gradlew connectedCheck` failures seen in #3485 should be fine by now.  

#### Build tasks success  
Successfully running following tasks on local:
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`

#### Related PR  
Related to PR #3485