### PR TITLE
Use Completable instead of Flowable to refresh Drawer

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/ui/views/drawer/Drawer.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/views/drawer/Drawer.java
@@ -80,7 +80,6 @@ import android.content.ActivityNotFoundException;
 import android.content.Intent;
 import android.content.res.ColorStateList;
 import android.content.res.Configuration;
-import android.content.res.Resources;
 import android.graphics.Color;
 import android.os.Build;
 import android.text.TextUtils;
@@ -121,7 +120,6 @@ public class Drawer implements NavigationView.OnNavigationItemSelectedListener {
   };
 
   @NonNull private final MainActivity mainActivity;
-  private Resources resources;
   private DataUtils dataUtils;
 
   private ActionViewStateManager actionViewStateManager;
@@ -150,7 +148,6 @@ public class Drawer implements NavigationView.OnNavigationItemSelectedListener {
 
   public Drawer(MainActivity mainActivity) {
     this.mainActivity = mainActivity;
-    resources = mainActivity.getResources();
     dataUtils = DataUtils.getInstance();
 
     drawerHeaderLayout = mainActivity.getLayoutInflater().inflate(R.layout.drawerheader, null);


### PR DESCRIPTION
## Description
Following suit from other parts of `MainActivity` to refresh `Drawer` after updating database.

Also refactored `MainActivity.addConnection()` to use `Completable` too to add entirely new SMB connection to drawer.

#### Issue tracker   
Fixes #3478

#### Automatic tests
- [ ] Added test cases
  
#### Manual tests
- [x] Done  
  
- Device: Pixel 6 emulator
- OS: Android 12

1. Add a bookmark
2. Open drawer
3. Tap the pen icon next to the newly created bookmark
4. Edit bookmark dialog opened
5. Tap **Delete**
6. Bookmark is deleted without app crash

#### Build tasks success  
Successfully running following tasks on local:
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`
