### PR TITLE
Check working directory and change to root before listing files

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/filesystem/root/ListFilesCommand.kt
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/root/ListFilesCommand.kt
@@ -124,6 +124,12 @@ object ListFilesCommand : IRootCommand() {
                         PreferencesConstants.PREFERENCE_ROOT_LEGACY_LISTING,
                         false
                     )
+            // #3476: Check current working dir, change back to / before proceeding
+            runShellCommand("pwd").run {
+                if (out.first() != "/") {
+                    runShellCommand("cd /")
+                }
+            }
             return if (!retryWithLs && !enforceLegacyFileListing) {
                 log.info("Using stat for list parsing")
                 Pair(

--- a/app/src/test/java/com/amaze/filemanager/filesystem/root/ListFilesCommandTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/filesystem/root/ListFilesCommandTest.kt
@@ -32,6 +32,7 @@ import com.amaze.filemanager.filesystem.HybridFileParcelable
 import com.amaze.filemanager.shadows.ShadowMultiDex
 import com.amaze.filemanager.test.ShadowNativeOperations
 import com.amaze.filemanager.ui.fragments.preferencefragments.PreferencesConstants
+import com.topjohnwu.superuser.Shell
 import io.mockk.every
 import io.mockk.mockkObject
 import org.junit.Assert.assertEquals
@@ -90,6 +91,13 @@ class ListFilesCommandTest {
         every {
             ListFilesCommand.executeRootCommand(anyString(), anyBoolean(), anyBoolean())
         } answers { callOriginal() }
+        every { ListFilesCommand.runShellCommand("pwd") }.answers {
+            object : Shell.Result() {
+                override fun getOut(): MutableList<String> = listOf("/").toMutableList()
+                override fun getErr(): MutableList<String> = emptyList<String>().toMutableList()
+                override fun getCode(): Int = 0
+            }
+        }
         every { ListFilesCommand.runShellCommandToList("ls -l \"/bin\"") } answers { lsLines }
         every { ListFilesCommand.runShellCommandToList("ls -l \"/\"") } answers { lsRootLines }
         every {

--- a/app/src/test/java/com/amaze/filemanager/filesystem/root/ListFilesCommandTest2.kt
+++ b/app/src/test/java/com/amaze/filemanager/filesystem/root/ListFilesCommandTest2.kt
@@ -34,6 +34,7 @@ import com.amaze.filemanager.shadows.ShadowMultiDex
 import com.amaze.filemanager.test.ShadowNativeOperations
 import com.amaze.filemanager.test.TestUtils
 import com.amaze.filemanager.ui.fragments.preferencefragments.PreferencesConstants
+import com.topjohnwu.superuser.Shell
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Before
@@ -90,6 +91,13 @@ class ListFilesCommandTest2 {
                 anyBoolean()
             )
         ).thenCallRealMethod()
+        `when`(mockCommand.runShellCommand("pwd")).thenReturn(
+            object : Shell.Result() {
+                override fun getOut(): MutableList<String> = listOf("/").toMutableList()
+                override fun getErr(): MutableList<String> = emptyList<String>().toMutableList()
+                override fun getCode(): Int = 0
+            }
+        )
         `when`(mockCommand.runShellCommandToList("ls -l \"/bin\"")).thenReturn(lsLines)
         `when`(
             mockCommand.runShellCommandToList(


### PR DESCRIPTION
## Description
Also fixes line parsing of filenames having colons as I work on, listing files under `/dev`.

#### Issue tracker   
Fixes #3476 

#### Automatic tests
- [ ] Added test cases
  
#### Manual tests
- [ ] Done  
  
#### Build tasks success  
<!-- run these! -->
Successfully running following tasks on local:
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`