### PR TITLE
Clear cloud connection credentials if loading failed after database migration

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/database/CloudHandler.java
+++ b/app/src/main/java/com/amaze/filemanager/database/CloudHandler.java
@@ -80,6 +80,10 @@ public class CloudHandler {
             throwable -> LOG.warn("failed to delete cloud connection", throwable));
   }
 
+  public void clearAllCloudConnections() {
+    database.cloudEntryDao().clear().subscribeOn(Schedulers.io()).blockingGet();
+  }
+
   public void updateEntry(OpenMode serviceType, CloudEntry newCloudEntry)
       throws CloudPluginException {
 

--- a/app/src/main/java/com/amaze/filemanager/database/daos/CloudEntryDao.java
+++ b/app/src/main/java/com/amaze/filemanager/database/daos/CloudEntryDao.java
@@ -31,6 +31,7 @@ import androidx.room.Dao;
 import androidx.room.Delete;
 import androidx.room.Insert;
 import androidx.room.Query;
+import androidx.room.Transaction;
 import androidx.room.Update;
 
 import io.reactivex.Completable;
@@ -62,4 +63,8 @@ public interface CloudEntryDao {
 
   @Delete
   Completable delete(CloudEntry entry);
+
+  @Transaction
+  @Query("DELETE FROM " + TABLE_CLOUD_PERSIST)
+  Completable clear();
 }

--- a/app/src/main/java/com/amaze/filemanager/ui/activities/MainActivity.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/activities/MainActivity.java
@@ -359,8 +359,20 @@ public class MainActivity extends PermissionsActivity
     mainActivityActionMode = new MainActivityActionMode(new WeakReference<>(MainActivity.this));
 
     if (CloudSheetFragment.isCloudProviderAvailable(this)) {
-
-      LoaderManager.getInstance(this).initLoader(REQUEST_CODE_CLOUD_LIST_KEYS, null, this);
+      try {
+        LoaderManager.getInstance(this).initLoader(REQUEST_CODE_CLOUD_LIST_KEYS, null, this);
+      } catch (Exception errorRaised) {
+        LOG.error("Error initializing cloud connections", errorRaised);
+        cloudHandler.clearAllCloudConnections();
+        AlertDialog.show(
+            this,
+            R.string.cloud_connection_credentials_cleared_msg,
+            R.string.cloud_connection_credentials_cleared,
+            android.R.string.ok,
+            null,
+            false);
+        LoaderManager.getInstance(this).initLoader(REQUEST_CODE_CLOUD_LIST_KEYS, null, this);
+      }
     }
 
     path = intent.getStringExtra("path");

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -794,5 +794,7 @@ You only need to do this once, until the next time you select a new location for
     <string name="disable_player_intent_filters">Disable player intent filters</string>
     <string name="disable_player_intent_filters_summary">Disables Amaze inbuilt media players from file chooser</string>
     <string name="no_app_found_intent">No app found to handle this intent. Do you have DocumentsUI installed?</string>
+    <string name="cloud_connection_credentials_cleared">Cloud Connection credentials cleared</string>
+    <string name="cloud_connection_credentials_cleared_msg">Unfortunately, we were unable to migrate your cloud connection credentials to the new database schema, and we had to remove them from the app. Please create the cloud connection again.</string>
 </resources>
 


### PR DESCRIPTION
## Description
After numerous attempts to fix the problem with database migration and crash on startup, 've decided to wipe out the credentials altogether.

Users just need to re-authorize access to the Cloud plugin again, that should not be a problem; but on the other hand, hope this will never be the show-breaker again - this problem had exist throughout the 3.8 cycle for too long, this must be fixed.

My apologies again to all Amaze users again for the troubles...

#### Issue tracker   
Fixes #3645

#### Manual tests
- [x] Done  
  
Device: Pixel 2 emulator
OS: Android 9
By intentionally create an exception at MainActivity.onCreateLoader(), an alert dialog will popup, while cloud connection credentials will be cleared. Amaze will continue to run, just without the previously established cloud connections

#### Build tasks success  
Successfully running following tasks on local:
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`