### PR TITLE
Access Android/data or obb dirs individually as app package

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/filesystem/HybridFile.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/HybridFile.java
@@ -20,6 +20,7 @@
 
 package com.amaze.filemanager.filesystem;
 
+import static com.amaze.filemanager.filesystem.FileProperties.ANDROID_DATA_DIRS;
 import static com.amaze.filemanager.filesystem.ftp.NetCopyClientConnectionPool.FTPS_URI_PREFIX;
 import static com.amaze.filemanager.filesystem.ftp.NetCopyClientConnectionPool.FTP_URI_PREFIX;
 import static com.amaze.filemanager.filesystem.ftp.NetCopyClientConnectionPool.SSH_URI_PREFIX;
@@ -42,6 +43,7 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.EnumSet;
+import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
@@ -107,7 +109,9 @@ import io.reactivex.disposables.Disposable;
 import io.reactivex.schedulers.Schedulers;
 import jcifs.smb.SmbException;
 import jcifs.smb.SmbFile;
+import kotlin.collections.ArraysKt;
 import kotlin.io.ByteStreamsKt;
+import kotlin.text.Charsets;
 import net.schmizz.sshj.SSHClient;
 import net.schmizz.sshj.common.Buffer;
 import net.schmizz.sshj.common.IOUtils;
@@ -258,6 +262,10 @@ public class HybridFile {
 
   public boolean isGoogleDriveFile() {
     return mode == OpenMode.GDRIVE;
+  }
+
+  public boolean isAndroidDataDir() {
+    return mode == OpenMode.ANDROID_DATA;
   }
 
   public boolean isCloudDriveFile() {
@@ -537,6 +545,22 @@ public class HybridFile {
       case ROOT:
         return getFile().getParent();
       case SFTP:
+      case DOCUMENT_FILE:
+        String thisPath = path;
+        if (thisPath.contains("%")) {
+          try {
+            thisPath = URLDecoder.decode(path, Charsets.UTF_8.name());
+          } catch (UnsupportedEncodingException ignored) {
+          }
+        }
+        List<String> pathSegments = Uri.parse(thisPath).getPathSegments();
+        String currentName = pathSegments.get(pathSegments.size() - 1);
+        String parent = thisPath.substring(0, thisPath.lastIndexOf(currentName));
+        if (ArraysKt.any(ANDROID_DATA_DIRS, dir -> parent.endsWith(dir + "/"))) {
+          return FileProperties.unmapPathForApi30OrAbove(parent);
+        } else {
+          return parent;
+        }
       default:
         if (getPath().length() == getName(context).length()) {
           return null;
@@ -1435,7 +1459,7 @@ public class HybridFile {
       } catch (Exception e) {
         LOG.warn("failed to create folder for cloud file", e);
       }
-    } else MakeDirectoryOperation.mkdir(getFile(), context);
+    } else MakeDirectoryOperation.mkdirs(context, this);
   }
 
   public boolean delete(Context context, boolean rootmode)

--- a/app/src/main/java/com/amaze/filemanager/filesystem/MakeDirectoryOperation.kt
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/MakeDirectoryOperation.kt
@@ -93,6 +93,8 @@ object MakeDirectoryOperation {
                 isSuccessful = documentFile != null
             }
             OpenMode.FILE -> isSuccessful = mkdir(File(file.getPath()), context)
+            // With ANDROID_DATA will not accept create directory
+            OpenMode.ANDROID_DATA -> isSuccessful = false
             else -> isSuccessful = true
         }
         return isSuccessful

--- a/app/src/main/java/com/amaze/filemanager/filesystem/Operations.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/Operations.java
@@ -149,6 +149,12 @@ public class Operations {
           return null;
         }
 
