### PR TITLE
Fix possible NPE when iterating through DocumentFile collection on listing files

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/ui/fragments/MainFragment.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/fragments/MainFragment.java
@@ -582,7 +582,7 @@ public class MainFragment extends Fragment
     String actualPath = FileProperties.remapPathForApi30OrAbove(providedPath, false);
 
     if (!providedPath.equals(actualPath) && SDK_INT >= Q) {
-      openMode = loadPathInQ(actualPath, providedPath, providedOpenMode);
+      openMode = loadPathInQ(actualPath, providedPath);
     }
     // Monkeypatch :( to fix problems with unexpected non content URI path while openMode is still
     // OpenMode.DOCUMENT_FILE
@@ -615,7 +615,7 @@ public class MainFragment extends Fragment
   }
 
   @RequiresApi(api = Q)
-  private OpenMode loadPathInQ(String actualPath, String providedPath, OpenMode providedMode) {
+  private OpenMode loadPathInQ(String actualPath, String providedPath) {
 
     boolean hasAccessToSpecialFolder = false;
     List<UriPermission> uriPermissions =
@@ -651,7 +651,10 @@ public class MainFragment extends Fragment
                 d.dismiss();
               });
       d.show();
-      return providedMode;
+      // At this point LoadFilesListTask will be triggered.
+      // No harm even give OpenMode.FILE here, it loads blank when it doesn't; and after the
+      // UriPermission is granted loadlist will be called again
+      return OpenMode.FILE;
     } else {
       return OpenMode.DOCUMENT_FILE;
     }

--- a/app/src/main/java/com/amaze/filemanager/utils/OTGUtil.kt
+++ b/app/src/main/java/com/amaze/filemanager/utils/OTGUtil.kt
@@ -112,7 +112,7 @@ object OTGUtil {
             if (part == "otg:" || part == "" || part == "content:") continue
 
             // iterating through the required path to find the end point
-            rootUri = rootUri?.findFile(part)
+            rootUri = rootUri?.findFile(part) ?: rootUri
         }
 
         if (rootUri == null) {
@@ -180,9 +180,9 @@ object OTGUtil {
             if (part == "otg:" || part == "" || part == "content:") continue
 
             // iterating through the required path to find the end point
-            var nextDocument = retval!!.findFile(part)
+            var nextDocument = retval?.findFile(part) ?: retval
             if (createRecursive && (nextDocument == null || !nextDocument.exists())) {
-                nextDocument = retval.createFile(part.substring(part.lastIndexOf(".")), part)
+                nextDocument = retval?.createFile(part.substring(part.lastIndexOf(".")), part)
             }
             retval = nextDocument
         }


### PR DESCRIPTION
## Description
As band-it solution.

Additionally, stay on OpenMode.FILE before ACTION_OPEN_DOCUMENT_TREE Intent returns. It is found in some cases the ACTION_OPEN_DOCUMENT_TREE Intent didn't block the app from accessing Android/data before UriPermission is granted. So stay on OpenMode.FILE when the intent launches.

**This does not fix problem of accessing `Android/data` on API33 however.**

#### Issue tracker   
Addresses #3038, #3533

#### Manual tests
- [x] Done  
  
- Device: Pixel 6 emulator
- OS: Android 12 (API31), Android 13 (API33)
No regression on accessing Android/data, but should without crashes

#### Build tasks success  
<!-- run these! -->
Successfully running following tasks on local:
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`