### PR TITLE
Allow case sensitive local file rename

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/filesystem/Operations.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/Operations.java
@@ -443,8 +443,7 @@ public class Operations {
       private final DataUtils dataUtils = DataUtils.getInstance();
 
       private final boolean isLocalFilesystemCaseInsensitive =
-          oldFile.isLocal()
-              && Objects.requireNonNull(oldFile.getFile()).exists()
+          Objects.requireNonNull(oldFile.getFile()).exists()
               && new File(oldFile.getFile().getParent(), oldFile.getSimpleName().toUpperCase())
                   .exists()
               && new File(oldFile.getFile().getParent(), oldFile.getSimpleName().toLowerCase())

--- a/app/src/main/java/com/amaze/filemanager/filesystem/Operations.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/Operations.java
@@ -441,12 +441,18 @@ public class Operations {
 
       private final DataUtils dataUtils = DataUtils.getInstance();
 
-      private final Boolean isCaseSensitiveRename =
+      /**
+       * Determines whether double rename is required based on original and new file name regardless
+       * of the case-sensitivity of the filesystem
+       */
+      private final boolean isCaseSensitiveRename =
           oldFile.getSimpleName().equalsIgnoreCase(newFile.getSimpleName())
               && !oldFile.getSimpleName().equals(newFile.getSimpleName());
 
-      // random string that is appended to file to prevent name collision, max file name is 255
-      // bytes
+      /**
+       * random string that is appended to file to prevent name collision, max file name is 255
+       * bytes
+       */
       private static final String TEMP_FILE_EXT = "u0CtHRqWUnvxIaeBQ@nY2umVm9MDyR1P";
 
       private boolean localRename(@NonNull HybridFile oldFile, @NonNull HybridFile newFile) {
@@ -457,43 +463,50 @@ public class Operations {
         switch (oldFile.getMode()) {
           case FILE:
             int mode = checkFolder(file.getParentFile(), context);
-            if (mode == 2) {
-              errorCallBack.launchSAF(oldFile, newFile);
-            } else if (mode == 1 || mode == 0) {
+            if (mode == 1 || mode == 0) {
               try {
                 RenameOperation.renameFolder(file, file1, context);
-                result = true;
               } catch (ShellNotRunningException e) {
                 LOG.warn("failed to rename file in local filesystem", e);
               }
-              boolean a = !file.exists() && file1.exists();
-              if (!a && rootMode) {
+              result = !file.exists() && file1.exists();
+              if (!result && rootMode) {
                 try {
                   RenameFileCommand.INSTANCE.renameFile(file.getPath(), file1.getPath());
-                  result = true;
                 } catch (ShellNotRunningException e) {
                   LOG.warn("failed to rename file in local filesystem", e);
                 }
                 oldFile.setMode(OpenMode.ROOT);
                 newFile.setMode(OpenMode.ROOT);
-                a = !file.exists() && file1.exists();
+                result = !file.exists() && file1.exists();
               }
-              errorCallBack.done(newFile, a);
             }
             break;
           case ROOT:
             try {
-              RenameFileCommand.INSTANCE.renameFile(file.getPath(), file1.getPath());
-              result = true;
+              result = RenameFileCommand.INSTANCE.renameFile(file.getPath(), file1.getPath());
             } catch (ShellNotRunningException e) {
               LOG.warn("failed to rename file in root", e);
             }
-
             newFile.setMode(OpenMode.ROOT);
-            errorCallBack.done(newFile, true);
             break;
         }
         return result;
+      }
+
+      private boolean localDoubleRename(@NonNull HybridFile oldFile, @NonNull HybridFile newFile) {
+        HybridFile tempFile = new HybridFile(oldFile.mode, oldFile.getPath().concat(TEMP_FILE_EXT));
+        if (localRename(oldFile, tempFile)) {
+          if (localRename(tempFile, newFile)) {
+            return true;
+          } else {
+            // attempts to rollback
+            // changes the temporary file name back to original file name
+            LOG.warn("reverting temporary file rename");
+            return localRename(tempFile, oldFile);
+          }
+        }
+        return false;
       }
 
       private Function<DocumentFile, Void> safRenameFile =
@@ -665,17 +678,21 @@ public class Operations {
                   false));
           return null;
         } else {
-          if (isCaseSensitiveRename) {
-            HybridFile tempFile =
-                new HybridFile(oldFile.mode, oldFile.getPath().concat(TEMP_FILE_EXT));
-            if (localRename(oldFile, tempFile) && !localRename(tempFile, newFile)) {
-              // revert changes
-              LOG.warn("reverting temporary file rename");
-              localRename(tempFile, oldFile);
+          File file = new File(oldFile.getPath());
+          if (oldFile.getMode() == OpenMode.FILE) {
+            int mode = checkFolder(file.getParentFile(), context);
+            if (mode == 2) {
+              errorCallBack.launchSAF(oldFile, newFile);
             }
-          } else {
-            localRename(oldFile, newFile);
           }
+
+          boolean result;
+          if (isCaseSensitiveRename) {
+            result = localDoubleRename(oldFile, newFile);
+          } else {
+            result = localRename(oldFile, newFile);
+          }
+          errorCallBack.done(newFile, result);
         }
         return null;
       }

--- a/app/src/main/java/com/amaze/filemanager/filesystem/Operations.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/Operations.java
@@ -442,8 +442,8 @@ public class Operations {
       private final DataUtils dataUtils = DataUtils.getInstance();
 
       private final Boolean isCaseSensitiveRename =
-          !oldFile.getSimpleName().equals(newFile.getSimpleName())
-              && oldFile.getSimpleName().equalsIgnoreCase(newFile.getSimpleName());
+          oldFile.getSimpleName().equalsIgnoreCase(newFile.getSimpleName())
+              && !oldFile.getSimpleName().equals(newFile.getSimpleName());
 
       // random string that is appended to file to prevent name collision, max file name is 255
       // bytes
@@ -668,12 +668,10 @@ public class Operations {
           if (isCaseSensitiveRename) {
             HybridFile tempFile =
                 new HybridFile(oldFile.mode, oldFile.getPath().concat(TEMP_FILE_EXT));
-            if (localRename(oldFile, tempFile)) {
-              // stop if first rename failed
-              if (!localRename(tempFile, newFile)) {
-                // revert changes
-                localRename(tempFile, oldFile);
-              }
+            if (localRename(oldFile, tempFile) && !localRename(tempFile, newFile)) {
+              // revert changes
+              LOG.warn("reverting temporary file rename");
+              localRename(tempFile, oldFile);
             }
           } else {
             localRename(oldFile, newFile);

--- a/app/src/main/java/com/amaze/filemanager/filesystem/Operations.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/Operations.java
@@ -442,16 +442,14 @@ public class Operations {
       private final DataUtils dataUtils = DataUtils.getInstance();
 
       private final Boolean isCaseSensitiveRename =
-              !oldFile.getSimpleName().equals(newFile.getSimpleName()) &&
-              oldFile.getSimpleName().equalsIgnoreCase(newFile.getSimpleName());
+          !oldFile.getSimpleName().equals(newFile.getSimpleName())
+              && oldFile.getSimpleName().equalsIgnoreCase(newFile.getSimpleName());
 
-      // random string that is appended to file to prevent name collision
-      private static final String TEMP_FILE_EXT = "qwerty";
+      // random string that is appended to file to prevent name collision, max file name is 255
+      // bytes
+      private static final String TEMP_FILE_EXT = "u0CtHRqWUnvxIaeBQ@nY2umVm9MDyR1P";
 
-      private boolean defaultRename(
-          @NonNull HybridFile oldFile,
-          @NonNull HybridFile newFile
-      ) {
+      private boolean localRename(@NonNull HybridFile oldFile, @NonNull HybridFile newFile) {
         File file = new File(oldFile.getPath());
         File file1 = new File(newFile.getPath());
         boolean result = false;
@@ -668,14 +666,17 @@ public class Operations {
           return null;
         } else {
           if (isCaseSensitiveRename) {
-            HybridFile tempFile = new HybridFile(
-              oldFile.mode, oldFile.getPath().concat(TEMP_FILE_EXT)
-            );
-            if (defaultRename(oldFile, tempFile)) {
-              defaultRename(tempFile, newFile);
+            HybridFile tempFile =
+                new HybridFile(oldFile.mode, oldFile.getPath().concat(TEMP_FILE_EXT));
+            if (localRename(oldFile, tempFile)) {
+              // stop if first rename failed
+              if (!localRename(tempFile, newFile)) {
+                // revert changes
+                localRename(tempFile, oldFile);
+              }
             }
           } else {
-            defaultRename(oldFile, newFile);
+            localRename(oldFile, newFile);
           }
         }
         return null;

--- a/app/src/main/java/com/amaze/filemanager/filesystem/Operations.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/Operations.java
@@ -30,6 +30,7 @@ import java.io.OutputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Objects;
 import java.util.concurrent.Executor;
 
 import org.apache.commons.net.ftp.FTPClient;
@@ -441,13 +442,12 @@ public class Operations {
 
       private final DataUtils dataUtils = DataUtils.getInstance();
 
-      /**
-       * Determines whether double rename is required based on original and new file name regardless
-       * of the case-sensitivity of the filesystem
-       */
-      private final boolean isCaseSensitiveRename =
-          oldFile.getSimpleName().equalsIgnoreCase(newFile.getSimpleName())
-              && !oldFile.getSimpleName().equals(newFile.getSimpleName());
+      private final boolean isLocalFilesystemCaseInsensitive =
+          Objects.requireNonNull(oldFile.getFile()).exists()
+              && new File(oldFile.getFile().getParent(), oldFile.getSimpleName().toUpperCase())
+                  .exists()
+              && new File(oldFile.getFile().getParent(), oldFile.getSimpleName().toLowerCase())
+                  .exists();
 
       /**
        * random string that is appended to file to prevent name collision, max file name is 255
@@ -530,7 +530,7 @@ public class Operations {
           return null;
         }
 
-        if (newFile.exists() && !isCaseSensitiveRename) {
+        if (newFile.exists() && !isLocalFilesystemCaseInsensitive) {
           errorCallBack.exists(newFile);
           return null;
         }
@@ -687,7 +687,7 @@ public class Operations {
           }
 
           boolean result;
-          if (isCaseSensitiveRename) {
+          if (isLocalFilesystemCaseInsensitive) {
             result = localDoubleRename(oldFile, newFile);
           } else {
             result = localRename(oldFile, newFile);

--- a/app/src/main/java/com/amaze/filemanager/filesystem/Operations.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/Operations.java
@@ -30,7 +30,6 @@ import java.io.OutputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
-import java.util.Objects;
 import java.util.concurrent.Executor;
 
 import org.apache.commons.net.ftp.FTPClient;
@@ -442,12 +441,13 @@ public class Operations {
 
       private final DataUtils dataUtils = DataUtils.getInstance();
 
-      private final boolean isLocalFilesystemCaseInsensitive =
-          Objects.requireNonNull(oldFile.getFile()).exists()
-              && new File(oldFile.getFile().getParent(), oldFile.getSimpleName().toUpperCase())
-                  .exists()
-              && new File(oldFile.getFile().getParent(), oldFile.getSimpleName().toLowerCase())
-                  .exists();
+      /**
+       * Determines whether double rename is required based on original and new file name regardless
+       * of the case-sensitivity of the filesystem
+       */
+      private final boolean isCaseSensitiveRename =
+          oldFile.getSimpleName().equalsIgnoreCase(newFile.getSimpleName())
+              && !oldFile.getSimpleName().equals(newFile.getSimpleName());
 
       /**
        * random string that is appended to file to prevent name collision, max file name is 255
@@ -530,7 +530,7 @@ public class Operations {
           return null;
         }
 
-        if (newFile.exists() && !isLocalFilesystemCaseInsensitive) {
+        if (newFile.exists() && !isCaseSensitiveRename) {
           errorCallBack.exists(newFile);
           return null;
         }
@@ -687,7 +687,7 @@ public class Operations {
           }
 
           boolean result;
-          if (isLocalFilesystemCaseInsensitive) {
+          if (isCaseSensitiveRename) {
             result = localDoubleRename(oldFile, newFile);
           } else {
             result = localRename(oldFile, newFile);

--- a/app/src/main/java/com/amaze/filemanager/filesystem/Operations.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/Operations.java
@@ -443,7 +443,8 @@ public class Operations {
       private final DataUtils dataUtils = DataUtils.getInstance();
 
       private final boolean isLocalFilesystemCaseInsensitive =
-          Objects.requireNonNull(oldFile.getFile()).exists()
+          oldFile.isLocal()
+              && Objects.requireNonNull(oldFile.getFile()).exists()
               && new File(oldFile.getFile().getParent(), oldFile.getSimpleName().toUpperCase())
                   .exists()
               && new File(oldFile.getFile().getParent(), oldFile.getSimpleName().toLowerCase())


### PR DESCRIPTION
<!-- 
Read this first:
To open a pull request read this file,
uncomment the corresponding lines and 
complete them.
-->

## Description
The FAT filesystem in android sd card is case-insensitive. This allows case-sensitive renaming by checking whether the changed name and original name is equivalent case-insensitively and doing a double rename. Only the code for local file renaming is changed.
Not sure what indent to use.

#### Issue tracker   
Fixes [#3587](https://github.com/TeamAmaze/AmazeFileManager/issues/3587)

#### Automatic tests
- [ ] Added test cases
  
#### Manual tests
- [x] Done  
  
- Device: Resizable
- OS: Api 33

#### Build tasks success  
<!-- run these! -->
Successfully running following tasks on local:
- [ ] `./gradlew assembledebug`
- [ ] `./gradlew spotlessCheck`
These tasks failed even with unmodified source code so probably local configuration issues