+        // Android data directory, prohibit create directory
+        if (file.isAndroidDataDir()) {
+          errorCallBack.done(file, false);
+          return null;
+        }
+
         if (file.isSftp() || file.isFtp()) {
           file.mkdir(context);
           /*
@@ -299,6 +305,13 @@ public class Operations {
           errorCallBack.exists(file);
           return null;
         }
+
+        // Android data directory, prohibit create file
+        if (file.isAndroidDataDir()) {
+          errorCallBack.done(file, false);
+          return null;
+        }
+
         if (file.isSftp() || file.isFtp()) {
           OutputStream out = file.getOutputStream(context);
           if (out == null) {

--- a/app/src/main/java/com/amaze/filemanager/filesystem/files/FileUtils.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/files/FileUtils.java
@@ -599,7 +599,6 @@ public class FileUtils {
   /** Method determines if there is something to go back to */
   public static boolean canGoBack(Context context, HybridFile currentFile) {
     switch (currentFile.getMode()) {
-
         // we're on main thread and can't list the cloud files
       case DROPBOX:
       case BOX:

--- a/app/src/main/java/com/amaze/filemanager/ui/activities/MainActivityViewModel.kt
+++ b/app/src/main/java/com/amaze/filemanager/ui/activities/MainActivityViewModel.kt
@@ -31,8 +31,8 @@ import kotlinx.coroutines.launch
 class MainActivityViewModel(val applicationContext: Application) :
     AndroidViewModel(applicationContext) {
 
-    var mediaCacheHash: List<ArrayList<LayoutElementParcelable>?> = List(5) { null }
-    var listCache: LruCache<String, ArrayList<LayoutElementParcelable>> = LruCache(50)
+    var mediaCacheHash: List<List<LayoutElementParcelable>?> = List(5) { null }
+    var listCache: LruCache<String, List<LayoutElementParcelable>> = LruCache(50)
 
     companion object {
         /**
@@ -44,7 +44,7 @@ class MainActivityViewModel(val applicationContext: Application) :
     /**
      * Put list for a given path in cache
      */
-    fun putInCache(path: String, listToCache: ArrayList<LayoutElementParcelable>) {
+    fun putInCache(path: String, listToCache: List<LayoutElementParcelable>) {
         viewModelScope.launch(Dispatchers.Default) {
             listCache.put(path, listToCache)
         }
@@ -62,14 +62,14 @@ class MainActivityViewModel(val applicationContext: Application) :
     /**
      * Get cache from a given path and updates files / folder count
      */
-    fun getFromListCache(path: String): ArrayList<LayoutElementParcelable>? {
+    fun getFromListCache(path: String): List<LayoutElementParcelable>? {
         return listCache.get(path)
     }
 
     /**
      * Get cache from a given path and updates files / folder count
      */
-    fun getFromMediaFilesCache(mediaType: Int): ArrayList<LayoutElementParcelable>? {
+    fun getFromMediaFilesCache(mediaType: Int): List<LayoutElementParcelable>? {
         return mediaCacheHash[mediaType]
     }
 }

--- a/app/src/main/java/com/amaze/filemanager/ui/fragments/MainFragment.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/fragments/MainFragment.java
@@ -24,6 +24,8 @@ import static android.os.Build.VERSION.SDK_INT;
 import static android.os.Build.VERSION_CODES.JELLY_BEAN;
 import static android.os.Build.VERSION_CODES.JELLY_BEAN_MR2;
 import static android.os.Build.VERSION_CODES.Q;
+import static com.amaze.filemanager.filesystem.FileProperties.ANDROID_DATA_DIRS;
+import static com.amaze.filemanager.filesystem.FileProperties.ANDROID_DEVICE_DATA_DIRS;
 import static com.amaze.filemanager.filesystem.ftp.NetCopyClientConnectionPool.SSH_URI_PREFIX;
 import static com.amaze.filemanager.ui.fragments.preferencefragments.PreferencesConstants.PREFERENCE_SHOW_DIVIDERS;
 import static com.amaze.filemanager.ui.fragments.preferencefragments.PreferencesConstants.PREFERENCE_SHOW_GOBACK_BUTTON;
@@ -78,6 +80,7 @@ import com.amaze.filemanager.ui.views.FastScroller;
 import com.amaze.filemanager.ui.views.WarnableTextInputValidator;
 import com.amaze.filemanager.utils.BottomBarButtonPath;
 import com.amaze.filemanager.utils.DataUtils;
+import com.amaze.filemanager.utils.GenericExtKt;
 import com.amaze.filemanager.utils.MainActivityHelper;
 import com.amaze.filemanager.utils.OTGUtil;
 import com.amaze.filemanager.utils.Utils;
@@ -89,13 +92,11 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.SharedPreferences;
 import android.content.UriPermission;
-import android.content.res.Resources;
 import android.graphics.Color;
 import android.media.RingtoneManager;
 import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Bundle;
-import android.os.Environment;
 import android.provider.DocumentsContract;
 import android.text.TextUtils;
 import android.text.format.Formatter;
@@ -130,6 +131,8 @@ import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 
 import jcifs.smb.SmbException;
 import jcifs.smb.SmbFile;
+import kotlin.collections.ArraysKt;
+import kotlin.collections.CollectionsKt;
 
 public class MainFragment extends Fragment
     implements BottomBarButtonPath,
@@ -141,7 +144,6 @@ public class MainFragment extends Fragment
 
   public RecyclerAdapter adapter;
   private SharedPreferences sharedPref;
-  private Resources res;
 
   // ATTRIBUTES FOR APPEARANCE AND COLORS
   private LinearLayoutManager mLayoutManager;
@@ -163,7 +165,7 @@ public class MainFragment extends Fragment
   private MainFragmentViewModel mainFragmentViewModel;
   private MainActivityViewModel mainActivityViewModel;
 
-  private ActivityResultLauncher<Intent> handleDocumentUriForRestrictedDirectories =
+  private final ActivityResultLauncher<Intent> handleDocumentUriForRestrictedDirectories =
       registerForActivityResult(
           new ActivityResultContracts.StartActivityForResult(),
           result -> {
@@ -190,19 +192,18 @@ public class MainFragment extends Fragment
     mainActivityViewModel =
         new ViewModelProvider(requireMainActivity()).get(MainActivityViewModel.class);
 
-    utilsProvider = getMainActivity().getUtilsProvider();
+    utilsProvider = requireMainActivity().getUtilsProvider();
     sharedPref = PreferenceManager.getDefaultSharedPreferences(requireActivity());
-    res = getResources();
     mainFragmentViewModel.initBundleArguments(getArguments());
     mainFragmentViewModel.initIsList();
     mainFragmentViewModel.initColumns(sharedPref);
     mainFragmentViewModel.initSortModes(
         SortHandler.getSortType(getContext(), getCurrentPath()), sharedPref);
-    mainFragmentViewModel.setAccentColor(getMainActivity().getAccent());
+    mainFragmentViewModel.setAccentColor(requireMainActivity().getAccent());
     mainFragmentViewModel.setPrimaryColor(
-        getMainActivity().getCurrentColorPreference().getPrimaryFirstTab());
+        requireMainActivity().getCurrentColorPreference().getPrimaryFirstTab());
     mainFragmentViewModel.setPrimaryTwoColor(
-        getMainActivity().getCurrentColorPreference().getPrimarySecondTab());
+        requireMainActivity().getCurrentColorPreference().getPrimarySecondTab());
   }
 
   @Override
@@ -218,7 +219,7 @@ public class MainFragment extends Fragment
     super.onViewCreated(view, savedInstanceState);
     mainFragmentViewModel = new ViewModelProvider(this).get(MainFragmentViewModel.class);
     listView = rootView.findViewById(R.id.listView);
-    mToolbarContainer = getMainActivity().getAppbar().getAppbarLayout();
+    mToolbarContainer = requireMainActivity().getAppbar().getAppbarLayout();
     fastScroller = rootView.findViewById(R.id.fastscroll);
     fastScroller.setPressedHandleColor(mainFragmentViewModel.getAccentColor());
     View.OnTouchListener onTouchListener =
@@ -274,7 +275,7 @@ public class MainFragment extends Fragment
     // View footerView = getActivity().getLayoutInflater().inflate(R.layout.divider, null);// TODO:
     // 23/5/2017 use or delete
     dividerItemDecoration =
-        new DividerItemDecoration(getActivity(), false, getBoolean(PREFERENCE_SHOW_DIVIDERS));
+        new DividerItemDecoration(requireActivity(), false, getBoolean(PREFERENCE_SHOW_DIVIDERS));
     listView.addItemDecoration(dividerItemDecoration);
     mSwipeRefreshLayout.setColorSchemeColors(mainFragmentViewModel.getAccentColor());
     DefaultItemAnimator animator = new DefaultItemAnimator();
@@ -403,7 +404,7 @@ public class MainFragment extends Fragment
               && mainFragmentViewModel.getEncryptBaseFile() != null) {
             FileUtils.openFile(
                 mainFragmentViewModel.getEncryptBaseFile().getFile(),
-                getMainActivity(),
+                requireMainActivity(),
                 sharedPref);
             mainFragmentViewModel.setEncryptOpen(false);
           }
@@ -430,14 +431,14 @@ public class MainFragment extends Fragment
     if (mainFragmentViewModel.getResults()) {
       // check to initialize search results
       // if search task is been running, cancel it
-      FragmentManager fragmentManager = getActivity().getSupportFragmentManager();
+      FragmentManager fragmentManager = requireActivity().getSupportFragmentManager();
       SearchWorkerFragment fragment =
           (SearchWorkerFragment) fragmentManager.findFragmentByTag(MainActivity.TAG_ASYNC_HELPER);
       if (fragment != null) {
         if (fragment.searchAsyncTask.getStatus() == AsyncTask.Status.RUNNING) {
           fragment.searchAsyncTask.cancel(true);
         }
-        getActivity().getSupportFragmentManager().beginTransaction().remove(fragment).commit();
+        requireActivity().getSupportFragmentManager().beginTransaction().remove(fragment).commit();
       }
 
       mainFragmentViewModel.setRetainSearchTask(true);
@@ -447,13 +448,13 @@ public class MainFragment extends Fragment
       MainActivityHelper.SEARCH_TEXT = null;
     }
 
-    if (getMainActivity().getListItemSelected()) {
+    if (requireMainActivity().getListItemSelected()) {
       if (isBackButton) {
-        getMainActivity().setListItemSelected(false);
-        if (getMainActivity().getActionModeHelper().getActionMode() != null) {
-          getMainActivity().getActionModeHelper().getActionMode().finish();
+        requireMainActivity().setListItemSelected(false);
+        if (requireMainActivity().getActionModeHelper().getActionMode() != null) {
+          requireMainActivity().getActionModeHelper().getActionMode().finish();
         }
-        getMainActivity().getActionModeHelper().setActionMode(null);
+        requireMainActivity().getActionModeHelper().setActionMode(null);
       } else {
         // the first {goback} item if back navigation is enabled
         adapter.toggleChecked(position, imageView);
@@ -463,8 +464,8 @@ public class MainFragment extends Fragment
         goBackItemClick();
       } else {
         // hiding search view if visible
-        if (getMainActivity().getAppbar().getSearchView().isEnabled()) {
-          getMainActivity().getAppbar().getSearchView().hideSearchView();
+        if (requireMainActivity().getAppbar().getSearchView().isEnabled()) {
+          requireMainActivity().getAppbar().getSearchView().hideSearchView();
         }
 
         String path =
@@ -522,9 +523,9 @@ public class MainFragment extends Fragment
    */
   public void returnIntentResults(HybridFileParcelable baseFile) {
 
-    getMainActivity().mReturnIntent = false;
+    requireMainActivity().mReturnIntent = false;
 
-    Uri mediaStoreUri = Utils.getUriForBaseFile(getActivity(), baseFile);
+    Uri mediaStoreUri = Utils.getUriForBaseFile(requireActivity(), baseFile);
     LOG.debug(
         mediaStoreUri.toString()
             + "\t"
@@ -533,7 +534,7 @@ public class MainFragment extends Fragment
     intent.setFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
     intent.setAction(Intent.ACTION_SEND);
 
-    if (getMainActivity().mRingtonePickerIntent) {
+    if (requireMainActivity().mRingtonePickerIntent) {
       intent.setDataAndType(
           mediaStoreUri, MimeTypes.getMimeType(baseFile.getPath(), baseFile.isDirectory()));
       intent.putExtra(RingtoneManager.EXTRA_RINGTONE_PICKED_URI, mediaStoreUri);
@@ -581,12 +582,13 @@ public class MainFragment extends Fragment
     OpenMode openMode = providedOpenMode;
     String actualPath = FileProperties.remapPathForApi30OrAbove(providedPath, false);
 
-    if (!providedPath.equals(actualPath) && SDK_INT >= Q) {
-      openMode = loadPathInQ(actualPath, providedPath);
+    if (SDK_INT >= Q && ArraysKt.any(ANDROID_DATA_DIRS, providedPath::contains)) {
+      openMode = loadPathInQ(actualPath, providedPath, providedOpenMode);
     }
     // Monkeypatch :( to fix problems with unexpected non content URI path while openMode is still
     // OpenMode.DOCUMENT_FILE
-    else if (actualPath.startsWith("/") && OpenMode.DOCUMENT_FILE.equals(openMode)) {
+    else if (actualPath.startsWith("/")
+        && (OpenMode.DOCUMENT_FILE.equals(openMode) || OpenMode.ANDROID_DATA.equals(openMode))) {
       openMode = OpenMode.FILE;
     }
 
@@ -615,48 +617,57 @@ public class MainFragment extends Fragment
   }
 
   @RequiresApi(api = Q)
-  private OpenMode loadPathInQ(String actualPath, String providedPath) {
+  private OpenMode loadPathInQ(String actualPath, String providedPath, OpenMode providedMode) {
 
-    boolean hasAccessToSpecialFolder = false;
-    List<UriPermission> uriPermissions =
-        getContext().getContentResolver().getPersistedUriPermissions();
+    if (GenericExtKt.containsPath(ANDROID_DEVICE_DATA_DIRS, providedPath)
+        && !OpenMode.ANDROID_DATA.equals(providedMode)) {
+      return OpenMode.ANDROID_DATA;
+    } else if (actualPath.startsWith("/")) {
+      return OpenMode.FILE;
+    } else if (actualPath.equals(providedPath)) {
+      return providedMode;
+    } else {
+      boolean hasAccessToSpecialFolder = false;
+      List<UriPermission> uriPermissions =
+          requireContext().getContentResolver().getPersistedUriPermissions();
 
-    if (uriPermissions != null && uriPermissions.size() > 0) {
-      for (UriPermission p : uriPermissions) {
-        if (p.isReadPermission() && actualPath.startsWith(p.getUri().toString())) {
-          hasAccessToSpecialFolder = true;
-          SafRootHolder.setUriRoot(p.getUri());
-          break;
+      if (uriPermissions != null && uriPermissions.size() > 0) {
+        for (UriPermission p : uriPermissions) {
+          if (p.isReadPermission() && actualPath.startsWith(p.getUri().toString())) {
+            hasAccessToSpecialFolder = true;
+            SafRootHolder.setUriRoot(p.getUri());
+            break;
+          }
         }
       }
-    }
 
-    if (!hasAccessToSpecialFolder) {
-      Intent intent =
-          new Intent(Intent.ACTION_OPEN_DOCUMENT_TREE)
-              .putExtra(
-                  DocumentsContract.EXTRA_INITIAL_URI,
-                  Uri.parse(FileProperties.remapPathForApi30OrAbove(providedPath, true)));
-      MaterialDialog d =
-          GeneralDialogCreation.showBasicDialog(
-              getMainActivity(),
-              R.string.android_data_prompt_saf_access,
-              R.string.android_data_prompt_saf_access_title,
-              android.R.string.ok,
-              android.R.string.cancel);
-      d.getActionButton(DialogAction.POSITIVE)
-          .setOnClickListener(
-              v -> {
-                handleDocumentUriForRestrictedDirectories.launch(intent);
-                d.dismiss();
-              });
-      d.show();
-      // At this point LoadFilesListTask will be triggered.
-      // No harm even give OpenMode.FILE here, it loads blank when it doesn't; and after the
-      // UriPermission is granted loadlist will be called again
-      return OpenMode.FILE;
-    } else {
-      return OpenMode.DOCUMENT_FILE;
+      if (!hasAccessToSpecialFolder) {
+        Intent intent =
+            new Intent(Intent.ACTION_OPEN_DOCUMENT_TREE)
+                .putExtra(
+                    DocumentsContract.EXTRA_INITIAL_URI,
+                    Uri.parse(FileProperties.remapPathForApi30OrAbove(providedPath, true)));
+        MaterialDialog d =
+            GeneralDialogCreation.showBasicDialog(
+                requireMainActivity(),
+                R.string.android_data_prompt_saf_access,
+                R.string.android_data_prompt_saf_access_title,
+                android.R.string.ok,
+                android.R.string.cancel);
+        d.getActionButton(DialogAction.POSITIVE)
+            .setOnClickListener(
+                v -> {
+                  handleDocumentUriForRestrictedDirectories.launch(intent);
+                  d.dismiss();
+                });
+        d.show();
+        // At this point LoadFilesListTask will be triggered.
+        // No harm even give OpenMode.FILE here, it loads blank when it doesn't; and after the
+        // UriPermission is granted loadlist will be called again
+        return OpenMode.FILE;
+      } else {
+        return OpenMode.DOCUMENT_FILE;
+      }
     }
   }
 
@@ -678,9 +689,9 @@ public class MainFragment extends Fragment
             (v, keyCode, event) -> {
               if (event.getAction() == KeyEvent.ACTION_DOWN) {
                 if (event.getKeyCode() == KeyEvent.KEYCODE_DPAD_RIGHT) {
-                  getMainActivity().getFAB().requestFocus();
+                  requireMainActivity().getFAB().requestFocus();
                 } else if (event.getKeyCode() == KeyEvent.KEYCODE_BACK) {
-                  getMainActivity().onBackPressed();
+                  requireMainActivity().onBackPressed();
                 } else {
                   return false;
                 }
@@ -710,7 +721,7 @@ public class MainFragment extends Fragment
    * @param grid whether to set grid view or list view
    */
   public void setListElements(
-      ArrayList<LayoutElementParcelable> bitmap,
+      List<LayoutElementParcelable> bitmap,
       boolean back,
       String path,
       final OpenMode openMode,
@@ -771,7 +782,7 @@ public class MainFragment extends Fragment
 
         adapter =
             new RecyclerAdapter(
-                getMainActivity(),
+                requireMainActivity(),
                 this,
                 utilsProvider,
                 sharedPref,
@@ -798,7 +809,8 @@ public class MainFragment extends Fragment
 
       if (mainFragmentViewModel.getAddHeader() && mainFragmentViewModel.isList()) {
         dividerItemDecoration =
-            new DividerItemDecoration(getActivity(), true, getBoolean(PREFERENCE_SHOW_DIVIDERS));
+            new DividerItemDecoration(
+                requireMainActivity(), true, getBoolean(PREFERENCE_SHOW_DIVIDERS));
         listView.addItemDecoration(dividerItemDecoration);
         mainFragmentViewModel.setAddHeader(false);
       }
@@ -813,9 +825,9 @@ public class MainFragment extends Fragment
         }
       }
 
-      getMainActivity().updatePaths(mainFragmentViewModel.getNo());
-      getMainActivity().showFab();
-      getMainActivity().getAppbar().getAppbarLayout().setExpanded(true);
+      requireMainActivity().updatePaths(mainFragmentViewModel.getNo());
+      requireMainActivity().showFab();
+      requireMainActivity().getAppbar().getAppbarLayout().setExpanded(true);
       listView.stopScroll();
       fastScroller.setRecyclerView(
           listView,
@@ -880,13 +892,13 @@ public class MainFragment extends Fragment
    */
   private void resumeDecryptOperations() {
     if (SDK_INT >= JELLY_BEAN_MR2) {
-      (getActivity())
+      (requireMainActivity())
           .registerReceiver(
               decryptReceiver, new IntentFilter(EncryptDecryptUtils.DECRYPT_BROADCAST));
       if (!mainFragmentViewModel.isEncryptOpen()
           && !Utils.isNullOrEmpty(mainFragmentViewModel.getEncryptBaseFiles())) {
         // we've opened the file and are ready to delete it
-        new DeleteTask(getActivity()).execute(mainFragmentViewModel.getEncryptBaseFiles());
+        new DeleteTask(requireMainActivity()).execute(mainFragmentViewModel.getEncryptBaseFiles());
         mainFragmentViewModel.setEncryptBaseFiles(new ArrayList<>());
       }
     }
@@ -1003,7 +1015,7 @@ public class MainFragment extends Fragment
     if (!mainFragmentViewModel.getResults()) {
       if (!mainFragmentViewModel.getRetainSearchTask()) {
         // normal case
-        if (getMainActivity().getListItemSelected()) {
+        if (requireMainActivity().getListItemSelected()) {
           adapter.toggleChecked(false);
         } else {
           if (OpenMode.SMB.equals(mainFragmentViewModel.getOpenMode())) {
@@ -1056,41 +1068,27 @@ public class MainFragment extends Fragment
                   && mainFragmentViewModel.getHome().equals(mainFragmentViewModel.getCurrentPath()))
               || mainFragmentViewModel.getIsOnCloudRoot()) {
             getMainActivity().exit();
-          } else if (OpenMode.DOCUMENT_FILE.equals(mainFragmentViewModel.getOpenMode())) {
-            if (!currentFile.getPath().startsWith("content://")) {
-              mainFragmentViewModel.setOpenMode(OpenMode.FILE);
-              currentFile.setMode(OpenMode.FILE);
-              currentFile.setPath(Environment.getExternalStorageDirectory().getAbsolutePath());
-              loadlist(currentFile.getPath(), false, mainFragmentViewModel.getOpenMode(), false);
+          } else if (OpenMode.DOCUMENT_FILE.equals(mainFragmentViewModel.getOpenMode())
+              && !currentFile.getPath().startsWith("content://")) {
+            if (CollectionsKt.contains(
+                ANDROID_DEVICE_DATA_DIRS, currentFile.getParent(getContext()))) {
+              loadlist(currentFile.getParent(getContext()), false, OpenMode.ANDROID_DATA, false);
             } else {
-              List<String> pathSegments = Uri.parse(currentFile.getPath()).getPathSegments();
-              if (pathSegments.size() < 3) {
-                mainFragmentViewModel.setOpenMode(OpenMode.FILE);
-                String subPath = pathSegments.get(1);
-                currentFile.setMode(OpenMode.FILE);
-                currentFile.setPath(
-                    new File(
-                            Environment.getExternalStorageDirectory(),
-                            subPath.substring(
-                                subPath.lastIndexOf(':') + 1, subPath.lastIndexOf('/')))
-                        .getAbsolutePath());
-                loadlist(currentFile.getPath(), false, mainFragmentViewModel.getOpenMode(), false);
-              } else {
-                loadlist(
-                    currentFile.getParent(getContext()),
-                    true,
-                    mainFragmentViewModel.getOpenMode(),
-                    false);
-              }
+              loadlist(
+                  currentFile.getParent(getContext()),
+                  true,
+                  mainFragmentViewModel.getOpenMode(),
+                  false);
             }
-
           } else if (FileUtils.canGoBack(getContext(), currentFile)) {
             loadlist(
                 currentFile.getParent(getContext()),
                 true,
                 mainFragmentViewModel.getOpenMode(),
                 false);
-          } else getMainActivity().exit();
+          } else {
+            requireMainActivity().exit();
+          }
         }
       } else {
         // case when we had pressed on an item from search results and wanna go back
@@ -1099,7 +1097,7 @@ public class MainFragment extends Fragment
         if (MainActivityHelper.SEARCH_TEXT != null) {
 
           // starting the search query again :O
-          FragmentManager fm = getMainActivity().getSupportFragmentManager();
+          FragmentManager fm = requireMainActivity().getSupportFragmentManager();
 
           // getting parent path to resume search from there
           String parentPath =
@@ -1116,7 +1114,7 @@ public class MainFragment extends Fragment
               parentPath,
               MainActivityHelper.SEARCH_TEXT,
               mainFragmentViewModel.getOpenMode(),
-              getMainActivity().isRootExplorer(),
+              requireMainActivity().isRootExplorer(),
               sharedPref.getBoolean(SearchWorkerFragment.KEY_REGEX, false),
               sharedPref.getBoolean(SearchWorkerFragment.KEY_REGEX_MATCHES, false));
         } else {
@@ -1126,7 +1124,7 @@ public class MainFragment extends Fragment
       }
     } else {
       // to go back after search list have been popped
-      FragmentManager fm = getActivity().getSupportFragmentManager();
+      FragmentManager fm = requireMainActivity().getSupportFragmentManager();
       SearchWorkerFragment fragment =
           (SearchWorkerFragment) fm.findFragmentByTag(MainActivity.TAG_ASYNC_HELPER);
       if (fragment != null) {
@@ -1148,7 +1146,7 @@ public class MainFragment extends Fragment
   public void reauthenticateSmb() {
     if (mainFragmentViewModel.getSmbPath() != null) {
       try {
-        getMainActivity()
+        requireMainActivity()
             .runOnUiThread(
                 () -> {
                   int i;
@@ -1157,7 +1155,7 @@ public class MainFragment extends Fragment
                           DataUtils.getInstance()
                               .containsServer(mainFragmentViewModel.getSmbPath()))
                       != -1) {
-                    getMainActivity()
+                    requireMainActivity()
                         .showSMBDialog(
                             DataUtils.getInstance().getServers().get(i)[0],
                             mainFragmentViewModel.getSmbPath(),
@@ -1178,7 +1176,7 @@ public class MainFragment extends Fragment
     HybridFile currentFile =
         new HybridFile(mainFragmentViewModel.getOpenMode(), mainFragmentViewModel.getCurrentPath());
     if (!mainFragmentViewModel.getResults()) {
-      if (getMainActivity().getListItemSelected()) {
+      if (requireMainActivity().getListItemSelected()) {
         adapter.toggleChecked(false);
       } else {
         if (mainFragmentViewModel.getOpenMode() == OpenMode.SMB) {
@@ -1196,14 +1194,14 @@ public class MainFragment extends Fragment
           } else loadlist(mainFragmentViewModel.getHome(), false, OpenMode.FILE, false);
         } else if (("/").equals(mainFragmentViewModel.getCurrentPath())
             || mainFragmentViewModel.getIsOnCloudRoot()) {
-          getMainActivity().exit();
+          requireMainActivity().exit();
         } else if (FileUtils.canGoBack(getContext(), currentFile)) {
           loadlist(
               currentFile.getParent(getContext()),
               true,
               mainFragmentViewModel.getOpenMode(),
               false);
-        } else getMainActivity().exit();
+        } else requireMainActivity().exit();
       }
     } else {
       loadlist(currentFile.getPath(), true, mainFragmentViewModel.getOpenMode(), false);
@@ -1222,7 +1220,7 @@ public class MainFragment extends Fragment
   @Override
   public void onResume() {
     super.onResume();
-    (getActivity())
+    (requireActivity())
         .registerReceiver(receiver2, new IntentFilter(MainActivity.KEY_INTENT_LOAD_LIST));
 
     resumeDecryptOperations();
@@ -1232,13 +1230,13 @@ public class MainFragment extends Fragment
   @Override
   public void onPause() {
     super.onPause();
-    (getActivity()).unregisterReceiver(receiver2);
+    (requireActivity()).unregisterReceiver(receiver2);
     if (customFileObserver != null) {
       customFileObserver.stopWatching();
     }
 
     if (SDK_INT >= JELLY_BEAN_MR2) {
-      (getActivity()).unregisterReceiver(decryptReceiver);
+      (requireActivity()).unregisterReceiver(decryptReceiver);
     }
   }
 
@@ -1271,7 +1269,7 @@ public class MainFragment extends Fragment
 
         LayoutElementParcelable layoutElement =
             new LayoutElementParcelable(
-                getContext(),
+                requireContext(),
                 name,
                 aMFilePathBuilder.build().toString(),
                 "",
@@ -1291,7 +1289,7 @@ public class MainFragment extends Fragment
         mainFragmentViewModel.setFileCount(mainFragmentViewModel.getFileCount() + 1);
         LayoutElementParcelable layoutElement =
             new LayoutElementParcelable(
-                getContext(),
+                requireContext(),
                 name,
                 aMFile.getPath(),
                 "",
@@ -1321,7 +1319,7 @@ public class MainFragment extends Fragment
     if (hybridFileParcelable.isDirectory()) {
       LayoutElementParcelable layoutElement =
           new LayoutElementParcelable(
-              getContext(),
+              requireContext(),
               hybridFileParcelable.getPath(),
               hybridFileParcelable.getPermission(),
               hybridFileParcelable.getLink(),
@@ -1378,7 +1376,7 @@ public class MainFragment extends Fragment
       File f1 = new File(path + "/" + ".nomedia");
       if (!f1.exists()) {
         try {
-          getMainActivity()
+          requireMainActivity()
               .mainActivityHelper
               .mkFile(
                   new HybridFile(OpenMode.FILE, path),
@@ -1388,16 +1386,17 @@ public class MainFragment extends Fragment
           LOG.warn("failure when hiding file", e);
         }
       }
-      FileUtils.scanFile(getActivity(), new HybridFile[] {new HybridFile(OpenMode.FILE, path)});
+      FileUtils.scanFile(
+          requireMainActivity(), new HybridFile[] {new HybridFile(OpenMode.FILE, path)});
     }
   }
 
   public void addShortcut(LayoutElementParcelable path) {
     // Adding shortcut for MainActivity
     // on Home screen
-    final Context ctx = getContext();
+    final Context ctx = requireContext();
 
-    if (!ShortcutManagerCompat.isRequestPinShortcutSupported(ctx)) {
+    if (!ShortcutManagerCompat.isRequestPinShortcutSupported(requireContext())) {
       Toast.makeText(
               getActivity(),
               getString(R.string.add_shortcut_not_supported_by_launcher),
@@ -1414,7 +1413,7 @@ public class MainFragment extends Fragment
     // Using file path as shortcut id.
     ShortcutInfoCompat info =
         new ShortcutInfoCompat.Builder(ctx, path.desc)
-            .setActivity(getMainActivity().getComponentName())
+            .setActivity(requireMainActivity().getComponentName())
             .setIcon(IconCompat.createWithResource(ctx, R.mipmap.ic_launcher))
             .setIntent(shortcutIntent)
             .setLongLabel(path.desc)
@@ -1426,8 +1425,8 @@ public class MainFragment extends Fragment
 
   // This method is used to implement the modification for the pre Searching
   public void onSearchPreExecute(String query) {
-    getMainActivity().getAppbar().getBottomBar().setPathText("");
-    getMainActivity()
+    requireMainActivity().getAppbar().getBottomBar().setPathText("");
+    requireMainActivity()
         .getAppbar()
         .getBottomBar()
         .setFullPathText(getString(R.string.searching, query));
@@ -1449,19 +1448,19 @@ public class MainFragment extends Fragment
 
     // adding new value to LIST_ELEMENTS
     @Nullable LayoutElementParcelable layoutElementAdded = addTo(hybridFileParcelable);
-    if (!getMainActivity()
+    if (!requireMainActivity()
         .getAppbar()
         .getBottomBar()
         .getFullPathText()
         .contains(getString(R.string.searching))) {
-      getMainActivity()
+      requireMainActivity()
           .getAppbar()
           .getBottomBar()
           .setFullPathText(getString(R.string.searching, query));
     }
     if (!mainFragmentViewModel.getResults()) {
       reloadListElements(false, true, !mainFragmentViewModel.isList());
-      getMainActivity().getAppbar().getBottomBar().setPathText("");
+      requireMainActivity().getAppbar().getBottomBar().setPathText("");
     } else if (layoutElementAdded != null) {
       adapter.addItem(layoutElementAdded);
     }
@@ -1469,7 +1468,7 @@ public class MainFragment extends Fragment
   }
 
   public void onSearchCompleted(final String query) {
-    final ArrayList<LayoutElementParcelable> elements = mainFragmentViewModel.getListElements();
+    final List<LayoutElementParcelable> elements = mainFragmentViewModel.getListElements();
     if (!mainFragmentViewModel.getResults()) {
       // no results were found
       mainFragmentViewModel.getListElements().clear();
@@ -1501,7 +1500,7 @@ public class MainFragment extends Fragment
   }
 
   @Nullable
-  public ArrayList<LayoutElementParcelable> getElementsList() {
+  public List<LayoutElementParcelable> getElementsList() {
     return mainFragmentViewModel.getListElements();
   }
 
@@ -1572,7 +1571,7 @@ public class MainFragment extends Fragment
   }
 
   private boolean getBoolean(String key) {
-    return getMainActivity().getBoolean(key);
+    return requireMainActivity().getBoolean(key);
   }
 
   @Override
@@ -1633,10 +1632,10 @@ public class MainFragment extends Fragment
       int[] location = new int[2];
       viewHolder.baseItemView.getLocationOnScreen(location);
       LOG.info("Current x and y " + location[0] + " " + location[1]);
-      if (location[1] < getMainActivity().getAppbar().getAppbarLayout().getHeight()) {
+      if (location[1] < requireMainActivity().getAppbar().getAppbarLayout().getHeight()) {
         listView.scrollToPosition(Math.max(viewHolder.getAdapterPosition() - 5, 0));
       } else if (location[1] + viewHolder.baseItemView.getHeight()
-          > getContext().getResources().getDisplayMetrics().heightPixels) {
+          > requireContext().getResources().getDisplayMetrics().heightPixels) {
         listView.scrollToPosition(
             Math.min(viewHolder.getAdapterPosition() + 5, adapter.getItemCount() - 1));
       }

--- a/app/src/main/java/com/amaze/filemanager/ui/fragments/data/MainFragmentViewModel.kt
+++ b/app/src/main/java/com/amaze/filemanager/ui/fragments/data/MainFragmentViewModel.kt
@@ -38,14 +38,13 @@ import com.amaze.filemanager.utils.DataUtils
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import java.util.*
-import kotlin.collections.ArrayList
 
 class MainFragmentViewModel : ViewModel() {
 
     var currentPath: String? = null
 
     /** This is not an exact copy of the elements in the adapter  */
-    var listElements = ArrayList<LayoutElementParcelable>()
+    var listElements: List<LayoutElementParcelable> = ArrayList<LayoutElementParcelable>()
 
     var adapterListItems: ArrayList<RecyclerAdapter.ListItem>? = null
     var iconList: ArrayList<IconDataParcelable>? = null

--- a/app/src/main/java/com/amaze/filemanager/utils/GenericExt.kt
+++ b/app/src/main/java/com/amaze/filemanager/utils/GenericExt.kt
@@ -84,6 +84,15 @@ fun ByteArray.toHex(separatorStr: String = ""): String =
         "%02x".format(eachByte)
     }
 
+/**
+ * Test a [List] for given path. Assumed paths in the list are not ending with /, so check for
+ * both ended with or not ended with / with the given path parameter.
+ */
+fun List<*>.containsPath(path: String): Boolean {
+    return this.contains(path) ||
+        (path.endsWith('/') && this.contains(path.substringBeforeLast('/')))
+}
+
 interface Function<T, R> {
     fun apply(t: T): R
 }

--- a/app/src/main/java/com/amaze/filemanager/utils/MainActivityHelper.java
+++ b/app/src/main/java/com/amaze/filemanager/utils/MainActivityHelper.java
@@ -164,9 +164,14 @@ public class MainActivityHelper {
         "",
         (dialog, which) -> {
           EditText textfield = dialog.getCustomView().findViewById(R.id.singleedittext_input);
+          String parentPath = path;
+          if (OpenMode.DOCUMENT_FILE.equals(openMode)
+              && Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            parentPath = FileProperties.remapPathForApi30OrAbove(path, false);
+          }
           mkDir(
-              new HybridFile(openMode, path),
-              new HybridFile(openMode, path, textfield.getText().toString().trim(), true),
+              new HybridFile(openMode, parentPath),
+              new HybridFile(openMode, parentPath, textfield.getText().toString().trim(), true),
               ma);
           dialog.dismiss();
         },

--- a/app/src/main/java/com/amaze/filemanager/utils/OTGUtil.kt
+++ b/app/src/main/java/com/amaze/filemanager/utils/OTGUtil.kt
@@ -37,6 +37,7 @@ import com.amaze.filemanager.fileoperations.filesystem.usb.SingletonUsbOtg
 import com.amaze.filemanager.fileoperations.filesystem.usb.UsbOtgRepresentation
 import com.amaze.filemanager.filesystem.HybridFileParcelable
 import com.amaze.filemanager.filesystem.RootHelper
+import java.net.URLDecoder
 
 /** Created by Vishal on 27-04-2017.  */
 object OTGUtil {
@@ -170,7 +171,7 @@ object OTGUtil {
         var retval: DocumentFile? = DocumentFile.fromTreeUri(context, rootUri)
             ?: throw DocumentFileNotFoundException(rootUri, path)
         val parts: Array<String> = if (openMode == OpenMode.DOCUMENT_FILE) {
-            path.substringAfter(rootUri.toString())
+            path.substringAfter(URLDecoder.decode(rootUri.toString(), Charsets.UTF_8.name()))
                 .split("/", PATH_SEPARATOR_ENCODED).toTypedArray()
         } else {
             path.split("/").toTypedArray()
@@ -180,7 +181,7 @@ object OTGUtil {
             if (part == "otg:" || part == "" || part == "content:") continue
 
             // iterating through the required path to find the end point
-            var nextDocument = retval?.findFile(part) ?: retval
+            var nextDocument = retval?.findFile(part)
             if (createRecursive && (nextDocument == null || !nextDocument.exists())) {
                 nextDocument = retval?.createFile(part.substring(part.lastIndexOf(".")), part)
             }

--- a/app/src/test/java/com/amaze/filemanager/filesystem/HybridFileTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/filesystem/HybridFileTest.kt
@@ -23,6 +23,7 @@ package com.amaze.filemanager.filesystem
 import android.os.Build.VERSION_CODES.JELLY_BEAN
 import android.os.Build.VERSION_CODES.KITKAT
 import android.os.Build.VERSION_CODES.P
+import android.os.Environment
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.amaze.filemanager.application.AppConfig
@@ -32,9 +33,11 @@ import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
+import java.io.File
 import java.net.URLDecoder
 import kotlin.random.Random
 
+/* ktlint-disable max-line-length */
 @RunWith(AndroidJUnit4::class)
 @Config(shadows = [ShadowMultiDex::class], sdk = [JELLY_BEAN, KITKAT, P])
 class HybridFileTest {
@@ -77,8 +80,116 @@ class HybridFileTest {
     fun testSshGetParentWithoutTrailingSlash() {
         val file = HybridFile(OpenMode.SFTP, "ssh://user@127.0.0.1/home/user/next/project")
         assertEquals(
-            "ssh://user@127.0.0.1/home/user/next",
+            "ssh://user@127.0.0.1/home/user/next/",
             file.getParent(ApplicationProvider.getApplicationContext())
+        )
+    }
+
+    /**
+     * Test [HybridFile.getParent] for Android/data path.
+     */
+    @Test
+    fun testDocumentFileAndroidDataGetParent1() {
+        var file = HybridFile(
+            OpenMode.DOCUMENT_FILE,
+            "content://com.android.externalstorage.documents/tree/primary:Android/data/com.amaze.filemanager.debug/cache"
+        )
+        assertEquals(
+            "content://com.android.externalstorage.documents/tree/primary:Android/data/com.amaze.filemanager.debug/",
+            file.getParent(AppConfig.getInstance())
+        )
+        file = HybridFile(
+            OpenMode.DOCUMENT_FILE,
+            file.getParent(AppConfig.getInstance())
+        )
+        assertEquals(
+            File(Environment.getExternalStorageDirectory(), "Android/data").absolutePath,
+            file.getParent(AppConfig.getInstance())
+        )
+    }
+
+    /**
+     * Test [HybridFile.getParent] for Android/data path (again).
+     */
+    @Test
+    fun testDocumentFileAndroidDataGetParent2() {
+        var file = HybridFile(
+            OpenMode.DOCUMENT_FILE,
+            "content://com.android.externalstorage.documents/tree/primary:Android/data/com.amaze.filemanager.debug/files/external"
+        )
+        assertEquals(
+            "content://com.android.externalstorage.documents/tree/primary:Android/data/com.amaze.filemanager.debug/files/",
+            file.getParent(AppConfig.getInstance())
+        )
+        file = HybridFile(
+            OpenMode.DOCUMENT_FILE,
+            file.getParent(AppConfig.getInstance())
+        )
+        assertEquals(
+            "content://com.android.externalstorage.documents/tree/primary:Android/data/com.amaze.filemanager.debug/",
+            file.getParent(AppConfig.getInstance())
+        )
+        file = HybridFile(
+            OpenMode.DOCUMENT_FILE,
+            file.getParent(AppConfig.getInstance())
+        )
+        assertEquals(
+            File(Environment.getExternalStorageDirectory(), "Android/data").absolutePath,
+            file.getParent(AppConfig.getInstance())
+        )
+    }
+
+    /**
+     * Test [HybridFile.getParent] for Android/obb path.
+     */
+    @Test
+    fun testDocumentFileAndroidObbGetParent3() {
+        var file = HybridFile(
+            OpenMode.DOCUMENT_FILE,
+            "content://com.android.externalstorage.documents/tree/primary:Android/obb/com.amaze.filemanager.debug/cache"
+        )
+        assertEquals(
+            "content://com.android.externalstorage.documents/tree/primary:Android/obb/com.amaze.filemanager.debug/",
+            file.getParent(AppConfig.getInstance())
+        )
+        file = HybridFile(
+            OpenMode.DOCUMENT_FILE,
+            file.getParent(AppConfig.getInstance())
+        )
+        assertEquals(
+            File(Environment.getExternalStorageDirectory(), "Android/obb").absolutePath,
+            file.getParent(AppConfig.getInstance())
+        )
+    }
+
+    /**
+     * Test [HybridFile.getParent] for Android/obb path (again).
+     */
+    @Test
+    fun testDocumentFileAndroidObbGetParent2() {
+        var file = HybridFile(
+            OpenMode.DOCUMENT_FILE,
+            "content://com.android.externalstorage.documents/tree/primary:Android/obb/com.amaze.filemanager.debug/files/external"
+        )
+        assertEquals(
+            "content://com.android.externalstorage.documents/tree/primary:Android/obb/com.amaze.filemanager.debug/files/",
+            file.getParent(AppConfig.getInstance())
+        )
+        file = HybridFile(
+            OpenMode.DOCUMENT_FILE,
+            file.getParent(AppConfig.getInstance())
+        )
+        assertEquals(
+            "content://com.android.externalstorage.documents/tree/primary:Android/obb/com.amaze.filemanager.debug/",
+            file.getParent(AppConfig.getInstance())
+        )
+        file = HybridFile(
+            OpenMode.DOCUMENT_FILE,
+            file.getParent(AppConfig.getInstance())
+        )
+        assertEquals(
+            File(Environment.getExternalStorageDirectory(), "Android/obb").absolutePath,
+            file.getParent(AppConfig.getInstance())
         )
     }
 
@@ -115,3 +226,4 @@ class HybridFileTest {
         assertEquals("down the pipe", file.getName(AppConfig.getInstance()))
     }
 }
+/* ktlint-enable max-line-length */

--- a/file_operations/src/main/java/com/amaze/filemanager/fileoperations/filesystem/OpenMode.java
+++ b/file_operations/src/main/java/com/amaze/filemanager/fileoperations/filesystem/OpenMode.java
@@ -45,7 +45,9 @@ public enum OpenMode {
   GDRIVE,
   DROPBOX,
   BOX,
-  ONEDRIVE;
+  ONEDRIVE,
+
+  ANDROID_DATA;
 
   /**
    * Get open mode based on the id assigned. Generally used to retrieve this type after config


### PR DESCRIPTION
## Description
Instead of previously request for accessing the whole Android/data and Android/obb directories, change to ask for access to individual package directory under Android/{data,obb}.

Also changed display of directories under Android/{data,obb} to comparing with installed packages, and display only those matches installed apps.

Create directory or file at Android/data is not allowed with this changeset, with regards to updated access model in newer Androids, for an easy solution.

No upgrade concerns IMO, as granted URI permissions should have nothing to do with this changeset, since it is not using the URI to list directories under Android/data.

#### Issue tracker   
Fixes #3032 (perhaps?)

#### Automatic tests
- [x] Added test cases (partial, unit test only)
  
#### Manual tests
- [x] Done  

Devices:
- Nexus 5x running LineageOS 18 (Android 10)
- Fairphone 3 running LineageOS 19.1 (Android 12 SDK 32)  
- Pixel 6 emulator running Android 13 SDK33

The following test cases should succeed without problem.
1. Android/data access
- navigate into/out of Android/data should have no problem, without asking for explicit access
- should be able to list directories created by installed apps
2. Directories under Android/data
- when accessing directories under Android/data, prompt will popup brings up DocumentsUI with location set at app package directory under Android/data. User can grant permission to access that directory by pressing "Use this folder"
- File/Directory CRUD operations including cut/copy and paste should have no problem after granting access
- Navigate from directories under Android/data upward, to above Android/data, should succeed without problem
- Navigate from directories under Android/data upward, to other directory under Android/data, should succeed without problem
3. Regression: OTG access
- File/Directory CRUD operations when device is plugged with storage device over OTG should continue to work without problem
4. Regression: Amaze FTP server (built-in)
- If using SAF (e.g. using SD card as shared directory) at FTP server, file/directory CRUD operations should continue to work as FTP client interact with Amaze's FTP server

This changeset is targeted at API >= 30, but may also test on older devices for regressions if available.

#### Build tasks success  
Successfully running following tasks on local:
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`