### PR TITLE
Add one more ID up on migrating Cloud connection entries

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/database/ExplorerDatabase.kt
+++ b/app/src/main/java/com/amaze/filemanager/database/ExplorerDatabase.kt
@@ -71,7 +71,7 @@ abstract class ExplorerDatabase : RoomDatabase() {
 
     companion object {
         private const val DATABASE_NAME = "explorer.db"
-        const val DATABASE_VERSION = 9
+        const val DATABASE_VERSION = 10
         const val TABLE_TAB = "tab"
         const val TABLE_CLOUD_PERSIST = "cloud"
         const val TABLE_ENCRYPTED = "encrypted"
@@ -280,7 +280,21 @@ abstract class ExplorerDatabase : RoomDatabase() {
                 )
             }
         }
-        internal val MIGRATION_8_9: Migration = object : Migration(8, DATABASE_VERSION) {
+        internal val MIGRATION_8_9: Migration = object : Migration(8, 9) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL(
+                    "UPDATE " +
+                        TABLE_CLOUD_PERSIST +
+                        " SET " +
+                        COLUMN_CLOUD_SERVICE +
+                        " = " +
+                        COLUMN_CLOUD_SERVICE +
+                        "+1"
+                )
+            }
+        }
+
+        internal val MIGRATION_9_10: Migration = object : Migration(9, DATABASE_VERSION) {
             override fun migrate(database: SupportSQLiteDatabase) {
                 database.execSQL(
                     "UPDATE " +
@@ -314,6 +328,7 @@ abstract class ExplorerDatabase : RoomDatabase() {
                 .addMigrations(MIGRATION_6_7)
                 .addMigrations(MIGRATION_7_8)
                 .addMigrations(MIGRATION_8_9)
+                .addMigrations(MIGRATION_9_10)
                 .allowMainThreadQueries()
                 .build()
         }

--- a/app/src/main/java/com/amaze/filemanager/database/typeconverters/EncryptedStringTypeConverter.kt
+++ b/app/src/main/java/com/amaze/filemanager/database/typeconverters/EncryptedStringTypeConverter.kt
@@ -20,6 +20,7 @@
 
 package com.amaze.filemanager.database.typeconverters
 
+import android.util.Base64
 import android.util.Log
 import androidx.room.TypeConverter
 import com.amaze.filemanager.application.AppConfig
@@ -49,7 +50,7 @@ object EncryptedStringTypeConverter {
     fun toPassword(encryptedStringEntryInDb: String): StringWrapper {
         return runCatching {
             StringWrapper(
-                decryptPassword(AppConfig.getInstance(), encryptedStringEntryInDb)
+                decryptPassword(AppConfig.getInstance(), encryptedStringEntryInDb, Base64.DEFAULT)
             )
         }.onFailure {
             Log.e(TAG, "Error decrypting password", it)
@@ -67,7 +68,8 @@ object EncryptedStringTypeConverter {
         return runCatching {
             encryptPassword(
                 AppConfig.getInstance(),
-                unencryptedPasswordString.value
+                unencryptedPasswordString.value,
+                Base64.DEFAULT
             )
         }.onFailure {
             Log.e(TAG, "Error encrypting password", it)

--- a/app/src/test/java/com/amaze/filemanager/database/ExplorerDatabaseMigrationTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/database/ExplorerDatabaseMigrationTest.kt
@@ -140,7 +140,7 @@ class ExplorerDatabaseMigrationTest {
                 "," +
                 ExplorerDatabase.COLUMN_CLOUD_PERSIST +
                 ") VALUES (1," +
-                (OpenMode.GDRIVE.ordinal - 2) +
+                (OpenMode.GDRIVE.ordinal - 3) +
                 ",'abcd')"
         )
         db.execSQL(
@@ -153,7 +153,7 @@ class ExplorerDatabaseMigrationTest {
                 "," +
                 ExplorerDatabase.COLUMN_CLOUD_PERSIST +
                 ") VALUES (2," +
-                (OpenMode.DROPBOX.ordinal - 2) +
+                (OpenMode.DROPBOX.ordinal - 3) +
                 ",'efgh')"
         )
         db.execSQL(
@@ -166,7 +166,7 @@ class ExplorerDatabaseMigrationTest {
                 "," +
                 ExplorerDatabase.COLUMN_CLOUD_PERSIST +
                 ") VALUES (3," +
-                (OpenMode.BOX.ordinal - 2) +
+                (OpenMode.BOX.ordinal - 3) +
                 ",'ijkl')"
         )
         db.execSQL(
@@ -179,7 +179,7 @@ class ExplorerDatabaseMigrationTest {
                 "," +
                 ExplorerDatabase.COLUMN_CLOUD_PERSIST +
                 ") VALUES (4," +
-                (OpenMode.ONEDRIVE.ordinal - 2) +
+                (OpenMode.ONEDRIVE.ordinal - 3) +
                 ",'mnop')"
         )
         db.close()
@@ -190,6 +190,7 @@ class ExplorerDatabaseMigrationTest {
         )
             .addMigrations(ExplorerDatabase.MIGRATION_7_8)
             .addMigrations(ExplorerDatabase.MIGRATION_8_9)
+            .addMigrations(ExplorerDatabase.MIGRATION_9_10)
             .allowMainThreadQueries()
             .build()
         explorerDatabase.openHelper.writableDatabase
@@ -241,7 +242,7 @@ class ExplorerDatabaseMigrationTest {
                 "," +
                 ExplorerDatabase.COLUMN_CLOUD_PERSIST +
                 ") VALUES (1," +
-                (OpenMode.GDRIVE.ordinal - 1) +
+                (OpenMode.GDRIVE.ordinal - 2) +
                 ",'abcd')"
         )
         db.execSQL(
@@ -254,7 +255,7 @@ class ExplorerDatabaseMigrationTest {
                 "," +
                 ExplorerDatabase.COLUMN_CLOUD_PERSIST +
                 ") VALUES (2," +
-                (OpenMode.DROPBOX.ordinal - 1) +
+                (OpenMode.DROPBOX.ordinal - 2) +
                 ",'efgh')"
         )
         db.execSQL(
@@ -267,7 +268,7 @@ class ExplorerDatabaseMigrationTest {
                 "," +
                 ExplorerDatabase.COLUMN_CLOUD_PERSIST +
                 ") VALUES (3," +
-                (OpenMode.BOX.ordinal - 1) +
+                (OpenMode.BOX.ordinal - 2) +
                 ",'ijkl')"
         )
         db.execSQL(
@@ -280,7 +281,7 @@ class ExplorerDatabaseMigrationTest {
                 "," +
                 ExplorerDatabase.COLUMN_CLOUD_PERSIST +
                 ") VALUES (4," +
-                (OpenMode.ONEDRIVE.ordinal - 1) +
+                (OpenMode.ONEDRIVE.ordinal - 2) +
                 ",'mnop')"
         )
         db.close()
@@ -290,6 +291,7 @@ class ExplorerDatabaseMigrationTest {
             TEST_DB
         )
             .addMigrations(ExplorerDatabase.MIGRATION_8_9)
+            .addMigrations(ExplorerDatabase.MIGRATION_9_10)
             .allowMainThreadQueries()
             .build()
         explorerDatabase.openHelper.writableDatabase

--- a/app/src/test/java/com/amaze/filemanager/database/typeconverters/EncryptedStringTypeConverterTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/database/typeconverters/EncryptedStringTypeConverterTest.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2014-2022 Arpit Khurana <arpitkh96@gmail.com>, Vishal Nehra <vishalmeham2@gmail.com>,
+ * Emmanuel Messulam<emmanuelbendavid@gmail.com>, Raymond Lai <airwave209gt at gmail.com> and Contributors.
+ *
+ * This file is part of Amaze File Manager.
+ *
+ * Amaze File Manager is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.amaze.filemanager.database.typeconverters
+
+import android.os.Build.VERSION_CODES.JELLY_BEAN
+import android.os.Build.VERSION_CODES.KITKAT
+import android.os.Build.VERSION_CODES.P
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.amaze.filemanager.database.models.StringWrapper
+import com.amaze.filemanager.shadows.ShadowMultiDex
+import com.amaze.filemanager.test.ShadowPasswordUtil
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+/**
+ * Test on [EncryptedStringTypeConverter] for sanity.
+ */
+@RunWith(AndroidJUnit4::class)
+@Config(
+    shadows = [ShadowMultiDex::class, ShadowPasswordUtil::class],
+    sdk = [JELLY_BEAN, KITKAT, P]
+)
+class EncryptedStringTypeConverterTest {
+
+    /**
+     * Test encrypt and decrypt capability.
+     */
+    @Test
+    fun testEncryptDecrypt() {
+        val password = "{ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789[]-=@#}"
+        val result = EncryptedStringTypeConverter.fromPassword(StringWrapper(password))
+        val verify = EncryptedStringTypeConverter.toPassword(result.toString())
+        assertEquals(password, verify.toString())
+    }
+}

--- a/app/src/test/resources/schemas/com.amaze.filemanager.database.ExplorerDatabase/10.json
+++ b/app/src/test/resources/schemas/com.amaze.filemanager.database.ExplorerDatabase/10.json
@@ -1,0 +1,136 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 10,
+    "identityHash": "06766b689063c1bcaa4d0df3fd06f5e6",
+    "entities": [
+      {
+        "tableName": "tab",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`tab_no` INTEGER NOT NULL, `path` TEXT, `home` TEXT, PRIMARY KEY(`tab_no`))",
+        "fields": [
+          {
+            "fieldPath": "tabNumber",
+            "columnName": "tab_no",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "path",
+            "columnName": "path",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "home",
+            "columnName": "home",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "tab_no"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "sort",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`path` TEXT NOT NULL, `type` INTEGER NOT NULL, PRIMARY KEY(`path`))",
+        "fields": [
+          {
+            "fieldPath": "path",
+            "columnName": "path",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "path"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "encrypted",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `path` TEXT, `password` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "_id",
+            "columnName": "_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "path",
+            "columnName": "path",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "password",
+            "columnName": "password",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "_id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "cloud",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `service` INTEGER, `persist` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "_id",
+            "columnName": "_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serviceType",
+            "columnName": "service",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "persistData",
+            "columnName": "persist",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "_id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '06766b689063c1bcaa4d0df3fd06f5e6')"
+    ]
+  }
+}


### PR DESCRIPTION
## Description

Also fixed problem with encrypted secrets in Cloud database, due to PasswordUtils encrypt strings with URI-safe Base64, while Cloud connection secrets are not. Fix by specifying Base64.DEFAULT on encrypt/decrypting secrets.

#### Issue tracker   
Fixes #3488 (again)

#### Automatic tests
- [x] Added test cases
  
#### Manual tests
- [x] Done  
  
- Device: Pixel 6 emulator
- OS: Android 13

Test steps
1. Install 3.7.2 and Cloud plugin
2. Setup Google Drive connection
3. Open the connection and verify the connection is working
4. Upgrade to `hotfix/3.8.2` with this changeset
5. App should not crash, and Google Drive connection should continue show up at drawer and still working

#### Build tasks success  
Successfully running following tasks on local:
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`
