### PR TITLE
Fix line parsing of ls/stat output

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/filesystem/files/FileUtils.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/files/FileUtils.java
@@ -899,7 +899,7 @@ public class FileUtils {
       }
     }
     int p = getColonPosition(array);
-    if (p != -1) {
+    if (p != -1 && (p + 1) != array.length) {
       date = array[p - 1] + " | " + array[p];
       size = array[p - 2];
     } else if (isStat) {
@@ -916,6 +916,10 @@ public class FileUtils {
       int q = getLinkPosition(array);
       for (int i = p + 1; i < q; i++) {
         name.append(" ").append(array[i]);
+      }
+      // Newer *boxes may introduce full path during stat. Trim down to the very last /
+      if (name.lastIndexOf("/") > 0) {
+        name.delete(0, name.lastIndexOf("/") + 1);
       }
       name = new StringBuilder(name.toString().trim());
       for (int i = q + 1; i < array.length; i++) {


### PR DESCRIPTION
## Description
To deal with newer versions of toybox and probably busybox as well.

Split out the changes to FileUtils.parseName() at #3492.

#### Issue tracker   
Fixes #3546
Fixes #3541
Fixes #3520

#### Automatic tests
- [x] Added test cases
  
#### Manual tests
- [ ] Done  
  
#### Build tasks success  
Successfully running following tasks on local:
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`