### PR TITLE
Fix ExtractService use of Context

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/asynchronous/services/ExtractService.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/services/ExtractService.java
@@ -64,8 +64,6 @@ import androidx.preference.PreferenceManager;
 
 public class ExtractService extends AbstractProgressiveService {
 
-  Context context;
-
   private final Logger LOG = LoggerFactory.getLogger(ExtractService.class);
   private final IBinder mBinder = new ObtainableServiceBinder<>(this);
 
@@ -89,7 +87,6 @@ public class ExtractService extends AbstractProgressiveService {
   public void onCreate() {
     super.onCreate();
     registerReceiver(receiver1, new IntentFilter(TAG_BROADCAST_EXTRACT_CANCEL));
-    context = getApplicationContext();
   }
 
   @Override
@@ -99,7 +96,7 @@ public class ExtractService extends AbstractProgressiveService {
     String[] entries = intent.getStringArrayExtra(KEY_ENTRIES_ZIP);
 
     mNotifyManager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
-    sharedPreferences = PreferenceManager.getDefaultSharedPreferences(context);
+    sharedPreferences = PreferenceManager.getDefaultSharedPreferences(getApplicationContext());
     accentColor =
         ((AppConfig) getApplication())
             .getUtilsProvider()
@@ -118,12 +115,15 @@ public class ExtractService extends AbstractProgressiveService {
 
     Intent stopIntent = new Intent(TAG_BROADCAST_EXTRACT_CANCEL);
     PendingIntent stopPendingIntent =
-        PendingIntent.getBroadcast(context, 1234, stopIntent, PendingIntent.FLAG_UPDATE_CURRENT);
+        PendingIntent.getBroadcast(
+            getApplicationContext(), 1234, stopIntent, PendingIntent.FLAG_UPDATE_CURRENT);
     NotificationCompat.Action action =
         new NotificationCompat.Action(
             R.drawable.ic_zip_box_grey, getString(R.string.stop_ftp), stopPendingIntent);
 
-    mBuilder = new NotificationCompat.Builder(context, NotificationConstants.CHANNEL_NORMAL_ID);
+    mBuilder =
+        new NotificationCompat.Builder(
+            getApplicationContext(), NotificationConstants.CHANNEL_NORMAL_ID);
     mBuilder
         .setContentIntent(pendingIntent)
         .setSmallIcon(R.drawable.ic_zip_box_grey)
@@ -312,7 +312,10 @@ public class ExtractService extends AbstractProgressiveService {
                 ServiceWatcherUtil.UPDATE_POSITION);
 
         if (extractor == null) {
-          Toast.makeText(context, R.string.error_cant_decompress_that_file, Toast.LENGTH_LONG)
+          Toast.makeText(
+                  getApplicationContext(),
+                  R.string.error_cant_decompress_that_file,
+                  Toast.LENGTH_LONG)
               .show();
           return false;
         }
@@ -327,13 +330,13 @@ public class ExtractService extends AbstractProgressiveService {
         } catch (Extractor.EmptyArchiveNotice e) {
           LOG.error("Archive " + compressedPath + " is an empty archive");
           AppConfig.toast(
-              extractService,
+              getApplicationContext(),
               extractService.getString(R.string.error_empty_archive, compressedPath));
           return true;
         } catch (Extractor.BadArchiveNotice e) {
           LOG.error("Archive " + compressedPath + " is a corrupted archive.", e);
           AppConfig.toast(
-              extractService,
+              getApplicationContext(),
               e.getCause() != null && TextUtils.isEmpty(e.getCause().getMessage())
                   ? getString(R.string.error_bad_archive_without_info, compressedPath)
                   : getString(
@@ -348,7 +351,7 @@ public class ExtractService extends AbstractProgressiveService {
             if (ArchivePasswordCache.getInstance().containsKey(compressedPath)) {
               ArchivePasswordCache.getInstance().remove(compressedPath);
               AppConfig.toast(
-                  extractService,
+                  getApplicationContext(),
                   extractService.getString(R.string.error_archive_password_incorrect));
             }
             passwordProtected = true;
@@ -358,12 +361,12 @@ public class ExtractService extends AbstractProgressiveService {
               && UnsupportedRarV5Exception.class.isAssignableFrom(e.getCause().getClass())) {
             LOG.error("RAR " + compressedPath + " is unsupported V5 archive", e);
             AppConfig.toast(
-                extractService,
+                getApplicationContext(),
                 extractService.getString(R.string.error_unsupported_v5_rar, compressedPath));
             return false;
           } else {
             LOG.error("Error while extracting file " + compressedPath, e);
-            AppConfig.toast(extractService, extractService.getString(R.string.error));
+            AppConfig.toast(getApplicationContext(), extractService.getString(R.string.error));
             paused = true;
             publishProgress(e);
           }
@@ -382,7 +385,7 @@ public class ExtractService extends AbstractProgressiveService {
       IOException result = values[0];
       ArchivePasswordCache.getInstance().remove(compressedPath);
       GeneralDialogCreation.showPasswordDialog(
-          AppConfig.getInstance().getMainActivityContext(),
+          getApplicationContext(),
           (MainActivity) AppConfig.getInstance().getMainActivityContext(),
           AppConfig.getInstance().getUtilsProvider().getAppTheme(),
           R.string.archive_password_prompt,
@@ -419,7 +422,8 @@ public class ExtractService extends AbstractProgressiveService {
       extractService.stopSelf();
 
       if (!hasInvalidEntries)
-        AppConfig.toast(extractService, getString(R.string.multiple_invalid_archive_entries));
+        AppConfig.toast(
+            getApplicationContext(), getString(R.string.multiple_invalid_archive_entries));
     }
 
     @Override
@@ -430,7 +434,7 @@ public class ExtractService extends AbstractProgressiveService {
 
     private void toastOnParseError(IOException result) {
       Toast.makeText(
-              AppConfig.getInstance().getMainActivityContext(),
+              getApplicationContext(),
               AppConfig.getInstance()
                   .getResources()
                   .getString(

--- a/app/src/test/java/com/amaze/filemanager/asynchronous/services/ExtractServiceTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/asynchronous/services/ExtractServiceTest.kt
@@ -22,17 +22,23 @@ package com.amaze.filemanager.asynchronous.services
 
 import android.content.Context
 import android.content.Intent
-import android.os.Build.VERSION_CODES.JELLY_BEAN
-import android.os.Build.VERSION_CODES.KITKAT
+import android.os.Build.VERSION.SDK_INT
+import android.os.Build.VERSION_CODES.N
 import android.os.Build.VERSION_CODES.P
 import android.os.Environment
+import androidx.lifecycle.Lifecycle
+import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.amaze.filemanager.R
+import com.amaze.filemanager.application.AppConfig
 import com.amaze.filemanager.fileoperations.filesystem.compressed.ArchivePasswordCache
 import com.amaze.filemanager.shadows.ShadowMultiDex
+import com.amaze.filemanager.test.ShadowTabHandler
+import com.amaze.filemanager.test.TestUtils
 import com.amaze.filemanager.test.randomBytes
 import com.amaze.filemanager.test.supportedArchiveExtensions
+import com.amaze.filemanager.ui.activities.MainActivity
 import org.awaitility.Awaitility.await
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -59,7 +65,7 @@ import java.nio.file.Paths
 import java.util.concurrent.TimeUnit
 
 @RunWith(AndroidJUnit4::class)
-@Config(shadows = [ShadowMultiDex::class], sdk = [JELLY_BEAN, KITKAT, P])
+@Config(shadows = [ShadowMultiDex::class, ShadowTabHandler::class], sdk = [P])
 @LooperMode(LooperMode.Mode.PAUSED)
 @Suppress("TooManyFunctions", "StringLiteralDuplication")
 class ExtractServiceTest {
@@ -113,6 +119,7 @@ class ExtractServiceTest {
     }
 
     private lateinit var service: ExtractService
+    private lateinit var scenario: ActivityScenario<MainActivity>
 
     /**
      * Copy archives to storage.
@@ -159,6 +166,9 @@ class ExtractServiceTest {
         ShadowToast.reset()
 
         service = Robolectric.setupService(ExtractService::class.java)
+        if (SDK_INT >= N) TestUtils.initializeInternalStorage()
+        scenario = ActivityScenario.launch(MainActivity::class.java)
+        scenario.moveToState(Lifecycle.State.STARTED)
     }
 
     /**
@@ -177,6 +187,7 @@ class ExtractServiceTest {
         }
         service.stopSelf()
         service.onDestroy()
+        scenario.close()
     }
 
     /**
@@ -430,14 +441,18 @@ class ExtractServiceTest {
     }
 
     private fun performTest(archiveFile: File) {
-        val intent = Intent(ApplicationProvider.getApplicationContext(), ExtractService::class.java)
-            .putExtra(ExtractService.KEY_PATH_ZIP, archiveFile.absolutePath)
-            .putExtra(ExtractService.KEY_ENTRIES_ZIP, arrayOfNulls<String>(0))
-            .putExtra(
-                ExtractService.KEY_PATH_EXTRACT,
-                File(Environment.getExternalStorageDirectory(), "test-archive")
-                    .absolutePath
-            )
-        service.onStartCommand(intent, 0, 0)
+        scenario.onActivity { activity ->
+            AppConfig.getInstance().setMainActivityContext(activity)
+            val intent =
+                Intent(ApplicationProvider.getApplicationContext(), ExtractService::class.java)
+                    .putExtra(ExtractService.KEY_PATH_ZIP, archiveFile.absolutePath)
+                    .putExtra(ExtractService.KEY_ENTRIES_ZIP, arrayOfNulls<String>(0))
+                    .putExtra(
+                        ExtractService.KEY_PATH_EXTRACT,
+                        File(Environment.getExternalStorageDirectory(), "test-archive")
+                            .absolutePath
+                    )
+            service.onStartCommand(intent, 0, 0)
+        }
     }
 }


### PR DESCRIPTION
## Description
- Toast uses getApplicationContext() instead of provided ones or ExtractService itself, which caused ExtractServiceTest to fail after timeout ~~when built with Gradle 7.4~~ under certain setups
- Remove unnecessary reference to Context as local variable

#### Automatic tests
- [ ] Added test cases
  
#### Manual tests
- [x] Done  
  
Devices:
- Pixel 2 emulator running Android 9.0
- Galaxy Nexus emulator running Android 4.4
- Nexus 4 emulator running Android 5.1

#### Build tasks success  
Successfully running following tasks on local:
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`

#### Related PR  
Related to PR #3228