### PR TITLE
Fix explorer.db upgrade causing Amaze crash on start

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/database/ExplorerDatabase.kt
+++ b/app/src/main/java/com/amaze/filemanager/database/ExplorerDatabase.kt
@@ -71,7 +71,7 @@ abstract class ExplorerDatabase : RoomDatabase() {
 
     companion object {
         private const val DATABASE_NAME = "explorer.db"
-        const val DATABASE_VERSION = 10
+        const val DATABASE_VERSION = 11
         const val TABLE_TAB = "tab"
         const val TABLE_CLOUD_PERSIST = "cloud"
         const val TABLE_ENCRYPTED = "encrypted"
@@ -156,7 +156,7 @@ abstract class ExplorerDatabase : RoomDatabase() {
                 )
             }
         }
-        internal val MIGRATION_6_7: Migration = object : Migration(6, DATABASE_VERSION) {
+        internal val MIGRATION_6_7: Migration = object : Migration(6, 7) {
             override fun migrate(database: SupportSQLiteDatabase) {
                 database.execSQL(
                     "CREATE TABLE " +
@@ -190,9 +190,9 @@ abstract class ExplorerDatabase : RoomDatabase() {
                         " FROM " +
                         TABLE_TAB
                 )
-                database.execSQL("DROP TABLE " + TABLE_TAB)
+                database.execSQL("DROP TABLE $TABLE_TAB")
                 database.execSQL(
-                    "ALTER TABLE " + TEMP_TABLE_PREFIX + TABLE_TAB + " RENAME TO " + TABLE_TAB
+                    "ALTER TABLE $TEMP_TABLE_PREFIX$TABLE_TAB RENAME TO $TABLE_TAB"
                 )
                 database.execSQL(
                     "CREATE TABLE " +
@@ -205,11 +205,11 @@ abstract class ExplorerDatabase : RoomDatabase() {
                         " INTEGER NOT NULL)"
                 )
                 database.execSQL(
-                    "INSERT INTO " + TEMP_TABLE_PREFIX + TABLE_SORT + " SELECT * FROM " + TABLE_SORT
+                    "INSERT INTO $TEMP_TABLE_PREFIX$TABLE_SORT SELECT * FROM $TABLE_SORT"
                 )
-                database.execSQL("DROP TABLE " + TABLE_SORT)
+                database.execSQL("DROP TABLE $TABLE_SORT")
                 database.execSQL(
-                    "ALTER TABLE " + TEMP_TABLE_PREFIX + TABLE_SORT + " RENAME TO " + TABLE_SORT
+                    "ALTER TABLE $TEMP_TABLE_PREFIX$TABLE_SORT RENAME TO $TABLE_SORT"
                 )
                 database.execSQL(
                     "CREATE TABLE " +
@@ -230,7 +230,7 @@ abstract class ExplorerDatabase : RoomDatabase() {
                         " SELECT * FROM " +
                         TABLE_ENCRYPTED
                 )
-                database.execSQL("DROP TABLE " + TABLE_ENCRYPTED)
+                database.execSQL("DROP TABLE $TABLE_ENCRYPTED")
                 database.execSQL(
                     "ALTER TABLE " +
                         TEMP_TABLE_PREFIX +
@@ -257,7 +257,7 @@ abstract class ExplorerDatabase : RoomDatabase() {
                         " SELECT * FROM " +
                         TABLE_CLOUD_PERSIST
                 )
-                database.execSQL("DROP TABLE " + TABLE_CLOUD_PERSIST)
+                database.execSQL("DROP TABLE $TABLE_CLOUD_PERSIST")
                 database.execSQL(
                     "ALTER TABLE " +
                         TEMP_TABLE_PREFIX +
@@ -294,7 +294,7 @@ abstract class ExplorerDatabase : RoomDatabase() {
             }
         }
 
-        internal val MIGRATION_9_10: Migration = object : Migration(9, DATABASE_VERSION) {
+        internal val MIGRATION_9_10: Migration = object : Migration(9, 10) {
             override fun migrate(database: SupportSQLiteDatabase) {
                 database.execSQL(
                     "UPDATE " +
@@ -304,6 +304,20 @@ abstract class ExplorerDatabase : RoomDatabase() {
                         " = " +
                         COLUMN_CLOUD_SERVICE +
                         "+1"
+                )
+            }
+        }
+
+        internal val MIGRATION_10_11: Migration = object : Migration(10, DATABASE_VERSION) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL(
+                    "UPDATE " +
+                        TABLE_CLOUD_PERSIST +
+                        " SET " +
+                        COLUMN_CLOUD_SERVICE +
+                        " = " +
+                        COLUMN_CLOUD_SERVICE +
+                        "-2"
                 )
             }
         }
@@ -329,6 +343,7 @@ abstract class ExplorerDatabase : RoomDatabase() {
                 .addMigrations(MIGRATION_7_8)
                 .addMigrations(MIGRATION_8_9)
                 .addMigrations(MIGRATION_9_10)
+                .addMigrations(MIGRATION_10_11)
                 .allowMainThreadQueries()
                 .build()
         }

--- a/app/src/main/java/com/amaze/filemanager/database/typeconverters/EncryptedStringTypeConverter.kt
+++ b/app/src/main/java/com/amaze/filemanager/database/typeconverters/EncryptedStringTypeConverter.kt
@@ -20,7 +20,6 @@
 
 package com.amaze.filemanager.database.typeconverters
 
-import android.util.Base64
 import android.util.Log
 import androidx.room.TypeConverter
 import com.amaze.filemanager.application.AppConfig
@@ -50,7 +49,7 @@ object EncryptedStringTypeConverter {
     fun toPassword(encryptedStringEntryInDb: String): StringWrapper {
         return runCatching {
             StringWrapper(
-                decryptPassword(AppConfig.getInstance(), encryptedStringEntryInDb, Base64.DEFAULT)
+                decryptPassword(AppConfig.getInstance(), encryptedStringEntryInDb)
             )
         }.onFailure {
             Log.e(TAG, "Error decrypting password", it)
@@ -68,8 +67,7 @@ object EncryptedStringTypeConverter {
         return runCatching {
             encryptPassword(
                 AppConfig.getInstance(),
-                unencryptedPasswordString.value,
-                Base64.DEFAULT
+                unencryptedPasswordString.value
             )
         }.onFailure {
             Log.e(TAG, "Error encrypting password", it)

--- a/app/src/test/java/com/amaze/filemanager/database/ExplorerDatabaseMigrationTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/database/ExplorerDatabaseMigrationTest.kt
@@ -78,7 +78,9 @@ class ExplorerDatabaseMigrationTest {
                 ExplorerDatabase.MIGRATION_5_6,
                 ExplorerDatabase.MIGRATION_6_7,
                 ExplorerDatabase.MIGRATION_7_8,
-                ExplorerDatabase.MIGRATION_8_9
+                ExplorerDatabase.MIGRATION_8_9,
+                ExplorerDatabase.MIGRATION_9_10,
+                ExplorerDatabase.MIGRATION_10_11
             )
             .build()
         explorerDatabase.openHelper.writableDatabase
@@ -98,7 +100,14 @@ class ExplorerDatabaseMigrationTest {
             ExplorerDatabase::class.java,
             TEST_DB
         )
-            .addMigrations(ExplorerDatabase.MIGRATION_5_6, ExplorerDatabase.MIGRATION_6_7)
+            .addMigrations(
+                ExplorerDatabase.MIGRATION_5_6,
+                ExplorerDatabase.MIGRATION_6_7,
+                ExplorerDatabase.MIGRATION_7_8,
+                ExplorerDatabase.MIGRATION_8_9,
+                ExplorerDatabase.MIGRATION_9_10,
+                ExplorerDatabase.MIGRATION_10_11
+            )
             .build()
         explorerDatabase.openHelper.writableDatabase
         explorerDatabase.close()
@@ -117,7 +126,13 @@ class ExplorerDatabaseMigrationTest {
             ExplorerDatabase::class.java,
             TEST_DB
         )
-            .addMigrations(ExplorerDatabase.MIGRATION_6_7)
+            .addMigrations(
+                ExplorerDatabase.MIGRATION_6_7,
+                ExplorerDatabase.MIGRATION_7_8,
+                ExplorerDatabase.MIGRATION_8_9,
+                ExplorerDatabase.MIGRATION_9_10,
+                ExplorerDatabase.MIGRATION_10_11
+            )
             .build()
         explorerDatabase.openHelper.writableDatabase
         explorerDatabase.close()
@@ -140,7 +155,7 @@ class ExplorerDatabaseMigrationTest {
                 "," +
                 ExplorerDatabase.COLUMN_CLOUD_PERSIST +
                 ") VALUES (1," +
-                (OpenMode.GDRIVE.ordinal - 3) +
+                (OpenMode.GDRIVE.ordinal - 1) +
                 ",'abcd')"
         )
         db.execSQL(
@@ -153,7 +168,7 @@ class ExplorerDatabaseMigrationTest {
                 "," +
                 ExplorerDatabase.COLUMN_CLOUD_PERSIST +
                 ") VALUES (2," +
-                (OpenMode.DROPBOX.ordinal - 3) +
+                (OpenMode.DROPBOX.ordinal - 1) +
                 ",'efgh')"
         )
         db.execSQL(
@@ -166,7 +181,7 @@ class ExplorerDatabaseMigrationTest {
                 "," +
                 ExplorerDatabase.COLUMN_CLOUD_PERSIST +
                 ") VALUES (3," +
-                (OpenMode.BOX.ordinal - 3) +
+                (OpenMode.BOX.ordinal - 1) +
                 ",'ijkl')"
         )
         db.execSQL(
@@ -179,7 +194,7 @@ class ExplorerDatabaseMigrationTest {
                 "," +
                 ExplorerDatabase.COLUMN_CLOUD_PERSIST +
                 ") VALUES (4," +
-                (OpenMode.ONEDRIVE.ordinal - 3) +
+                (OpenMode.ONEDRIVE.ordinal - 1) +
                 ",'mnop')"
         )
         db.close()
@@ -188,10 +203,12 @@ class ExplorerDatabaseMigrationTest {
             ExplorerDatabase::class.java,
             TEST_DB
         )
-            .addMigrations(ExplorerDatabase.MIGRATION_7_8)
-            .addMigrations(ExplorerDatabase.MIGRATION_8_9)
-            .addMigrations(ExplorerDatabase.MIGRATION_9_10)
-            .allowMainThreadQueries()
+            .addMigrations(
+                ExplorerDatabase.MIGRATION_7_8,
+                ExplorerDatabase.MIGRATION_8_9,
+                ExplorerDatabase.MIGRATION_9_10,
+                ExplorerDatabase.MIGRATION_10_11
+            ).allowMainThreadQueries()
             .build()
         explorerDatabase.openHelper.writableDatabase
         var verify = explorerDatabase
@@ -242,7 +259,7 @@ class ExplorerDatabaseMigrationTest {
                 "," +
                 ExplorerDatabase.COLUMN_CLOUD_PERSIST +
                 ") VALUES (1," +
-                (OpenMode.GDRIVE.ordinal - 2) +
+                (OpenMode.GDRIVE.ordinal) +
                 ",'abcd')"
         )
         db.execSQL(
@@ -255,7 +272,7 @@ class ExplorerDatabaseMigrationTest {
                 "," +
                 ExplorerDatabase.COLUMN_CLOUD_PERSIST +
                 ") VALUES (2," +
-                (OpenMode.DROPBOX.ordinal - 2) +
+                (OpenMode.DROPBOX.ordinal) +
                 ",'efgh')"
         )
         db.execSQL(
@@ -268,7 +285,7 @@ class ExplorerDatabaseMigrationTest {
                 "," +
                 ExplorerDatabase.COLUMN_CLOUD_PERSIST +
                 ") VALUES (3," +
-                (OpenMode.BOX.ordinal - 2) +
+                (OpenMode.BOX.ordinal) +
                 ",'ijkl')"
         )
         db.execSQL(
@@ -281,7 +298,7 @@ class ExplorerDatabaseMigrationTest {
                 "," +
                 ExplorerDatabase.COLUMN_CLOUD_PERSIST +
                 ") VALUES (4," +
-                (OpenMode.ONEDRIVE.ordinal - 2) +
+                (OpenMode.ONEDRIVE.ordinal) +
                 ",'mnop')"
         )
         db.close()
@@ -290,8 +307,11 @@ class ExplorerDatabaseMigrationTest {
             ExplorerDatabase::class.java,
             TEST_DB
         )
-            .addMigrations(ExplorerDatabase.MIGRATION_8_9)
-            .addMigrations(ExplorerDatabase.MIGRATION_9_10)
+            .addMigrations(
+                ExplorerDatabase.MIGRATION_8_9,
+                ExplorerDatabase.MIGRATION_9_10,
+                ExplorerDatabase.MIGRATION_10_11
+            )
             .allowMainThreadQueries()
             .build()
         explorerDatabase.openHelper.writableDatabase


### PR DESCRIPTION
## Description
So sorry for the problems in 3.8 cycle... this change is to pull explorer.db database version back to 8.

#### Manual tests
- [x] Done 
  
- Device: Pixel 2 emulator
- OS: Android 9.0 + Google API

Test case:
1. Install `release/3.8`
2. Install Amaze Cloud plugin
3. Create SMB, SSH connections
4. Create Cloud connections. Test scenario tested having Dropbox and Google Drive
5. Verify all connections are working
6. Install this changeset which is based on `hotfix/3.8.3`
7. Connections created in 3 and 4 should continue to work, with no prompt for cloud connection logins again

#### Build tasks success  
Successfully running following tasks on local:
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`
