### PR TITLE
Disable FtpHybridFileTests at all

### DIFF
--- a/app/src/test/java/com/amaze/filemanager/filesystem/ftp/FtpHybridFileAnonymousLoginTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/filesystem/ftp/FtpHybridFileAnonymousLoginTest.kt
@@ -26,10 +26,12 @@ import org.apache.ftpserver.ConnectionConfigFactory
 import org.apache.ftpserver.FtpServerFactory
 import org.apache.ftpserver.usermanager.impl.BaseUser
 import org.apache.ftpserver.usermanager.impl.WritePermission
+import org.junit.Ignore
 
 /**
  * Test [HybridFile] FTP protocol handling with anonymous logins.
  */
+@Ignore
 class FtpHybridFileAnonymousLoginTest : FtpHybridFileTest() {
 
     override val ftpPort: Int

--- a/app/src/test/java/com/amaze/filemanager/filesystem/ftp/FtpHybridFileTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/filesystem/ftp/FtpHybridFileTest.kt
@@ -64,6 +64,7 @@ import java.util.concurrent.TimeUnit
     shadows = [ShadowPasswordUtil::class, ShadowMultiDex::class]
 )
 @Suppress("StringLiteralDuplication")
+@Ignore
 open class FtpHybridFileTest {
 
     protected lateinit var tmpFile: File


### PR DESCRIPTION
After introducing FtpHybridFileTest and deriatives since #3405, test runs were getting more flaky, hence it may be a better idea to disable them for good for the time being, while working on an alternative solution to offload the daemons outside the build, e.g. to Docker.

Band-it fix for sure, but the fact that it runs smooth locally but not on Github Actions is really annoying.