### PR TITLE
Upgrade commons-compress to 1.22

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ buildscript {
         espressoVersion = "3.4.0"
         materialDialogsVersion = "0.9.6.0"
         jacocoVersion = "0.8.7"
-        commonsCompressVersion = "1.20"
+        commonsCompressVersion = "1.22"
         libsuVersion = "3.2.1"
         mockkVersion = "1.12.2"
         logbackAndroidVersion = "2.0.0"

--- a/commons_compress_7z/build.gradle
+++ b/commons_compress_7z/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'com.android.library'
+apply plugin: 'kotlin-android'
 
 android {
     compileSdkVersion 28
@@ -21,5 +22,6 @@ android {
 
 dependencies {
     implementation "org.apache.commons:commons-compress:$commonsCompressVersion"
-    implementation 'org.tukaani:xz:1.8'
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation 'org.tukaani:xz:1.9'
 }

--- a/commons_compress_7z/src/main/java/com/amaze/filemanager/filesystem/compressed/sevenz/AES256SHA256Decoder.java
+++ b/commons_compress_7z/src/main/java/com/amaze/filemanager/filesystem/compressed/sevenz/AES256SHA256Decoder.java
@@ -41,15 +41,21 @@ class AES256SHA256Decoder extends CoderBase {
       final InputStream in,
       final long uncompressedLength,
       final Coder coder,
-      final byte[] passwordBytes)
-      throws IOException {
+      final byte[] passwordBytes,
+      final int maxMemoryLimitInKb) {
     return new InputStream() {
-      private boolean isInitialized = false;
-      private CipherInputStream cipherInputStream = null;
+      private boolean isInitialized;
+      private CipherInputStream cipherInputStream;
 
       private CipherInputStream init() throws IOException {
         if (isInitialized) {
           return cipherInputStream;
+        }
+        if (coder.properties == null) {
+          throw new IOException("Missing AES256 properties in " + archiveName);
+        }
+        if (coder.properties.length < 2) {
+          throw new IOException("AES256 properties too short in " + archiveName);
         }
         final int byte0 = 0xff & coder.properties[0];
         final int numCyclesPower = byte0 & 0x3f;
@@ -126,7 +132,11 @@ class AES256SHA256Decoder extends CoderBase {
       }
 
       @Override
-      public void close() {}
+      public void close() throws IOException {
+        if (cipherInputStream != null) {
+          cipherInputStream.close();
+        }
+      }
     };
   }
 }

--- a/commons_compress_7z/src/main/java/com/amaze/filemanager/filesystem/compressed/sevenz/Archive.java
+++ b/commons_compress_7z/src/main/java/com/amaze/filemanager/filesystem/compressed/sevenz/Archive.java
@@ -26,17 +26,17 @@ class Archive {
   /// Offset from beginning of file + SIGNATURE_HEADER_SIZE to packed streams.
   long packPos;
   /// Size of each packed stream.
-  long[] packSizes;
+  long[] packSizes = new long[0];
   /// Whether each particular packed streams has a CRC.
   BitSet packCrcsDefined;
   /// CRCs for each packed stream, valid only if that packed stream has one.
   long[] packCrcs;
   /// Properties of solid compression blocks.
-  Folder[] folders;
+  Folder[] folders = Folder.EMPTY_FOLDER_ARRAY;
   /// Temporary properties for non-empty files (subsumed into the files array later).
   SubStreamsInfo subStreamsInfo;
   /// The files and directories in the archive.
-  SevenZArchiveEntry[] files;
+  SevenZArchiveEntry[] files = SevenZArchiveEntry.EMPTY_SEVEN_Z_ARCHIVE_ENTRY_ARRAY;
   /// Mapping between folders, files and streams.
   StreamMap streamMap;
 

--- a/commons_compress_7z/src/main/java/com/amaze/filemanager/filesystem/compressed/sevenz/Coder.java
+++ b/commons_compress_7z/src/main/java/com/amaze/filemanager/filesystem/compressed/sevenz/Coder.java
@@ -24,5 +24,5 @@ class Coder {
   byte[] decompressionMethodId;
   long numInStreams;
   long numOutStreams;
-  byte[] properties = null;
+  byte[] properties;
 }

--- a/commons_compress_7z/src/main/java/com/amaze/filemanager/filesystem/compressed/sevenz/CoderBase.java
+++ b/commons_compress_7z/src/main/java/com/amaze/filemanager/filesystem/compressed/sevenz/CoderBase.java
@@ -24,11 +24,11 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 
+import org.apache.commons.compress.utils.ByteUtils;
+
 /** Base Codec class. */
 abstract class CoderBase {
   private final Class<?>[] acceptableOptions;
-  private static final byte[] NONE = new byte[0];
-
   /**
    * @param acceptableOptions types that can be used as options for this codec.
    */
@@ -52,7 +52,7 @@ abstract class CoderBase {
    * @return property-bytes to write in a Folder block
    */
   byte[] getOptionsAsProperties(final Object options) throws IOException {
-    return NONE;
+    return ByteUtils.EMPTY_BYTE_ARRAY;
   }
 
   /**
@@ -69,16 +69,17 @@ abstract class CoderBase {
   abstract InputStream decode(
       final String archiveName,
       final InputStream in,
-      long uncomressedLength,
+      long uncompressedLength,
       final Coder coder,
-      byte[] password)
+      byte[] password,
+      int maxMemoryLimitInKb)
       throws IOException;
 
   /**
    * @return a stream that writes to out using the given configuration.
    */
   OutputStream encode(final OutputStream out, final Object options) throws IOException {
-    throw new UnsupportedOperationException("method doesn't support writing");
+    throw new UnsupportedOperationException("Method doesn't support writing");
   }
 
   /**

--- a/commons_compress_7z/src/main/java/com/amaze/filemanager/filesystem/compressed/sevenz/Coders.java
+++ b/commons_compress_7z/src/main/java/com/amaze/filemanager/filesystem/compressed/sevenz/Coders.java
@@ -79,7 +79,8 @@ class Coders {
       final InputStream is,
       final long uncompressedLength,
       final Coder coder,
-      final byte[] password)
+      final byte[] password,
+      final int maxMemoryLimitInKb)
       throws IOException {
     final CoderBase cb = findByMethod(SevenZMethod.byId(coder.decompressionMethodId));
     if (cb == null) {
@@ -89,7 +90,7 @@ class Coders {
               + " used in "
               + archiveName);
     }
-    return cb.decode(archiveName, is, uncompressedLength, coder, password);
+    return cb.decode(archiveName, is, uncompressedLength, coder, password, maxMemoryLimitInKb);
   }
 
   static OutputStream addEncoder(
@@ -108,7 +109,8 @@ class Coders {
         final InputStream in,
         final long uncompressedLength,
         final Coder coder,
-        final byte[] password)
+        final byte[] password,
+        final int maxMemoryLimitInKb)
         throws IOException {
       return in;
     }
@@ -132,7 +134,8 @@ class Coders {
         final InputStream in,
         final long uncompressedLength,
         final Coder coder,
-        final byte[] password)
+        final byte[] password,
+        final int maxMemoryLimitInKb)
         throws IOException {
       try {
         return opts.getInputStream(in);
@@ -168,7 +171,8 @@ class Coders {
         final InputStream in,
         final long uncompressedLength,
         final Coder coder,
-        final byte[] password)
+        final byte[] password,
+        final int maxMemoryLimitInKb)
         throws IOException {
       final Inflater inflater = new Inflater(true);
       // Inflater with nowrap=true has this odd contract for a zero padding
@@ -192,10 +196,11 @@ class Coders {
 
     static class DeflateDecoderInputStream extends InputStream {
 
-      InflaterInputStream inflaterInputStream;
+      final InflaterInputStream inflaterInputStream;
       Inflater inflater;
 
-      public DeflateDecoderInputStream(InflaterInputStream inflaterInputStream, Inflater inflater) {
+      public DeflateDecoderInputStream(
+          final InflaterInputStream inflaterInputStream, final Inflater inflater) {
         this.inflaterInputStream = inflaterInputStream;
         this.inflater = inflater;
       }
@@ -227,11 +232,11 @@ class Coders {
 
     static class DeflateDecoderOutputStream extends OutputStream {
 
-      DeflaterOutputStream deflaterOutputStream;
+      final DeflaterOutputStream deflaterOutputStream;
       Deflater deflater;
 
       public DeflateDecoderOutputStream(
-          DeflaterOutputStream deflaterOutputStream, Deflater deflater) {
+          final DeflaterOutputStream deflaterOutputStream, final Deflater deflater) {
         this.deflaterOutputStream = deflaterOutputStream;
         this.deflater = deflater;
       }
@@ -274,7 +279,8 @@ class Coders {
         final InputStream in,
         final long uncompressedLength,
         final Coder coder,
-        final byte[] password)
+        final byte[] password,
+        final int maxMemoryLimitInKb)
         throws IOException {
       return new Deflate64CompressorInputStream(in);
     }
@@ -291,7 +297,8 @@ class Coders {
         final InputStream in,
         final long uncompressedLength,
         final Coder coder,
-        final byte[] password)
+        final byte[] password,
+        final int maxMemoryLimitInKb)
         throws IOException {
       return new BZip2CompressorInputStream(in);
     }

--- a/commons_compress_7z/src/main/java/com/amaze/filemanager/filesystem/compressed/sevenz/DeltaDecoder.java
+++ b/commons_compress_7z/src/main/java/com/amaze/filemanager/filesystem/compressed/sevenz/DeltaDecoder.java
@@ -39,7 +39,8 @@ class DeltaDecoder extends CoderBase {
       final InputStream in,
       final long uncompressedLength,
       final Coder coder,
-      final byte[] password)
+      final byte[] password,
+      final int maxMemoryLimitInKb)
       throws IOException {
     return new DeltaOptions(getOptionsFromCoder(coder)).getInputStream(in);
   }
@@ -50,7 +51,7 @@ class DeltaDecoder extends CoderBase {
     final int distance = numberOptionOrDefault(options, 1);
     try {
       return new DeltaOptions(distance).getOutputStream(new FinishableWrapperOutputStream(out));
-    } catch (final UnsupportedOptionsException ex) {
+    } catch (final UnsupportedOptionsException ex) { // NOSONAR
       throw new IOException(ex.getMessage());
     }
   }

--- a/commons_compress_7z/src/main/java/com/amaze/filemanager/filesystem/compressed/sevenz/IOUtils.java
+++ b/commons_compress_7z/src/main/java/com/amaze/filemanager/filesystem/compressed/sevenz/IOUtils.java
@@ -1,0 +1,288 @@
+/*
+ * Copyright (C) 2014-2022 Arpit Khurana <arpitkh96@gmail.com>, Vishal Nehra <vishalmeham2@gmail.com>,
+ * Emmanuel Messulam<emmanuelbendavid@gmail.com>, Raymond Lai <airwave209gt at gmail.com> and Contributors.
+ *
+ * This file is part of Amaze File Manager.
+ *
+ * Amaze File Manager is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.amaze.filemanager.filesystem.compressed.sevenz;
+
+import java.io.ByteArrayOutputStream;
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.nio.channels.ReadableByteChannel;
+
+import kotlin.io.ByteStreamsKt;
+
+/**
+ * A trimmed down version of original {@link org.apache.commons.compress.utils.IOUtils} but without
+ * the existence of classes that won't exist in older Androids, as well as removing methods that can
+ * be removed.
+ */
+class IOUtils {
+
+  private static final int COPY_BUF_SIZE = 8024;
+  private static final int SKIP_BUF_SIZE = 4096;
+
+  // This buffer does not need to be synchronized because it is write only; the contents are ignored
+  // Does not affect Immutability
+  private static final byte[] SKIP_BUF = new byte[SKIP_BUF_SIZE];
+
+  /** Private constructor to prevent instantiation of this utility class. */
+  private IOUtils() {}
+
+  /**
+   * Copies the content of a InputStream into an OutputStream. Uses a default buffer size of 8024
+   * bytes.
+   *
+   * @param input the InputStream to copy
+   * @param output the target, may be null to simulate output to dev/null on Linux and NUL on
+   *     Windows
+   * @return the number of bytes copied
+   * @throws IOException if an error occurs
+   */
+  public static long copy(final InputStream input, final OutputStream output) throws IOException {
+    return copy(input, output, COPY_BUF_SIZE);
+  }
+
+  /**
+   * Copies the content of a InputStream into an OutputStream
+   *
+   * @param input the InputStream to copy
+   * @param output the target, may be null to simulate output to dev/null on Linux and NUL on
+   *     Windows
+   * @param buffersize the buffer size to use, must be bigger than 0
+   * @return the number of bytes copied
+   * @throws IOException if an error occurs
+   * @throws IllegalArgumentException if buffersize is smaller than or equal to 0
+   */
+  public static long copy(final InputStream input, final OutputStream output, final int buffersize)
+      throws IOException {
+    return ByteStreamsKt.copyTo(input, output, buffersize);
+  }
+
+  /**
+   * Skips the given number of bytes by repeatedly invoking skip on the given input stream if
+   * necessary.
+   *
+   * <p>In a case where the stream's skip() method returns 0 before the requested number of bytes
+   * has been skip this implementation will fall back to using the read() method.
+   *
+   * <p>This method will only skip less than the requested number of bytes if the end of the input
+   * stream has been reached.
+   *
+   * @param input stream to skip bytes in
+   * @param numToSkip the number of bytes to skip
+   * @return the number of bytes actually skipped
+   * @throws IOException on error
+   */
+  public static long skip(final InputStream input, long numToSkip) throws IOException {
+    final long available = numToSkip;
+    while (numToSkip > 0) {
+      final long skipped = input.skip(numToSkip);
+      if (skipped == 0) {
+        break;
+      }
+      numToSkip -= skipped;
+    }
+
+    while (numToSkip > 0) {
+      final int read = readFully(input, SKIP_BUF, 0, (int) Math.min(numToSkip, SKIP_BUF_SIZE));
+      if (read < 1) {
+        break;
+      }
+      numToSkip -= read;
+    }
+    return available - numToSkip;
+  }
+
+  /**
+   * Reads as much from input as possible to fill the given array with the given amount of bytes.
+   *
+   * <p>This method may invoke read repeatedly to read the bytes and only read less bytes than the
+   * requested length if the end of the stream has been reached.
+   *
+   * @param input stream to read from
+   * @param array buffer to fill
+   * @param offset offset into the buffer to start filling at
+   * @param len of bytes to read
+   * @return the number of bytes actually read
+   * @throws IOException if an I/O error has occurred
+   */
+  public static int readFully(
+      final InputStream input, final byte[] array, final int offset, final int len)
+      throws IOException {
+    if (len < 0 || offset < 0 || len + offset > array.length || len + offset < 0) {
+      throw new IndexOutOfBoundsException();
+    }
+    int count = 0, x = 0;
+    while (count != len) {
+      x = input.read(array, offset + count, len - count);
+      if (x == -1) {
+        break;
+      }
+      count += x;
+    }
+    return count;
+  }
+
+  /**
+   * Reads {@code b.remaining()} bytes from the given channel starting at the current channel's
+   * position.
+   *
+   * <p>This method reads repeatedly from the channel until the requested number of bytes are read.
+   * This method blocks until the requested number of bytes are read, the end of the channel is
+   * detected, or an exception is thrown.
+   *
+   * @param channel the channel to read from
+   * @param byteBuffer the buffer into which the data is read.
+   * @throws IOException - if an I/O error occurs.
+   * @throws EOFException - if the channel reaches the end before reading all the bytes.
+   */
+  public static void readFully(final ReadableByteChannel channel, final ByteBuffer byteBuffer)
+      throws IOException {
+    final int expectedLength = byteBuffer.remaining();
+    int read = 0;
+    while (read < expectedLength) {
+      final int readNow = channel.read(byteBuffer);
+      if (readNow <= 0) {
+        break;
+      }
+      read += readNow;
+    }
+    if (read < expectedLength) {
+      throw new EOFException();
+    }
+  }
+
+  // toByteArray(InputStream) copied from:
+  // commons/proper/io/trunk/src/main/java/org/apache/commons/io/IOUtils.java?revision=1428941
+  // January 8th, 2013
+  //
+  // Assuming our copy() works just as well as theirs!  :-)
+
+  /**
+   * Gets the contents of an {@code InputStream} as a {@code byte[]}.
+   *
+   * <p>This method buffers the input internally, so there is no need to use a {@code
+   * BufferedInputStream}.
+   *
+   * @param input the {@code InputStream} to read from
+   * @return the requested byte array
+   * @throws NullPointerException if the input is null
+   * @throws IOException if an I/O error occurs
+   * @since 1.5
+   */
+  public static byte[] toByteArray(final InputStream input) throws IOException {
+    return ByteStreamsKt.readBytes(input);
+  }
+
+  /**
+   * Copies part of the content of a InputStream into an OutputStream. Uses a default buffer size of
+   * 8024 bytes.
+   *
+   * @param input the InputStream to copy
+   * @param output the target Stream
+   * @param len maximum amount of bytes to copy
+   * @return the number of bytes copied
+   * @throws IOException if an error occurs
+   * @since 1.21
+   */
+  public static long copyRange(final InputStream input, final long len, final OutputStream output)
+      throws IOException {
+    return copyRange(input, len, output, COPY_BUF_SIZE);
+  }
+
+  /**
+   * Copies part of the content of a InputStream into an OutputStream
+   *
+   * @param input the InputStream to copy
+   * @param len maximum amount of bytes to copy
+   * @param output the target, may be null to simulate output to dev/null on Linux and NUL on
+   *     Windows
+   * @param buffersize the buffer size to use, must be bigger than 0
+   * @return the number of bytes copied
+   * @throws IOException if an error occurs
+   * @throws IllegalArgumentException if buffersize is smaller than or equal to 0
+   * @since 1.21
+   */
+  public static long copyRange(
+      final InputStream input, final long len, final OutputStream output, final int buffersize)
+      throws IOException {
+    if (buffersize < 1) {
+      throw new IllegalArgumentException("buffersize must be bigger than 0");
+    }
+    final byte[] buffer = new byte[(int) Math.min(buffersize, len)];
+    int n = 0;
+    long count = 0;
+    while (count < len
+        && -1 != (n = input.read(buffer, 0, (int) Math.min(len - count, buffer.length)))) {
+      if (output != null) {
+        output.write(buffer, 0, n);
+      }
+      count += n;
+    }
+    return count;
+  }
+
+  /**
+   * Gets part of the contents of an {@code InputStream} as a {@code byte[]}.
+   *
+   * @param input the {@code InputStream} to read from
+   * @param len maximum amount of bytes to copy
+   * @return the requested byte array
+   * @throws NullPointerException if the input is null
+   * @throws IOException if an I/O error occurs
+   * @since 1.21
+   */
+  public static byte[] readRange(final InputStream input, final int len) throws IOException {
+    final ByteArrayOutputStream output = new ByteArrayOutputStream();
+    copyRange(input, len, output);
+    return output.toByteArray();
+  }
+
+  /**
+   * Gets part of the contents of an {@code ReadableByteChannel} as a {@code byte[]}.
+   *
+   * @param input the {@code ReadableByteChannel} to read from
+   * @param len maximum amount of bytes to copy
+   * @return the requested byte array
+   * @throws NullPointerException if the input is null
+   * @throws IOException if an I/O error occurs
+   * @since 1.21
+   */
+  public static byte[] readRange(final ReadableByteChannel input, final int len)
+      throws IOException {
+    final ByteArrayOutputStream output = new ByteArrayOutputStream();
+    final ByteBuffer b = ByteBuffer.allocate(Math.min(len, COPY_BUF_SIZE));
+    int read = 0;
+    while (read < len) {
+      // Make sure we never read more than len bytes
+      b.limit(Math.min(len - read, b.capacity()));
+      final int readNow = input.read(b);
+      if (readNow <= 0) {
+        break;
+      }
+      output.write(b.array(), 0, readNow);
+      b.rewind();
+      read += readNow;
+    }
+    return output.toByteArray();
+  }
+}

--- a/commons_compress_7z/src/main/java/com/amaze/filemanager/filesystem/compressed/sevenz/SevenZArchiveEntry.java
+++ b/commons_compress_7z/src/main/java/com/amaze/filemanager/filesystem/compressed/sevenz/SevenZArchiveEntry.java
@@ -20,10 +20,13 @@
 
 package com.amaze.filemanager.filesystem.compressed.sevenz;
 
+import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Collections;
 import java.util.Date;
+import java.util.Iterator;
 import java.util.LinkedList;
+import java.util.Objects;
 import java.util.TimeZone;
 
 import org.apache.commons.compress.archivers.ArchiveEntry;
@@ -50,6 +53,7 @@ public class SevenZArchiveEntry implements ArchiveEntry {
   private long crc, compressedCrc;
   private long size, compressedSize;
   private Iterable<? extends SevenZMethodConfiguration> contentMethods;
+  static final SevenZArchiveEntry[] EMPTY_SEVEN_Z_ARCHIVE_ENTRY_ARRAY = new SevenZArchiveEntry[0];
 
   public SevenZArchiveEntry() {}
 
@@ -369,7 +373,7 @@ public class SevenZArchiveEntry implements ArchiveEntry {
   /**
    * Gets the CRC.
    *
-   * @since Compress 1.7
+   * @since 1.7
    * @return the CRC
    */
   public long getCrcValue() {
@@ -379,7 +383,7 @@ public class SevenZArchiveEntry implements ArchiveEntry {
   /**
    * Sets the CRC.
    *
-   * @since Compress 1.7
+   * @since 1.7
    * @param crc the CRC
    */
   public void setCrcValue(final long crc) {
@@ -411,7 +415,7 @@ public class SevenZArchiveEntry implements ArchiveEntry {
   /**
    * Gets the compressed CRC.
    *
-   * @since Compress 1.7
+   * @since 1.7
    * @return the CRC
    */
   long getCompressedCrcValue() {
@@ -421,7 +425,7 @@ public class SevenZArchiveEntry implements ArchiveEntry {
   /**
    * Sets the compressed CRC.
    *
-   * @since Compress 1.7
+   * @since 1.7
    * @param crc the CRC
    */
   void setCompressedCrcValue(final long crc) {
@@ -489,6 +493,21 @@ public class SevenZArchiveEntry implements ArchiveEntry {
   }
 
   /**
+   * Sets the (compression) methods to use for entry's content - the default is LZMA2.
+   *
+   * <p>Currently only {@link SevenZMethod#COPY}, {@link SevenZMethod#LZMA2}, {@link
+   * SevenZMethod#BZIP2} and {@link SevenZMethod#DEFLATE} are supported when writing archives.
+   *
+   * <p>The methods will be consulted in iteration order to create the final output.
+   *
+   * @param methods the methods to use for the content
+   * @since 1.22
+   */
+  public void setContentMethods(SevenZMethodConfiguration... methods) {
+    setContentMethods(Arrays.asList(methods));
+  }
+
+  /**
    * Gets the (compression) methods to use for entry's content - the default is LZMA2.
    *
    * <p>Currently only {@link SevenZMethod#COPY}, {@link SevenZMethod#LZMA2}, {@link
@@ -501,6 +520,41 @@ public class SevenZArchiveEntry implements ArchiveEntry {
    */
   public Iterable<? extends SevenZMethodConfiguration> getContentMethods() {
     return contentMethods;
+  }
+
+  @Override
+  public int hashCode() {
+    final String n = getName();
+    return n == null ? 0 : n.hashCode();
+  }
+
+  @Override
+  public boolean equals(final Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (obj == null || getClass() != obj.getClass()) {
+      return false;
+    }
+    final SevenZArchiveEntry other = (SevenZArchiveEntry) obj;
+    return Objects.equals(name, other.name)
+        && hasStream == other.hasStream
+        && isDirectory == other.isDirectory
+        && isAntiItem == other.isAntiItem
+        && hasCreationDate == other.hasCreationDate
+        && hasLastModifiedDate == other.hasLastModifiedDate
+        && hasAccessDate == other.hasAccessDate
+        && creationDate == other.creationDate
+        && lastModifiedDate == other.lastModifiedDate
+        && accessDate == other.accessDate
+        && hasWindowsAttributes == other.hasWindowsAttributes
+        && windowsAttributes == other.windowsAttributes
+        && hasCrc == other.hasCrc
+        && crc == other.crc
+        && compressedCrc == other.compressedCrc
+        && size == other.size
+        && compressedSize == other.compressedSize
+        && equalSevenZMethods(contentMethods, other.contentMethods);
   }
 
   /**
@@ -530,5 +584,26 @@ public class SevenZArchiveEntry implements ArchiveEntry {
     ntfsEpoch.set(1601, 0, 1, 0, 0, 0);
     ntfsEpoch.set(Calendar.MILLISECOND, 0);
     return ((date.getTime() - ntfsEpoch.getTimeInMillis()) * 1000 * 10);
+  }
+
+  private boolean equalSevenZMethods(
+      final Iterable<? extends SevenZMethodConfiguration> c1,
+      final Iterable<? extends SevenZMethodConfiguration> c2) {
+    if (c1 == null) {
+      return c2 == null;
+    }
+    if (c2 == null) {
+      return false;
+    }
+    final Iterator<? extends SevenZMethodConfiguration> i2 = c2.iterator();
+    for (SevenZMethodConfiguration element : c1) {
+      if (!i2.hasNext()) {
+        return false;
+      }
+      if (!element.equals(i2.next())) {
+        return false;
+      }
+    }
+    return !i2.hasNext();
   }
 }

--- a/commons_compress_7z/src/main/java/com/amaze/filemanager/filesystem/compressed/sevenz/SevenZFile.java
+++ b/commons_compress_7z/src/main/java/com/amaze/filemanager/filesystem/compressed/sevenz/SevenZFile.java
@@ -24,6 +24,7 @@ import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.Closeable;
 import java.io.DataInputStream;
+import java.io.EOFException;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FilterInputStream;
@@ -32,23 +33,27 @@ import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.CharBuffer;
+import java.nio.channels.Channels;
 import java.nio.channels.FileChannel;
 import java.nio.charset.Charset;
-import java.nio.charset.CharsetEncoder;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.BitSet;
+import java.util.LinkedHashMap;
 import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
 import java.util.zip.CRC32;
+import java.util.zip.CheckedInputStream;
 
+import org.apache.commons.compress.MemoryLimitException;
 import org.apache.commons.compress.utils.BoundedInputStream;
+import org.apache.commons.compress.utils.ByteUtils;
 import org.apache.commons.compress.utils.CRC32VerifyingInputStream;
-import org.apache.commons.compress.utils.CharsetNames;
-import org.apache.commons.compress.utils.IOUtils;
 import org.apache.commons.compress.utils.InputStreamStatistics;
 
 /**
- * Reads a 7z file, using FileChannel under the covers.
+ * Reads a 7z file, using SeekableByteChannel under the covers.
  *
  * <p>The 7z file format is a flexible container that can contain many compression and encryption
  * types, but at the moment only only Copy, LZMA, LZMA2, BZIP2, Deflate and AES-256 + SHA-256 are
@@ -61,20 +66,27 @@ import org.apache.commons.compress.utils.InputStreamStatistics;
  *
  * <p>Both the header and file contents may be compressed and/or encrypted. With both encrypted,
  * neither file names nor file contents can be read, but the use of encryption isn't plausibly
- * deniable. @NotThreadSafe
+ * deniable.
+ *
+ * <p>Multi volume archives can be read by concatenating the parts in correct order - either
+ * manually or by using {link org.apache.commons.compress.utils.MultiReadOnlySeekableByteChannel}
+ * for example. @NotThreadSafe
  *
  * @since 1.6
  */
 public class SevenZFile implements Closeable {
   static final int SIGNATURE_HEADER_SIZE = 32;
 
+  private static final String DEFAULT_FILE_NAME = "unknown archive";
+
   private final String fileName;
   private FileChannel channel;
   private final Archive archive;
   private int currentEntryIndex = -1;
   private int currentFolderIndex = -1;
-  private InputStream currentFolderInputStream = null;
+  private InputStream currentFolderInputStream;
   private byte[] password;
+  private final SevenZFileOptions options;
 
   private long compressedBytesReadFromCurrentEntry;
   private long uncompressedBytesReadFromCurrentEntry;
@@ -89,34 +101,55 @@ public class SevenZFile implements Closeable {
   /**
    * Reads a file as 7z archive
    *
-   * @param filename the file to read
+   * @param fileName the file to read
    * @param password optional password if the archive is encrypted
    * @throws IOException if reading the archive fails
    * @since 1.17
    */
-  public SevenZFile(final File filename, final char[] password) throws IOException {
+  public SevenZFile(final File fileName, final char[] password) throws IOException {
+    this(fileName, password, SevenZFileOptions.DEFAULT);
+  }
+
+  /**
+   * Reads a file as 7z archive with additional options.
+   *
+   * @param fileName the file to read
+   * @param password optional password if the archive is encrypted
+   * @param options the options to apply
+   * @throws IOException if reading the archive fails or the memory limit (if set) is too small
+   * @since 1.19
+   */
+  public SevenZFile(final File fileName, final char[] password, final SevenZFileOptions options)
+      throws IOException {
     this(
-        new FileInputStream(filename).getChannel(),
-        filename.getAbsolutePath(),
+        new FileInputStream(fileName).getChannel(), // NOSONAR
+        fileName.getAbsolutePath(),
         utf16Decode(password),
-        true);
+        true,
+        options);
   }
 
   /**
    * Reads a file as 7z archive
    *
-   * @param filename the file to read
+   * @param fileName the file to read
    * @param password optional password if the archive is encrypted - the byte array is supposed to
    *     be the UTF16-LE encoded representation of the password.
    * @throws IOException if reading the archive fails
    * @deprecated use the char[]-arg version for the password instead
    */
-  public SevenZFile(final File filename, final byte[] password) throws IOException {
-    this(new FileInputStream(filename).getChannel(), filename.getAbsolutePath(), password, true);
+  @Deprecated
+  public SevenZFile(final File fileName, final byte[] password) throws IOException {
+    this(
+        new FileInputStream(fileName).getChannel(),
+        fileName.getAbsolutePath(),
+        password,
+        true,
+        SevenZFileOptions.DEFAULT);
   }
 
   /**
-   * Reads a FileChannel as 7z archive
+   * Reads a SeekableByteChannel as 7z archive
    *
    * <p>{@link org.apache.commons.compress.utils.SeekableInMemoryByteChannel} allows you to read
    * from an in-memory archive.
@@ -126,11 +159,26 @@ public class SevenZFile implements Closeable {
    * @since 1.13
    */
   public SevenZFile(final FileChannel channel) throws IOException {
-    this(channel, "unknown archive", (char[]) null);
+    this(channel, SevenZFileOptions.DEFAULT);
   }
 
   /**
-   * Reads a FileChannel as 7z archive
+   * Reads a SeekableByteChannel as 7z archive with addtional options.
+   *
+   * <p>{@link org.apache.commons.compress.utils.SeekableInMemoryByteChannel} allows you to read
+   * from an in-memory archive.
+   *
+   * @param channel the channel to read
+   * @param options the options to apply
+   * @throws IOException if reading the archive fails or the memory limit (if set) is too small
+   * @since 1.19
+   */
+  public SevenZFile(final FileChannel channel, final SevenZFileOptions options) throws IOException {
+    this(channel, DEFAULT_FILE_NAME, null, options);
+  }
+
+  /**
+   * Reads a SeekableByteChannel as 7z archive
    *
    * <p>{@link org.apache.commons.compress.utils.SeekableInMemoryByteChannel} allows you to read
    * from an in-memory archive.
@@ -141,83 +189,148 @@ public class SevenZFile implements Closeable {
    * @since 1.17
    */
   public SevenZFile(final FileChannel channel, final char[] password) throws IOException {
-    this(channel, "unknown archive", utf16Decode(password));
+    this(channel, password, SevenZFileOptions.DEFAULT);
   }
 
   /**
-   * Reads a FileChannel as 7z archive
+   * Reads a SeekableByteChannel as 7z archive with additional options.
    *
    * <p>{@link org.apache.commons.compress.utils.SeekableInMemoryByteChannel} allows you to read
    * from an in-memory archive.
    *
    * @param channel the channel to read
-   * @param filename name of the archive - only used for error reporting
+   * @param password optional password if the archive is encrypted
+   * @param options the options to apply
+   * @throws IOException if reading the archive fails or the memory limit (if set) is too small
+   * @since 1.19
+   */
+  public SevenZFile(
+      final FileChannel channel, final char[] password, final SevenZFileOptions options)
+      throws IOException {
+    this(channel, DEFAULT_FILE_NAME, password, options);
+  }
+
+  /**
+   * Reads a SeekableByteChannel as 7z archive
+   *
+   * <p>{@link org.apache.commons.compress.utils.SeekableInMemoryByteChannel} allows you to read
+   * from an in-memory archive.
+   *
+   * @param channel the channel to read
+   * @param fileName name of the archive - only used for error reporting
    * @param password optional password if the archive is encrypted
    * @throws IOException if reading the archive fails
    * @since 1.17
    */
-  public SevenZFile(final FileChannel channel, String filename, final char[] password)
+  public SevenZFile(final FileChannel channel, final String fileName, final char[] password)
       throws IOException {
-    this(channel, filename, utf16Decode(password), false);
+    this(channel, fileName, password, SevenZFileOptions.DEFAULT);
   }
 
   /**
-   * Reads a FileChannel as 7z archive
+   * Reads a SeekableByteChannel as 7z archive with addtional options.
    *
    * <p>{@link org.apache.commons.compress.utils.SeekableInMemoryByteChannel} allows you to read
    * from an in-memory archive.
    *
    * @param channel the channel to read
-   * @param filename name of the archive - only used for error reporting
+   * @param fileName name of the archive - only used for error reporting
+   * @param password optional password if the archive is encrypted
+   * @param options the options to apply
+   * @throws IOException if reading the archive fails or the memory limit (if set) is too small
+   * @since 1.19
+   */
+  public SevenZFile(
+      final FileChannel channel,
+      final String fileName,
+      final char[] password,
+      final SevenZFileOptions options)
+      throws IOException {
+    this(channel, fileName, utf16Decode(password), false, options);
+  }
+
+  /**
+   * Reads a SeekableByteChannel as 7z archive
+   *
+   * <p>{@link org.apache.commons.compress.utils.SeekableInMemoryByteChannel} allows you to read
+   * from an in-memory archive.
+   *
+   * @param channel the channel to read
+   * @param fileName name of the archive - only used for error reporting
    * @throws IOException if reading the archive fails
    * @since 1.17
    */
-  public SevenZFile(final FileChannel channel, String filename) throws IOException {
-    this(channel, filename, null, false);
+  public SevenZFile(final FileChannel channel, final String fileName) throws IOException {
+    this(channel, fileName, SevenZFileOptions.DEFAULT);
   }
 
   /**
-   * Reads a FileChannel as 7z archive
+   * Reads a SeekableByteChannel as 7z archive with additional options.
    *
    * <p>{@link org.apache.commons.compress.utils.SeekableInMemoryByteChannel} allows you to read
    * from an in-memory archive.
    *
    * @param channel the channel to read
-   * @param password optional password if the archive is encrypted - the byte array is supposed to
-   *     be the UTF16-LE encoded representation of the password.
-   * @throws IOException if reading the archive fails
-   * @since 1.13
-   * @deprecated use the char[]-arg version for the password instead
+   * @param fileName name of the archive - only used for error reporting
+   * @param options the options to apply
+   * @throws IOException if reading the archive fails or the memory limit (if set) is too small
+   * @since 1.19
    */
-  public SevenZFile(final FileChannel channel, final byte[] password) throws IOException {
-    this(channel, "unknown archive", password);
-  }
-
-  /**
-   * Reads a FileChannel as 7z archive
-   *
-   * <p>{@link org.apache.commons.compress.utils.SeekableInMemoryByteChannel} allows you to read
-   * from an in-memory archive.
-   *
-   * @param channel the channel to read
-   * @param filename name of the archive - only used for error reporting
-   * @param password optional password if the archive is encrypted - the byte array is supposed to
-   *     be the UTF16-LE encoded representation of the password.
-   * @throws IOException if reading the archive fails
-   * @since 1.13
-   * @deprecated use the char[]-arg version for the password instead
-   */
-  public SevenZFile(final FileChannel channel, String filename, final byte[] password)
+  public SevenZFile(
+      final FileChannel channel, final String fileName, final SevenZFileOptions options)
       throws IOException {
-    this(channel, filename, password, false);
+    this(channel, fileName, null, false, options);
+  }
+
+  /**
+   * Reads a SeekableByteChannel as 7z archive
+   *
+   * <p>{@link org.apache.commons.compress.utils.SeekableInMemoryByteChannel} allows you to read
+   * from an in-memory archive.
+   *
+   * @param channel the channel to read
+   * @param password optional password if the archive is encrypted - the byte array is supposed to
+   *     be the UTF16-LE encoded representation of the password.
+   * @throws IOException if reading the archive fails
+   * @since 1.13
+   * @deprecated use the char[]-arg version for the password instead
+   */
+  @Deprecated
+  public SevenZFile(final FileChannel channel, final byte[] password) throws IOException {
+    this(channel, DEFAULT_FILE_NAME, password);
+  }
+
+  /**
+   * Reads a SeekableByteChannel as 7z archive
+   *
+   * <p>{@link org.apache.commons.compress.utils.SeekableInMemoryByteChannel} allows you to read
+   * from an in-memory archive.
+   *
+   * @param channel the channel to read
+   * @param fileName name of the archive - only used for error reporting
+   * @param password optional password if the archive is encrypted - the byte array is supposed to
+   *     be the UTF16-LE encoded representation of the password.
+   * @throws IOException if reading the archive fails
+   * @since 1.13
+   * @deprecated use the char[]-arg version for the password instead
+   */
+  @Deprecated
+  public SevenZFile(final FileChannel channel, final String fileName, final byte[] password)
+      throws IOException {
+    this(channel, fileName, password, false, SevenZFileOptions.DEFAULT);
   }
 
   private SevenZFile(
-      final FileChannel channel, String filename, final byte[] password, boolean closeOnError)
+      final FileChannel channel,
+      final String filename,
+      final byte[] password,
+      final boolean closeOnError,
+      final SevenZFileOptions options)
       throws IOException {
     boolean succeeded = false;
     this.channel = channel;
     this.fileName = filename;
+    this.options = options;
     try {
       archive = readHeaders(password);
       if (password != null) {
@@ -236,11 +349,23 @@ public class SevenZFile implements Closeable {
   /**
    * Reads a file as unencrypted 7z archive
    *
-   * @param filename the file to read
+   * @param fileName the file to read
    * @throws IOException if reading the archive fails
    */
-  public SevenZFile(final File filename) throws IOException {
-    this(filename, (char[]) null);
+  public SevenZFile(final File fileName) throws IOException {
+    this(fileName, SevenZFileOptions.DEFAULT);
+  }
+
+  /**
+   * Reads a file as unencrypted 7z archive
+   *
+   * @param fileName the file to read
+   * @param options the options to apply
+   * @throws IOException if reading the archive fails or the memory limit (if set) is too small
+   * @since 1.19
+   */
+  public SevenZFile(final File fileName, final SevenZFileOptions options) throws IOException {
+    this(fileName, null, options);
   }
 
   /**
@@ -275,13 +400,16 @@ public class SevenZFile implements Closeable {
     }
     ++currentEntryIndex;
     final SevenZArchiveEntry entry = archive.files[currentEntryIndex];
-    buildDecodingStream();
+    if (entry.getName() == null && options.getUseDefaultNameForUnnamedEntries()) {
+      entry.setName(getDefaultName());
+    }
+    buildDecodingStream(currentEntryIndex, false);
     uncompressedBytesReadFromCurrentEntry = compressedBytesReadFromCurrentEntry = 0;
     return entry;
   }
 
   /**
-   * Returns meta-data of all archive entries.
+   * Returns a copy of meta-data of all archive entries.
    *
    * <p>This method only provides meta-data, the entries can not be used to read the contents, you
    * still need to process all entries in order using {@link #getNextEntry} for that.
@@ -289,15 +417,15 @@ public class SevenZFile implements Closeable {
    * <p>The content methods are only available for entries that have already been reached via {@link
    * #getNextEntry}.
    *
-   * @return meta-data of all archive entries.
+   * @return a copy of meta-data of all archive entries.
    * @since 1.11
    */
   public Iterable<SevenZArchiveEntry> getEntries() {
-    return Arrays.asList(archive.files);
+    return new ArrayList<>(Arrays.asList(archive.files));
   }
 
   private Archive readHeaders(final byte[] password) throws IOException {
-    ByteBuffer buf =
+    final ByteBuffer buf =
         ByteBuffer.allocate(12 /* signature + 2 bytes version + 4 bytes CRC */)
             .order(ByteOrder.LITTLE_ENDIAN);
     readFully(buf);
@@ -315,23 +443,104 @@ public class SevenZFile implements Closeable {
               "Unsupported 7z version (%d,%d)", archiveVersionMajor, archiveVersionMinor));
     }
 
+    boolean headerLooksValid =
+        false; // See https://www.7-zip.org/recover.html - "There is no correct End Header at the
+    // end of archive"
     final long startHeaderCrc = 0xffffFFFFL & buf.getInt();
-    final StartHeader startHeader = readStartHeader(startHeaderCrc);
+    if (startHeaderCrc == 0) {
+      // This is an indication of a corrupt header - peek the next 20 bytes
+      final long currentPosition = channel.position();
+      final ByteBuffer peekBuf = ByteBuffer.allocate(20);
+      readFully(peekBuf);
+      channel.position(currentPosition);
+      // Header invalid if all data is 0
+      while (peekBuf.hasRemaining()) {
+        if (peekBuf.get() != 0) {
+          headerLooksValid = true;
+          break;
+        }
+      }
+    } else {
+      headerLooksValid = true;
+    }
 
+    if (headerLooksValid) {
+      return initializeArchive(readStartHeader(startHeaderCrc), password, true);
+    }
+    // No valid header found - probably first file of multipart archive was removed too early. Scan
+    // for end header.
+    if (options.getTryToRecoverBrokenArchives()) {
+      return tryToLocateEndHeader(password);
+    }
+    throw new IOException(
+        "archive seems to be invalid.\nYou may want to retry and enable the"
+            + " tryToRecoverBrokenArchives if the archive could be a multi volume archive that has been closed"
+            + " prematurely.");
+  }
+
+  private Archive tryToLocateEndHeader(final byte[] password) throws IOException {
+    final ByteBuffer nidBuf = ByteBuffer.allocate(1);
+    final long searchLimit = 1024L * 1024 * 1;
+    // Main header, plus bytes that readStartHeader would read
+    final long previousDataSize = channel.position() + 20;
+    final long minPos;
+    // Determine minimal position - can't start before current position
+    if (channel.position() + searchLimit > channel.size()) {
+      minPos = channel.position();
+    } else {
+      minPos = channel.size() - searchLimit;
+    }
+    long pos = channel.size() - 1;
+    // Loop: Try from end of archive
+    while (pos > minPos) {
+      pos--;
+      channel.position(pos);
+      nidBuf.rewind();
+      if (channel.read(nidBuf) < 1) {
+        throw new EOFException();
+      }
+      final int nid = nidBuf.array()[0];
+      // First indicator: Byte equals one of these header identifiers
+      if (nid == NID.kEncodedHeader || nid == NID.kHeader) {
+        try {
+          // Try to initialize Archive structure from here
+          final StartHeader startHeader = new StartHeader();
+          startHeader.nextHeaderOffset = pos - previousDataSize;
+          startHeader.nextHeaderSize = channel.size() - pos;
+          final Archive result = initializeArchive(startHeader, password, false);
+          // Sanity check: There must be some data...
+          if (result.packSizes.length > 0 && result.files.length > 0) {
+            return result;
+          }
+        } catch (final Exception ignore) {
+          // Wrong guess...
+        }
+      }
+    }
+    throw new IOException("Start header corrupt and unable to guess end header");
+  }
+
+  private Archive initializeArchive(
+      final StartHeader startHeader, final byte[] password, final boolean verifyCrc)
+      throws IOException {
+    assertFitsIntoNonNegativeInt("nextHeaderSize", startHeader.nextHeaderSize);
     final int nextHeaderSizeInt = (int) startHeader.nextHeaderSize;
-    if (nextHeaderSizeInt != startHeader.nextHeaderSize) {
-      throw new IOException("cannot handle nextHeaderSize " + startHeader.nextHeaderSize);
-    }
     channel.position(SIGNATURE_HEADER_SIZE + startHeader.nextHeaderOffset);
-    buf = ByteBuffer.allocate(nextHeaderSizeInt).order(ByteOrder.LITTLE_ENDIAN);
-    readFully(buf);
-    final CRC32 crc = new CRC32();
-    crc.update(buf.array());
-    if (startHeader.nextHeaderCrc != crc.getValue()) {
-      throw new IOException("NextHeader CRC mismatch");
+    if (verifyCrc) {
+      final long position = channel.position();
+      CheckedInputStream cis =
+          new CheckedInputStream(Channels.newInputStream(channel), new CRC32());
+      if (cis.skip(nextHeaderSizeInt) != nextHeaderSizeInt) {
+        throw new IOException("Problem computing NextHeader CRC-32");
+      }
+      if (startHeader.nextHeaderCrc != cis.getChecksum().getValue()) {
+        throw new IOException("NextHeader CRC-32 mismatch");
+      }
+      channel.position(position);
     }
-
     Archive archive = new Archive();
+    ByteBuffer buf = ByteBuffer.allocate(nextHeaderSizeInt).order(ByteOrder.LITTLE_ENDIAN);
+    readFully(buf);
     int nid = getUnsignedByte(buf);
     if (nid == NID.kEncodedHeader) {
       buf = readEncodedHeader(buf, archive, password);
@@ -339,11 +548,11 @@ public class SevenZFile implements Closeable {
       archive = new Archive();
       nid = getUnsignedByte(buf);
     }
-    if (nid == NID.kHeader) {
-      readHeader(buf, archive);
-    } else {
+    if (nid != NID.kHeader) {
       throw new IOException("Broken or unsupported archive: no Header");
     }
+    readHeader(buf, archive);
+    archive.subStreamsInfo = null;
     return archive;
   }
 
@@ -351,17 +560,35 @@ public class SevenZFile implements Closeable {
     final StartHeader startHeader = new StartHeader();
     // using Stream rather than ByteBuffer for the benefit of the
     // built-in CRC check
-    DataInputStream dataInputStream =
+    try (DataInputStream dataInputStream =
         new DataInputStream(
             new CRC32VerifyingInputStream(
-                new BoundedFileChannelInputStream(channel, 20), 20, startHeaderCrc));
-    startHeader.nextHeaderOffset = Long.reverseBytes(dataInputStream.readLong());
-    startHeader.nextHeaderSize = Long.reverseBytes(dataInputStream.readLong());
-    startHeader.nextHeaderCrc = 0xffffFFFFL & Integer.reverseBytes(dataInputStream.readInt());
-    return startHeader;
+                new BoundedFileChannelInputStream(channel, 20), 20, startHeaderCrc))) {
+      startHeader.nextHeaderOffset = Long.reverseBytes(dataInputStream.readLong());
+      if (startHeader.nextHeaderOffset < 0
+          || startHeader.nextHeaderOffset + SIGNATURE_HEADER_SIZE > channel.size()) {
+        throw new IOException("nextHeaderOffset is out of bounds");
+      }
+
+      startHeader.nextHeaderSize = Long.reverseBytes(dataInputStream.readLong());
+      final long nextHeaderEnd = startHeader.nextHeaderOffset + startHeader.nextHeaderSize;
+      if (nextHeaderEnd < startHeader.nextHeaderOffset
+          || nextHeaderEnd + SIGNATURE_HEADER_SIZE > channel.size()) {
+        throw new IOException("nextHeaderSize is out of bounds");
+      }
+
+      startHeader.nextHeaderCrc = 0xffffFFFFL & Integer.reverseBytes(dataInputStream.readInt());
+
+      return startHeader;
+    }
   }
 
   private void readHeader(final ByteBuffer header, final Archive archive) throws IOException {
+    final int pos = header.position();
+    final ArchiveStatistics stats = sanityCheckAndCollectStatistics(header);
+    stats.assertValidity(options.getMaxMemoryLimitInKb());
+    header.position(pos);
+
     int nid = getUnsignedByte(header);
 
     if (nid == NID.kArchiveProperties) {
@@ -371,7 +598,7 @@ public class SevenZFile implements Closeable {
 
     if (nid == NID.kAdditionalStreamsInfo) {
       throw new IOException("Additional streams unsupported");
-      // nid = header.readUnsignedByte();
+      // nid = getUnsignedByte(header);
     }
 
     if (nid == NID.kMainStreamsInfo) {
@@ -383,10 +610,39 @@ public class SevenZFile implements Closeable {
       readFilesInfo(header, archive);
       nid = getUnsignedByte(header);
     }
+  }
+
+  private ArchiveStatistics sanityCheckAndCollectStatistics(final ByteBuffer header)
+      throws IOException {
+    final ArchiveStatistics stats = new ArchiveStatistics();
+
+    int nid = getUnsignedByte(header);
+
+    if (nid == NID.kArchiveProperties) {
+      sanityCheckArchiveProperties(header);
+      nid = getUnsignedByte(header);
+    }
+
+    if (nid == NID.kAdditionalStreamsInfo) {
+      throw new IOException("Additional streams unsupported");
+      // nid = getUnsignedByte(header);
+    }
+
+    if (nid == NID.kMainStreamsInfo) {
+      sanityCheckStreamsInfo(header, stats);
+      nid = getUnsignedByte(header);
+    }
+
+    if (nid == NID.kFilesInfo) {
+      sanityCheckFilesInfo(header, stats);
+      nid = getUnsignedByte(header);
+    }
 
     if (nid != NID.kEnd) {
       throw new IOException("Badly terminated header, found " + nid);
     }
+
+    return stats;
   }
 
   private void readArchiveProperties(final ByteBuffer input) throws IOException {
@@ -395,14 +651,38 @@ public class SevenZFile implements Closeable {
     while (nid != NID.kEnd) {
       final long propertySize = readUint64(input);
       final byte[] property = new byte[(int) propertySize];
-      input.get(property);
+      get(input, property);
       nid = getUnsignedByte(input);
+    }
+  }
+
+  private void sanityCheckArchiveProperties(final ByteBuffer header) throws IOException {
+    int nid = getUnsignedByte(header);
+    while (nid != NID.kEnd) {
+      final int propertySize = assertFitsIntoNonNegativeInt("propertySize", readUint64(header));
+      if (skipBytesFully(header, propertySize) < propertySize) {
+        throw new IOException("invalid property size");
+      }
+      nid = getUnsignedByte(header);
     }
   }
 
   private ByteBuffer readEncodedHeader(
       final ByteBuffer header, final Archive archive, final byte[] password) throws IOException {
+    final int pos = header.position();
+    final ArchiveStatistics stats = new ArchiveStatistics();
+    sanityCheckStreamsInfo(header, stats);
+    stats.assertValidity(options.getMaxMemoryLimitInKb());
+    header.position(pos);
+
     readStreamsInfo(header, archive);
+
+    if (archive.folders == null || archive.folders.length == 0) {
+      throw new IOException("no folders, can't read encoded header");
+    }
+    if (archive.packSizes == null || archive.packSizes.length == 0) {
+      throw new IOException("no packed streams, can't read encoded header");
+    }
 
     // FIXME: merge with buildDecodingStream()/buildDecoderStack() at some stage?
     final Folder folder = archive.folders[0];
@@ -422,16 +702,44 @@ public class SevenZFile implements Closeable {
               inputStreamStack, // NOSONAR
               folder.getUnpackSizeForCoder(coder),
               coder,
-              password);
+              password,
+              options.getMaxMemoryLimitInKb());
     }
     if (folder.hasCrc) {
       inputStreamStack =
           new CRC32VerifyingInputStream(inputStreamStack, folder.getUnpackSize(), folder.crc);
     }
-    final byte[] nextHeader = new byte[(int) folder.getUnpackSize()];
-    DataInputStream nextHeaderInputStream = new DataInputStream(inputStreamStack);
-    nextHeaderInputStream.readFully(nextHeader);
+    final int unpackSize = assertFitsIntoNonNegativeInt("unpackSize", folder.getUnpackSize());
+    final byte[] nextHeader = IOUtils.readRange(inputStreamStack, unpackSize);
+    if (nextHeader.length < unpackSize) {
+      throw new IOException("premature end of stream");
+    }
+    inputStreamStack.close();
     return ByteBuffer.wrap(nextHeader).order(ByteOrder.LITTLE_ENDIAN);
+  }
+
+  private void sanityCheckStreamsInfo(final ByteBuffer header, final ArchiveStatistics stats)
+      throws IOException {
+    int nid = getUnsignedByte(header);
+
+    if (nid == NID.kPackInfo) {
+      sanityCheckPackInfo(header, stats);
+      nid = getUnsignedByte(header);
+    }
+
+    if (nid == NID.kUnpackInfo) {
+      sanityCheckUnpackInfo(header, stats);
+      nid = getUnsignedByte(header);
+    }
+
+    if (nid == NID.kSubStreamsInfo) {
+      sanityCheckSubStreamsInfo(header, stats);
+      nid = getUnsignedByte(header);
+    }
+
+    if (nid != NID.kEnd) {
+      throw new IOException("Badly terminated StreamsInfo");
+    }
   }
 
   private void readStreamsInfo(final ByteBuffer header, final Archive archive) throws IOException {
@@ -447,40 +755,44 @@ public class SevenZFile implements Closeable {
       nid = getUnsignedByte(header);
     } else {
       // archive without unpack/coders info
-      archive.folders = new Folder[0];
+      archive.folders = Folder.EMPTY_FOLDER_ARRAY;
     }
 
     if (nid == NID.kSubStreamsInfo) {
       readSubStreamsInfo(header, archive);
       nid = getUnsignedByte(header);
     }
-
-    if (nid != NID.kEnd) {
-      throw new IOException("Badly terminated StreamsInfo");
-    }
   }
 
-  private void readPackInfo(final ByteBuffer header, final Archive archive) throws IOException {
-    archive.packPos = readUint64(header);
+  private void sanityCheckPackInfo(final ByteBuffer header, final ArchiveStatistics stats)
+      throws IOException {
+    final long packPos = readUint64(header);
+    if (packPos < 0
+        || SIGNATURE_HEADER_SIZE + packPos > channel.size()
+        || SIGNATURE_HEADER_SIZE + packPos < 0) {
+      throw new IOException("packPos (" + packPos + ") is out of range");
+    }
     final long numPackStreams = readUint64(header);
+    stats.numberOfPackedStreams = assertFitsIntoNonNegativeInt("numPackStreams", numPackStreams);
     int nid = getUnsignedByte(header);
     if (nid == NID.kSize) {
-      archive.packSizes = new long[(int) numPackStreams];
-      for (int i = 0; i < archive.packSizes.length; i++) {
-        archive.packSizes[i] = readUint64(header);
+      long totalPackSizes = 0;
+      for (int i = 0; i < stats.numberOfPackedStreams; i++) {
+        final long packSize = readUint64(header);
+        totalPackSizes += packSize;
+        final long endOfPackStreams = SIGNATURE_HEADER_SIZE + packPos + totalPackSizes;
+        if (packSize < 0 || endOfPackStreams > channel.size() || endOfPackStreams < packPos) {
+          throw new IOException("packSize (" + packSize + ") is out of range");
+        }
       }
       nid = getUnsignedByte(header);
     }
 
     if (nid == NID.kCRC) {
-      archive.packCrcsDefined = readAllOrBits(header, (int) numPackStreams);
-      archive.packCrcs = new long[(int) numPackStreams];
-      for (int i = 0; i < (int) numPackStreams; i++) {
-        if (archive.packCrcsDefined.get(i)) {
-          archive.packCrcs[i] = 0xffffFFFFL & header.getInt();
-        }
+      final int crcsDefined = readAllOrBits(header, stats.numberOfPackedStreams).cardinality();
+      if (skipBytesFully(header, 4 * crcsDefined) < 4 * crcsDefined) {
+        throw new IOException("invalid number of CRCs in PackInfo");
       }
-
       nid = getUnsignedByte(header);
     }
 
@@ -489,45 +801,76 @@ public class SevenZFile implements Closeable {
     }
   }
 
-  private void readUnpackInfo(final ByteBuffer header, final Archive archive) throws IOException {
+  private void readPackInfo(final ByteBuffer header, final Archive archive) throws IOException {
+    archive.packPos = readUint64(header);
+    final int numPackStreamsInt = (int) readUint64(header);
+    int nid = getUnsignedByte(header);
+    if (nid == NID.kSize) {
+      archive.packSizes = new long[numPackStreamsInt];
+      for (int i = 0; i < archive.packSizes.length; i++) {
+        archive.packSizes[i] = readUint64(header);
+      }
+      nid = getUnsignedByte(header);
+    }
+
+    if (nid == NID.kCRC) {
+      archive.packCrcsDefined = readAllOrBits(header, numPackStreamsInt);
+      archive.packCrcs = new long[numPackStreamsInt];
+      for (int i = 0; i < numPackStreamsInt; i++) {
+        if (archive.packCrcsDefined.get(i)) {
+          archive.packCrcs[i] = 0xffffFFFFL & getInt(header);
+        }
+      }
+
+      nid = getUnsignedByte(header);
+    }
+  }
+
+  private void sanityCheckUnpackInfo(final ByteBuffer header, final ArchiveStatistics stats)
+      throws IOException {
     int nid = getUnsignedByte(header);
     if (nid != NID.kFolder) {
       throw new IOException("Expected kFolder, got " + nid);
     }
     final long numFolders = readUint64(header);
-    final Folder[] folders = new Folder[(int) numFolders];
-    archive.folders = folders;
+    stats.numberOfFolders = assertFitsIntoNonNegativeInt("numFolders", numFolders);
     final int external = getUnsignedByte(header);
     if (external != 0) {
       throw new IOException("External unsupported");
     }
-    for (int i = 0; i < (int) numFolders; i++) {
-      folders[i] = readFolder(header);
+
+    final List<Integer> numberOfOutputStreamsPerFolder = new LinkedList<>();
+    for (int i = 0; i < stats.numberOfFolders; i++) {
+      numberOfOutputStreamsPerFolder.add(sanityCheckFolder(header, stats));
+    }
+
+    final long totalNumberOfBindPairs = stats.numberOfOutStreams - stats.numberOfFolders;
+    final long packedStreamsRequiredByFolders = stats.numberOfInStreams - totalNumberOfBindPairs;
+    if (packedStreamsRequiredByFolders < stats.numberOfPackedStreams) {
+      throw new IOException("archive doesn't contain enough packed streams");
     }
 
     nid = getUnsignedByte(header);
     if (nid != NID.kCodersUnpackSize) {
       throw new IOException("Expected kCodersUnpackSize, got " + nid);
     }
-    for (final Folder folder : folders) {
-      folder.unpackSizes = new long[(int) folder.totalOutputStreams];
-      for (int i = 0; i < folder.totalOutputStreams; i++) {
-        folder.unpackSizes[i] = readUint64(header);
+
+    for (final int numberOfOutputStreams : numberOfOutputStreamsPerFolder) {
+      for (int i = 0; i < numberOfOutputStreams; i++) {
+        final long unpackSize = readUint64(header);
+        if (unpackSize < 0) {
+          throw new IllegalArgumentException("negative unpackSize");
+        }
       }
     }
 
     nid = getUnsignedByte(header);
     if (nid == NID.kCRC) {
-      final BitSet crcsDefined = readAllOrBits(header, (int) numFolders);
-      for (int i = 0; i < (int) numFolders; i++) {
-        if (crcsDefined.get(i)) {
-          folders[i].hasCrc = true;
-          folders[i].crc = 0xffffFFFFL & header.getInt();
-        } else {
-          folders[i].hasCrc = false;
-        }
+      stats.folderHasCrc = readAllOrBits(header, stats.numberOfFolders);
+      final int crcsDefined = stats.folderHasCrc.cardinality();
+      if (skipBytesFully(header, 4 * crcsDefined) < 4 * crcsDefined) {
+        throw new IOException("invalid number of CRCs in UnpackInfo");
       }
-
       nid = getUnsignedByte(header);
     }
 
@@ -536,24 +879,126 @@ public class SevenZFile implements Closeable {
     }
   }
 
+  private void readUnpackInfo(final ByteBuffer header, final Archive archive) throws IOException {
+    int nid = getUnsignedByte(header);
+    final int numFoldersInt = (int) readUint64(header);
+    final Folder[] folders = new Folder[numFoldersInt];
+    archive.folders = folders;
+    /* final int external = */ getUnsignedByte(header);
+    for (int i = 0; i < numFoldersInt; i++) {
+      folders[i] = readFolder(header);
+    }
+
+    nid = getUnsignedByte(header);
+    for (final Folder folder : folders) {
+      assertFitsIntoNonNegativeInt("totalOutputStreams", folder.totalOutputStreams);
+      folder.unpackSizes = new long[(int) folder.totalOutputStreams];
+      for (int i = 0; i < folder.totalOutputStreams; i++) {
+        folder.unpackSizes[i] = readUint64(header);
+      }
+    }
+
+    nid = getUnsignedByte(header);
+    if (nid == NID.kCRC) {
+      final BitSet crcsDefined = readAllOrBits(header, numFoldersInt);
+      for (int i = 0; i < numFoldersInt; i++) {
+        if (crcsDefined.get(i)) {
+          folders[i].hasCrc = true;
+          folders[i].crc = 0xffffFFFFL & getInt(header);
+        } else {
+          folders[i].hasCrc = false;
+        }
+      }
+
+      nid = getUnsignedByte(header);
+    }
+  }
+
+  private void sanityCheckSubStreamsInfo(final ByteBuffer header, final ArchiveStatistics stats)
+      throws IOException {
+
+    int nid = getUnsignedByte(header);
+    final List<Integer> numUnpackSubStreamsPerFolder = new LinkedList<>();
+    if (nid == NID.kNumUnpackStream) {
+      for (int i = 0; i < stats.numberOfFolders; i++) {
+        numUnpackSubStreamsPerFolder.add(
+            assertFitsIntoNonNegativeInt("numStreams", readUint64(header)));
+      }
+      for (Integer n : numUnpackSubStreamsPerFolder) {
+        stats.numberOfUnpackSubStreams += n.longValue();
+      }
+      nid = getUnsignedByte(header);
+    } else {
+      stats.numberOfUnpackSubStreams = stats.numberOfFolders;
+    }
+
+    assertFitsIntoNonNegativeInt("totalUnpackStreams", stats.numberOfUnpackSubStreams);
+
+    if (nid == NID.kSize) {
+      for (final int numUnpackSubStreams : numUnpackSubStreamsPerFolder) {
+        if (numUnpackSubStreams == 0) {
+          continue;
+        }
+        for (int i = 0; i < numUnpackSubStreams - 1; i++) {
+          final long size = readUint64(header);
+          if (size < 0) {
+            throw new IOException("negative unpackSize");
+          }
+        }
+      }
+      nid = getUnsignedByte(header);
+    }
+
+    int numDigests = 0;
+    if (numUnpackSubStreamsPerFolder.isEmpty()) {
+      numDigests =
+          stats.folderHasCrc == null
+              ? stats.numberOfFolders
+              : stats.numberOfFolders - stats.folderHasCrc.cardinality();
+    } else {
+      int folderIdx = 0;
+      for (final int numUnpackSubStreams : numUnpackSubStreamsPerFolder) {
+        if (numUnpackSubStreams != 1
+            || stats.folderHasCrc == null
+            || !stats.folderHasCrc.get(folderIdx++)) {
+          numDigests += numUnpackSubStreams;
+        }
+      }
+    }
+
+    if (nid == NID.kCRC) {
+      assertFitsIntoNonNegativeInt("numDigests", numDigests);
+      final int missingCrcs = readAllOrBits(header, numDigests).cardinality();
+      if (skipBytesFully(header, 4 * missingCrcs) < 4 * missingCrcs) {
+        throw new IOException("invalid number of missing CRCs in SubStreamInfo");
+      }
+      nid = getUnsignedByte(header);
+    }
+
+    if (nid != NID.kEnd) {
+      throw new IOException("Badly terminated SubStreamsInfo");
+    }
+  }
+
   private void readSubStreamsInfo(final ByteBuffer header, final Archive archive)
       throws IOException {
     for (final Folder folder : archive.folders) {
       folder.numUnpackSubStreams = 1;
     }
-    int totalUnpackStreams = archive.folders.length;
+    long unpackStreamsCount = archive.folders.length;
 
     int nid = getUnsignedByte(header);
     if (nid == NID.kNumUnpackStream) {
-      totalUnpackStreams = 0;
+      unpackStreamsCount = 0;
       for (final Folder folder : archive.folders) {
         final long numStreams = readUint64(header);
         folder.numUnpackSubStreams = (int) numStreams;
-        totalUnpackStreams += numStreams;
+        unpackStreamsCount += numStreams;
       }
       nid = getUnsignedByte(header);
     }
 
+    final int totalUnpackStreams = (int) unpackStreamsCount;
     final SubStreamsInfo subStreamsInfo = new SubStreamsInfo();
     subStreamsInfo.unpackSizes = new long[totalUnpackStreams];
     subStreamsInfo.hasCrc = new BitSet(totalUnpackStreams);
@@ -571,6 +1016,9 @@ public class SevenZFile implements Closeable {
           subStreamsInfo.unpackSizes[nextUnpackStream++] = size;
           sum += size;
         }
+      }
+      if (sum > folder.getUnpackSize()) {
+        throw new IOException("sum of unpack sizes of folder exceeds total unpack size");
       }
       subStreamsInfo.unpackSizes[nextUnpackStream++] = folder.getUnpackSize() - sum;
     }
@@ -590,7 +1038,7 @@ public class SevenZFile implements Closeable {
       final long[] missingCrcs = new long[numDigests];
       for (int i = 0; i < numDigests; i++) {
         if (hasMissingCrc.get(i)) {
-          missingCrcs[i] = 0xffffFFFFL & header.getInt();
+          missingCrcs[i] = 0xffffFFFFL & getInt(header);
         }
       }
       int nextCrc = 0;
@@ -613,11 +1061,95 @@ public class SevenZFile implements Closeable {
       nid = getUnsignedByte(header);
     }
 
-    if (nid != NID.kEnd) {
-      throw new IOException("Badly terminated SubStreamsInfo");
+    archive.subStreamsInfo = subStreamsInfo;
+  }
+
+  private int sanityCheckFolder(final ByteBuffer header, final ArchiveStatistics stats)
+      throws IOException {
+
+    final int numCoders = assertFitsIntoNonNegativeInt("numCoders", readUint64(header));
+    if (numCoders == 0) {
+      throw new IOException("Folder without coders");
+    }
+    stats.numberOfCoders += numCoders;
+
+    long totalOutStreams = 0;
+    long totalInStreams = 0;
+    for (int i = 0; i < numCoders; i++) {
+      final int bits = getUnsignedByte(header);
+      final int idSize = bits & 0xf;
+      get(header, new byte[idSize]);
+
+      final boolean isSimple = (bits & 0x10) == 0;
+      final boolean hasAttributes = (bits & 0x20) != 0;
+      final boolean moreAlternativeMethods = (bits & 0x80) != 0;
+      if (moreAlternativeMethods) {
+        throw new IOException(
+            "Alternative methods are unsupported, please report. "
+                + // NOSONAR
+                "The reference implementation doesn't support them either.");
+      }
+
+      if (isSimple) {
+        totalInStreams++;
+        totalOutStreams++;
+      } else {
+        totalInStreams += assertFitsIntoNonNegativeInt("numInStreams", readUint64(header));
+        totalOutStreams += assertFitsIntoNonNegativeInt("numOutStreams", readUint64(header));
+      }
+
+      if (hasAttributes) {
+        final int propertiesSize =
+            assertFitsIntoNonNegativeInt("propertiesSize", readUint64(header));
+        if (skipBytesFully(header, propertiesSize) < propertiesSize) {
+          throw new IOException("invalid propertiesSize in folder");
+        }
+      }
+    }
+    assertFitsIntoNonNegativeInt("totalInStreams", totalInStreams);
+    assertFitsIntoNonNegativeInt("totalOutStreams", totalOutStreams);
+    stats.numberOfOutStreams += totalOutStreams;
+    stats.numberOfInStreams += totalInStreams;
+
+    if (totalOutStreams == 0) {
+      throw new IOException("Total output streams can't be 0");
     }
 
-    archive.subStreamsInfo = subStreamsInfo;
+    final int numBindPairs = assertFitsIntoNonNegativeInt("numBindPairs", totalOutStreams - 1);
+    if (totalInStreams < numBindPairs) {
+      throw new IOException("Total input streams can't be less than the number of bind pairs");
+    }
+    final BitSet inStreamsBound = new BitSet((int) totalInStreams);
+    for (int i = 0; i < numBindPairs; i++) {
+      final int inIndex = assertFitsIntoNonNegativeInt("inIndex", readUint64(header));
+      if (totalInStreams <= inIndex) {
+        throw new IOException("inIndex is bigger than number of inStreams");
+      }
+      inStreamsBound.set(inIndex);
+      final int outIndex = assertFitsIntoNonNegativeInt("outIndex", readUint64(header));
+      if (totalOutStreams <= outIndex) {
+        throw new IOException("outIndex is bigger than number of outStreams");
+      }
+    }
+
+    final int numPackedStreams =
+        assertFitsIntoNonNegativeInt("numPackedStreams", totalInStreams - numBindPairs);
+
+    if (numPackedStreams == 1) {
+      if (inStreamsBound.nextClearBit(0) == -1) {
+        throw new IOException("Couldn't find stream's bind pair index");
+      }
+    } else {
+      for (int i = 0; i < numPackedStreams; i++) {
+        final int packedStreamIndex =
+            assertFitsIntoNonNegativeInt("packedStreamIndex", readUint64(header));
+        if (packedStreamIndex >= totalInStreams) {
+          throw new IOException("packedStreamIndex is bigger than number of totalInStreams");
+        }
+      }
+    }
+
+    return (int) totalOutStreams;
   }
 
   private Folder readFolder(final ByteBuffer header) throws IOException {
@@ -636,7 +1168,7 @@ public class SevenZFile implements Closeable {
       final boolean moreAlternativeMethods = (bits & 0x80) != 0;
 
       coders[i].decompressionMethodId = new byte[idSize];
-      header.get(coders[i].decompressionMethodId);
+      get(header, coders[i].decompressionMethodId);
       if (isSimple) {
         coders[i].numInStreams = 1;
         coders[i].numOutStreams = 1;
@@ -649,22 +1181,20 @@ public class SevenZFile implements Closeable {
       if (hasAttributes) {
         final long propertiesSize = readUint64(header);
         coders[i].properties = new byte[(int) propertiesSize];
-        header.get(coders[i].properties);
+        get(header, coders[i].properties);
       }
       // would need to keep looping as above:
-      while (moreAlternativeMethods) {
+      if (moreAlternativeMethods) {
         throw new IOException(
             "Alternative methods are unsupported, please report. "
-                + "The reference implementation doesn't support them either.");
+                + // NOSONAR
+                "The reference implementation doesn't support them either.");
       }
     }
     folder.coders = coders;
     folder.totalInputStreams = totalInStreams;
     folder.totalOutputStreams = totalOutStreams;
 
-    if (totalOutStreams == 0) {
-      throw new IOException("Total output streams can't be 0");
-    }
     final long numBindPairs = totalOutStreams - 1;
     final BindPair[] bindPairs = new BindPair[(int) numBindPairs];
     for (int i = 0; i < bindPairs.length; i++) {
@@ -674,20 +1204,14 @@ public class SevenZFile implements Closeable {
     }
     folder.bindPairs = bindPairs;
 
-    if (totalInStreams < numBindPairs) {
-      throw new IOException("Total input streams can't be less than the number of bind pairs");
-    }
     final long numPackedStreams = totalInStreams - numBindPairs;
-    final long packedStreams[] = new long[(int) numPackedStreams];
+    final long[] packedStreams = new long[(int) numPackedStreams];
     if (numPackedStreams == 1) {
       int i;
       for (i = 0; i < (int) totalInStreams; i++) {
         if (folder.findBindPairForInStream(i) < 0) {
           break;
         }
-      }
-      if (i == (int) totalInStreams) {
-        throw new IOException("Couldn't find stream's bind pair index");
       }
       packedStreams[0] = i;
     } else {
@@ -729,15 +1253,11 @@ public class SevenZFile implements Closeable {
     return bits;
   }
 
-  private void readFilesInfo(final ByteBuffer header, final Archive archive) throws IOException {
-    final long numFiles = readUint64(header);
-    final SevenZArchiveEntry[] files = new SevenZArchiveEntry[(int) numFiles];
-    for (int i = 0; i < files.length; i++) {
-      files[i] = new SevenZArchiveEntry();
-    }
-    BitSet isEmptyStream = null;
-    BitSet isEmptyFile = null;
-    BitSet isAnti = null;
+  private void sanityCheckFilesInfo(final ByteBuffer header, final ArchiveStatistics stats)
+      throws IOException {
+    stats.numberOfEntries = assertFitsIntoNonNegativeInt("numFiles", readUint64(header));
+
+    int emptyStreams = -1;
     while (true) {
       final int propertyType = getUnsignedByte(header);
       if (propertyType == 0) {
@@ -747,24 +1267,24 @@ public class SevenZFile implements Closeable {
       switch (propertyType) {
         case NID.kEmptyStream:
           {
-            isEmptyStream = readBits(header, files.length);
+            emptyStreams = readBits(header, stats.numberOfEntries).cardinality();
             break;
           }
         case NID.kEmptyFile:
           {
-            if (isEmptyStream == null) { // protect against NPE
+            if (emptyStreams == -1) {
               throw new IOException(
                   "Header format error: kEmptyStream must appear before kEmptyFile");
             }
-            isEmptyFile = readBits(header, isEmptyStream.cardinality());
+            readBits(header, emptyStreams);
             break;
           }
         case NID.kAnti:
           {
-            if (isEmptyStream == null) { // protect against NPE
+            if (emptyStreams == -1) {
               throw new IOException("Header format error: kEmptyStream must appear before kAnti");
             }
-            isAnti = readBits(header, isEmptyStream.cardinality());
+            readBits(header, emptyStreams);
             break;
           }
         case NID.kName:
@@ -773,82 +1293,74 @@ public class SevenZFile implements Closeable {
             if (external != 0) {
               throw new IOException("Not implemented");
             }
-            if (((size - 1) & 1) != 0) {
+            final int namesLength = assertFitsIntoNonNegativeInt("file names length", size - 1);
+            if ((namesLength & 1) != 0) {
               throw new IOException("File names length invalid");
             }
-            final byte[] names = new byte[(int) (size - 1)];
-            header.get(names);
-            int nextFile = 0;
-            int nextName = 0;
-            for (int i = 0; i < names.length; i += 2) {
-              if (names[i] == 0 && names[i + 1] == 0) {
-                files[nextFile++].setName(
-                    new String(names, nextName, i - nextName, CharsetNames.UTF_16LE));
-                nextName = i + 2;
+
+            int filesSeen = 0;
+            for (int i = 0; i < namesLength; i += 2) {
+              final char c = getChar(header);
+              if (c == 0) {
+                filesSeen++;
               }
             }
-            if (nextName != names.length || nextFile != files.length) {
-              throw new IOException("Error parsing file names");
+            if (filesSeen != stats.numberOfEntries) {
+              throw new IOException(
+                  "Invalid number of file names ("
+                      + filesSeen
+                      + " instead of "
+                      + stats.numberOfEntries
+                      + ")");
             }
             break;
           }
         case NID.kCTime:
           {
-            final BitSet timesDefined = readAllOrBits(header, files.length);
+            final int timesDefined = readAllOrBits(header, stats.numberOfEntries).cardinality();
             final int external = getUnsignedByte(header);
             if (external != 0) {
-              throw new IOException("Unimplemented");
+              throw new IOException("Not implemented");
             }
-            for (int i = 0; i < files.length; i++) {
-              files[i].setHasCreationDate(timesDefined.get(i));
-              if (files[i].getHasCreationDate()) {
-                files[i].setCreationDate(header.getLong());
-              }
+            if (skipBytesFully(header, 8 * timesDefined) < 8 * timesDefined) {
+              throw new IOException("invalid creation dates size");
             }
             break;
           }
         case NID.kATime:
           {
-            final BitSet timesDefined = readAllOrBits(header, files.length);
+            final int timesDefined = readAllOrBits(header, stats.numberOfEntries).cardinality();
             final int external = getUnsignedByte(header);
             if (external != 0) {
-              throw new IOException("Unimplemented");
+              throw new IOException("Not implemented");
             }
-            for (int i = 0; i < files.length; i++) {
-              files[i].setHasAccessDate(timesDefined.get(i));
-              if (files[i].getHasAccessDate()) {
-                files[i].setAccessDate(header.getLong());
-              }
+            if (skipBytesFully(header, 8 * timesDefined) < 8 * timesDefined) {
+              throw new IOException("invalid access dates size");
             }
             break;
           }
         case NID.kMTime:
           {
-            final BitSet timesDefined = readAllOrBits(header, files.length);
+            final int timesDefined = readAllOrBits(header, stats.numberOfEntries).cardinality();
             final int external = getUnsignedByte(header);
             if (external != 0) {
-              throw new IOException("Unimplemented");
+              throw new IOException("Not implemented");
             }
-            for (int i = 0; i < files.length; i++) {
-              files[i].setHasLastModifiedDate(timesDefined.get(i));
-              if (files[i].getHasLastModifiedDate()) {
-                files[i].setLastModifiedDate(header.getLong());
-              }
+            if (skipBytesFully(header, 8 * timesDefined) < 8 * timesDefined) {
+              throw new IOException("invalid modification dates size");
             }
             break;
           }
         case NID.kWinAttributes:
           {
-            final BitSet attributesDefined = readAllOrBits(header, files.length);
+            final int attributesDefined =
+                readAllOrBits(header, stats.numberOfEntries).cardinality();
             final int external = getUnsignedByte(header);
             if (external != 0) {
-              throw new IOException("Unimplemented");
+              throw new IOException("Not implemented");
             }
-            for (int i = 0; i < files.length; i++) {
-              files[i].setHasWindowsAttributes(attributesDefined.get(i));
-              if (files[i].getHasWindowsAttributes()) {
-                files[i].setWindowsAttributes(header.getInt());
-              }
+            if (skipBytesFully(header, 4 * attributesDefined) < 4 * attributesDefined) {
+              throw new IOException("invalid windows attributes size");
             }
             break;
           }
@@ -877,27 +1389,177 @@ public class SevenZFile implements Closeable {
           }
       }
     }
+    stats.numberOfEntriesWithStream = stats.numberOfEntries - Math.max(emptyStreams, 0);
+  }
+
+  private void readFilesInfo(final ByteBuffer header, final Archive archive) throws IOException {
+    final int numFilesInt = (int) readUint64(header);
+    final Map<Integer, SevenZArchiveEntry> fileMap = new LinkedHashMap<>();
+    BitSet isEmptyStream = null;
+    BitSet isEmptyFile = null;
+    BitSet isAnti = null;
+    while (true) {
+      final int propertyType = getUnsignedByte(header);
+      if (propertyType == 0) {
+        break;
+      }
+      final long size = readUint64(header);
+      switch (propertyType) {
+        case NID.kEmptyStream:
+          {
+            isEmptyStream = readBits(header, numFilesInt);
+            break;
+          }
+        case NID.kEmptyFile:
+          {
+            isEmptyFile = readBits(header, isEmptyStream.cardinality());
+            break;
+          }
+        case NID.kAnti:
+          {
+            isAnti = readBits(header, isEmptyStream.cardinality());
+            break;
+          }
+        case NID.kName:
+          {
+            /* final int external = */ getUnsignedByte(header);
+            final byte[] names = new byte[(int) (size - 1)];
+            final int namesLength = names.length;
+            get(header, names);
+            int nextFile = 0;
+            int nextName = 0;
+            for (int i = 0; i < namesLength; i += 2) {
+              if (names[i] == 0 && names[i + 1] == 0) {
+                checkEntryIsInitialized(fileMap, nextFile);
+                fileMap
+                    .get(nextFile)
+                    .setName(new String(names, nextName, i - nextName, "UTF-16LE"));
+                nextName = i + 2;
+                nextFile++;
+              }
+            }
+            if (nextName != namesLength || nextFile != numFilesInt) {
+              throw new IOException("Error parsing file names");
+            }
+            break;
+          }
+        case NID.kCTime:
+          {
+            final BitSet timesDefined = readAllOrBits(header, numFilesInt);
+            /* final int external = */ getUnsignedByte(header);
+            for (int i = 0; i < numFilesInt; i++) {
+              checkEntryIsInitialized(fileMap, i);
+              final SevenZArchiveEntry entryAtIndex = fileMap.get(i);
+              entryAtIndex.setHasCreationDate(timesDefined.get(i));
+              if (entryAtIndex.getHasCreationDate()) {
+                entryAtIndex.setCreationDate(getLong(header));
+              }
+            }
+            break;
+          }
+        case NID.kATime:
+          {
+            final BitSet timesDefined = readAllOrBits(header, numFilesInt);
+            /* final int external = */ getUnsignedByte(header);
+            for (int i = 0; i < numFilesInt; i++) {
+              checkEntryIsInitialized(fileMap, i);
+              final SevenZArchiveEntry entryAtIndex = fileMap.get(i);
+              entryAtIndex.setHasAccessDate(timesDefined.get(i));
+              if (entryAtIndex.getHasAccessDate()) {
+                entryAtIndex.setAccessDate(getLong(header));
+              }
+            }
+            break;
+          }
+        case NID.kMTime:
+          {
+            final BitSet timesDefined = readAllOrBits(header, numFilesInt);
+            /* final int external = */ getUnsignedByte(header);
+            for (int i = 0; i < numFilesInt; i++) {
+              checkEntryIsInitialized(fileMap, i);
+              final SevenZArchiveEntry entryAtIndex = fileMap.get(i);
+              entryAtIndex.setHasLastModifiedDate(timesDefined.get(i));
+              if (entryAtIndex.getHasLastModifiedDate()) {
+                entryAtIndex.setLastModifiedDate(getLong(header));
+              }
+            }
+            break;
+          }
+        case NID.kWinAttributes:
+          {
+            final BitSet attributesDefined = readAllOrBits(header, numFilesInt);
+            /* final int external = */ getUnsignedByte(header);
+            for (int i = 0; i < numFilesInt; i++) {
+              checkEntryIsInitialized(fileMap, i);
+              final SevenZArchiveEntry entryAtIndex = fileMap.get(i);
+              entryAtIndex.setHasWindowsAttributes(attributesDefined.get(i));
+              if (entryAtIndex.getHasWindowsAttributes()) {
+                entryAtIndex.setWindowsAttributes(getInt(header));
+              }
+            }
+            break;
+          }
+        case NID.kDummy:
+          {
+            // 7z 9.20 asserts the content is all zeros and ignores the property
+            // Compress up to 1.8.1 would throw an exception, now we ignore it (see COMPRESS-287
+
+            skipBytesFully(header, size);
+            break;
+          }
+
+        default:
+          {
+            // Compress up to 1.8.1 would throw an exception, now we ignore it (see COMPRESS-287
+            skipBytesFully(header, size);
+            break;
+          }
+      }
+    }
     int nonEmptyFileCounter = 0;
     int emptyFileCounter = 0;
-    for (int i = 0; i < files.length; i++) {
-      files[i].setHasStream(isEmptyStream == null || !isEmptyStream.get(i));
-      if (files[i].hasStream()) {
-        files[i].setDirectory(false);
-        files[i].setAntiItem(false);
-        files[i].setHasCrc(archive.subStreamsInfo.hasCrc.get(nonEmptyFileCounter));
-        files[i].setCrcValue(archive.subStreamsInfo.crcs[nonEmptyFileCounter]);
-        files[i].setSize(archive.subStreamsInfo.unpackSizes[nonEmptyFileCounter]);
+    for (int i = 0; i < numFilesInt; i++) {
+      final SevenZArchiveEntry entryAtIndex = fileMap.get(i);
+      if (entryAtIndex == null) {
+        continue;
+      }
+      entryAtIndex.setHasStream(isEmptyStream == null || !isEmptyStream.get(i));
+      if (entryAtIndex.hasStream()) {
+        if (archive.subStreamsInfo == null) {
+          throw new IOException("Archive contains file with streams but no subStreamsInfo");
+        }
+        entryAtIndex.setDirectory(false);
+        entryAtIndex.setAntiItem(false);
+        entryAtIndex.setHasCrc(archive.subStreamsInfo.hasCrc.get(nonEmptyFileCounter));
+        entryAtIndex.setCrcValue(archive.subStreamsInfo.crcs[nonEmptyFileCounter]);
+        entryAtIndex.setSize(archive.subStreamsInfo.unpackSizes[nonEmptyFileCounter]);
+        if (entryAtIndex.getSize() < 0) {
+          throw new IOException("broken archive, entry with negative size");
+        }
         ++nonEmptyFileCounter;
       } else {
-        files[i].setDirectory(isEmptyFile == null || !isEmptyFile.get(emptyFileCounter));
-        files[i].setAntiItem(isAnti != null && isAnti.get(emptyFileCounter));
-        files[i].setHasCrc(false);
-        files[i].setSize(0);
+        entryAtIndex.setDirectory(isEmptyFile == null || !isEmptyFile.get(emptyFileCounter));
+        entryAtIndex.setAntiItem(isAnti != null && isAnti.get(emptyFileCounter));
+        entryAtIndex.setHasCrc(false);
+        entryAtIndex.setSize(0);
         ++emptyFileCounter;
       }
     }
-    archive.files = files;
+    List<SevenZArchiveEntry> entries = new LinkedList<>();
+    for (SevenZArchiveEntry entry : fileMap.values()) {
+      if (entry != null) {
+        entries.add(entry);
+      }
+    }
+    archive.files = entries.toArray(new SevenZArchiveEntry[entries.size()]);
     calculateStreamMap(archive);
+  }
+
+  private void checkEntryIsInitialized(
+      final Map<Integer, SevenZArchiveEntry> archiveEntries, final int index) {
+    if (archiveEntries.get(index) == null) {
+      archiveEntries.put(index, new SevenZArchiveEntry());
+    }
   }
 
   private void calculateStreamMap(final Archive archive) throws IOException {
@@ -912,7 +1574,7 @@ public class SevenZFile implements Closeable {
     }
 
     long nextPackStreamOffset = 0;
-    final int numPackSizes = archive.packSizes != null ? archive.packSizes.length : 0;
+    final int numPackSizes = archive.packSizes.length;
     streamMap.packStreamOffsets = new long[numPackSizes];
     for (int i = 0; i < numPackSizes; i++) {
       streamMap.packStreamOffsets[i] = nextPackStreamOffset;
@@ -953,40 +1615,69 @@ public class SevenZFile implements Closeable {
     archive.streamMap = streamMap;
   }
 
-  private void buildDecodingStream() throws IOException {
-    final int folderIndex = archive.streamMap.fileFolderIndex[currentEntryIndex];
+  /**
+   * Build the decoding stream for the entry to be read. This method may be called from a random
+   * access(getInputStream) or sequential access(getNextEntry). If this method is called from a
+   * random access, some entries may need to be skipped(we put them to the deferredBlockStreams and
+   * skip them when actually needed to improve the performance)
+   *
+   * @param entryIndex the index of the entry to be read
+   * @param isRandomAccess is this called in a random access
+   * @throws IOException if there are exceptions when reading the file
+   */
+  private void buildDecodingStream(final int entryIndex, final boolean isRandomAccess)
+      throws IOException {
+    if (archive.streamMap == null) {
+      throw new IOException("Archive doesn't contain stream information to read entries");
+    }
+    final int folderIndex = archive.streamMap.fileFolderIndex[entryIndex];
     if (folderIndex < 0) {
       deferredBlockStreams.clear();
       // TODO: previously it'd return an empty stream?
-      // new BoundedInputStream(new ByteArrayInputStream(new byte[0]), 0);
+      // new BoundedInputStream(new ByteArrayInputStream(ByteUtils.EMPTY_BYTE_ARRAY), 0);
       return;
     }
-    final SevenZArchiveEntry file = archive.files[currentEntryIndex];
+    final SevenZArchiveEntry file = archive.files[entryIndex];
+    boolean isInSameFolder = false;
     if (currentFolderIndex == folderIndex) {
       // (COMPRESS-320).
       // The current entry is within the same (potentially opened) folder. The
       // previous stream has to be fully decoded before we can start reading
       // but don't do it eagerly -- if the user skips over the entire folder nothing
       // is effectively decompressed.
-
-      file.setContentMethods(archive.files[currentEntryIndex - 1].getContentMethods());
-    } else {
-      // We're opening a new folder. Discard any queued streams/ folder stream.
-      currentFolderIndex = folderIndex;
-      deferredBlockStreams.clear();
-      if (currentFolderInputStream != null) {
-        currentFolderInputStream.close();
-        currentFolderInputStream = null;
+      if (entryIndex > 0) {
+        file.setContentMethods(archive.files[entryIndex - 1].getContentMethods());
       }
 
-      final Folder folder = archive.folders[folderIndex];
-      final int firstPackStreamIndex = archive.streamMap.folderFirstPackStreamIndex[folderIndex];
-      final long folderOffset =
-          SIGNATURE_HEADER_SIZE
-              + archive.packPos
-              + archive.streamMap.packStreamOffsets[firstPackStreamIndex];
-      currentFolderInputStream =
-          buildDecoderStack(folder, folderOffset, firstPackStreamIndex, file);
+      // if this is called in a random access, then the content methods of previous entry may be
+      // null
+      // the content methods should be set to methods of the first entry as it must not be null,
+      // and the content methods would only be set if the content methods was not set
+      if (isRandomAccess && file.getContentMethods() == null) {
+        final int folderFirstFileIndex = archive.streamMap.folderFirstFileIndex[folderIndex];
+        final SevenZArchiveEntry folderFirstFile = archive.files[folderFirstFileIndex];
+        file.setContentMethods(folderFirstFile.getContentMethods());
+      }
+      isInSameFolder = true;
+    } else {
+      currentFolderIndex = folderIndex;
+      // We're opening a new folder. Discard any queued streams/ folder stream.
+      reopenFolderInputStream(folderIndex, file);
+    }
+
+    boolean haveSkippedEntries = false;
+    if (isRandomAccess) {
+      // entries will only need to be skipped if it's a random access
+      haveSkippedEntries = skipEntriesWhenNeeded(entryIndex, isInSameFolder, folderIndex);
+    }
+
+    if (isRandomAccess && currentEntryIndex == entryIndex && !haveSkippedEntries) {
+      // we don't need to add another entry to the deferredBlockStreams when :
+      // 1. If this method is called in a random access and the entry index
+      // to be read equals to the current entry index, the input stream
+      // has already been put in the deferredBlockStreams
+      // 2. If this entry has not been read(which means no entries are skipped)
+      return;
     }
 
     InputStream fileStream = new BoundedInputStream(currentFolderInputStream, file.getSize());
@@ -995,6 +1686,128 @@ public class SevenZFile implements Closeable {
     }
 
     deferredBlockStreams.add(fileStream);
+  }
+
+  /**
+   * Discard any queued streams/ folder stream, and reopen the current folder input stream.
+   *
+   * @param folderIndex the index of the folder to reopen
+   * @param file the 7z entry to read
+   * @throws IOException if exceptions occur when reading the 7z file
+   */
+  private void reopenFolderInputStream(final int folderIndex, final SevenZArchiveEntry file)
+      throws IOException {
+    deferredBlockStreams.clear();
+    if (currentFolderInputStream != null) {
+      currentFolderInputStream.close();
+      currentFolderInputStream = null;
+    }
+    final Folder folder = archive.folders[folderIndex];
+    final int firstPackStreamIndex = archive.streamMap.folderFirstPackStreamIndex[folderIndex];
+    final long folderOffset =
+        SIGNATURE_HEADER_SIZE
+            + archive.packPos
+            + archive.streamMap.packStreamOffsets[firstPackStreamIndex];
+
+    currentFolderInputStream = buildDecoderStack(folder, folderOffset, firstPackStreamIndex, file);
+  }
+
+  /**
+   * Skip all the entries if needed. Entries need to be skipped when:
+   *
+   * <p>1. it's a random access 2. one of these 2 condition is meet :
+   *
+   * <p>2.1 currentEntryIndex != entryIndex : this means there are some entries to be
+   * skipped(currentEntryIndex < entryIndex) or the entry has already been read(currentEntryIndex >
+   * entryIndex)
+   *
+   * <p>2.2 currentEntryIndex == entryIndex && !hasCurrentEntryBeenRead: if the entry to be read is
+   * the current entry, but some data of it has been read before, then we need to reopen the stream
+   * of the folder and skip all the entries before the current entries
+   *
+   * @param entryIndex the entry to be read
+   * @param isInSameFolder are the entry to be read and the current entry in the same folder
+   * @param folderIndex the index of the folder which contains the entry
+   * @return true if there are entries actually skipped
+   * @throws IOException there are exceptions when skipping entries
+   * @since 1.21
+   */
+  private boolean skipEntriesWhenNeeded(
+      final int entryIndex, final boolean isInSameFolder, final int folderIndex)
+      throws IOException {
+    final SevenZArchiveEntry file = archive.files[entryIndex];
+    // if the entry to be read is the current entry, and the entry has not
+    // been read yet, then there's nothing we need to do
+    if (currentEntryIndex == entryIndex && !hasCurrentEntryBeenRead()) {
+      return false;
+    }
+
+    // 1. if currentEntryIndex < entryIndex :
+    // this means there are some entries to be skipped(currentEntryIndex < entryIndex)
+    // 2. if currentEntryIndex > entryIndex || (currentEntryIndex == entryIndex &&
+    // hasCurrentEntryBeenRead) :
+    // this means the entry has already been read before, and we need to reopen the
+    // stream of the folder and skip all the entries before the current entries
+    int filesToSkipStartIndex = archive.streamMap.folderFirstFileIndex[currentFolderIndex];
+    if (isInSameFolder) {
+      if (currentEntryIndex < entryIndex) {
+        // the entries between filesToSkipStartIndex and currentEntryIndex had already been skipped
+        filesToSkipStartIndex = currentEntryIndex + 1;
+      } else {
+        // the entry is in the same folder of current entry, but it has already been read before, we
+        // need to reset
+        // the position of the currentFolderInputStream to the beginning of folder, and then skip
+        // the files
+        // from the start entry of the folder again
+        reopenFolderInputStream(folderIndex, file);
+      }
+    }
+
+    for (int i = filesToSkipStartIndex; i < entryIndex; i++) {
+      final SevenZArchiveEntry fileToSkip = archive.files[i];
+      InputStream fileStreamToSkip =
+          new BoundedInputStream(currentFolderInputStream, fileToSkip.getSize());
+      if (fileToSkip.getHasCrc()) {
+        fileStreamToSkip =
+            new CRC32VerifyingInputStream(
+                fileStreamToSkip, fileToSkip.getSize(), fileToSkip.getCrcValue());
+      }
+      deferredBlockStreams.add(fileStreamToSkip);
+
+      // set the content methods as well, it equals to file.getContentMethods() because they are in
+      // same folder
+      fileToSkip.setContentMethods(file.getContentMethods());
+    }
+    return true;
+  }
+
+  /**
+   * Find out if any data of current entry has been read or not. This is achieved by comparing the
+   * bytes remaining to read and the size of the file.
+   *
+   * @return true if any data of current entry has been read
+   * @since 1.21
+   */
+  private boolean hasCurrentEntryBeenRead() {
+    boolean hasCurrentEntryBeenRead = false;
+    if (!deferredBlockStreams.isEmpty()) {
+      final InputStream currentEntryInputStream =
+          deferredBlockStreams.get(deferredBlockStreams.size() - 1);
+      // get the bytes remaining to read, and compare it with the size of
+      // the file to figure out if the file has been read
+      if (currentEntryInputStream instanceof CRC32VerifyingInputStream) {
+        hasCurrentEntryBeenRead =
+            ((CRC32VerifyingInputStream) currentEntryInputStream).getBytesRemaining()
+                != archive.files[currentEntryIndex].getSize();
+      }
+
+      if (currentEntryInputStream instanceof BoundedInputStream) {
+        hasCurrentEntryBeenRead =
+            ((BoundedInputStream) currentEntryInputStream).getBytesRemaining()
+                != archive.files[currentEntryIndex].getSize();
+      }
+    }
+    return hasCurrentEntryBeenRead;
   }
 
   private InputStream buildDecoderStack(
@@ -1025,6 +1838,9 @@ public class SevenZFile implements Closeable {
 
           @Override
           public int read(final byte[] b, final int off, final int len) throws IOException {
+            if (len == 0) {
+              return 0;
+            }
             final int r = in.read(b, off, len);
             if (r >= 0) {
               count(r);
@@ -1032,7 +1848,7 @@ public class SevenZFile implements Closeable {
             return r;
           }
 
-          private void count(int c) {
+          private void count(final int c) {
             compressedBytesReadFromCurrentEntry += c;
           }
         };
@@ -1044,7 +1860,12 @@ public class SevenZFile implements Closeable {
       final SevenZMethod method = SevenZMethod.byId(coder.decompressionMethodId);
       inputStreamStack =
           Coders.addDecoder(
-              fileName, inputStreamStack, folder.getUnpackSizeForCoder(coder), coder, password);
+              fileName,
+              inputStreamStack,
+              folder.getUnpackSizeForCoder(coder),
+              coder,
+              password,
+              options.getMaxMemoryLimitInKb());
       methods.addFirst(
           new SevenZMethodConfiguration(
               method, Coders.findByMethod(method).getOptionsFromCoder(coder, inputStreamStack)));
@@ -1063,7 +1884,7 @@ public class SevenZFile implements Closeable {
    * @throws IOException if an I/O error has occurred
    */
   public int read() throws IOException {
-    int b = getCurrentStream().read();
+    final int b = getCurrentStream().read();
     if (b >= 0) {
       uncompressedBytesReadFromCurrentEntry++;
     }
@@ -1072,7 +1893,7 @@ public class SevenZFile implements Closeable {
 
   private InputStream getCurrentStream() throws IOException {
     if (archive.files[currentEntryIndex].getSize() == 0) {
-      return new ByteArrayInputStream(new byte[0]);
+      return new ByteArrayInputStream(ByteUtils.EMPTY_BYTE_ARRAY);
     }
     if (deferredBlockStreams.isEmpty()) {
       throw new IllegalStateException("No current 7z entry (call getNextEntry() first).");
@@ -1082,12 +1903,44 @@ public class SevenZFile implements Closeable {
       // In solid compression mode we need to decompress all leading folder'
       // streams to get access to an entry. We defer this until really needed
       // so that entire blocks can be skipped without wasting time for decompression.
-      final InputStream stream = deferredBlockStreams.remove(0);
-      IOUtils.skip(stream, Long.MAX_VALUE);
+      try (final InputStream stream = deferredBlockStreams.remove(0)) {
+        IOUtils.skip(stream, Long.MAX_VALUE);
+      }
       compressedBytesReadFromCurrentEntry = 0;
     }
 
     return deferredBlockStreams.get(0);
+  }
+
+  /**
+   * Returns an InputStream for reading the contents of the given entry.
+   *
+   * <p>For archives using solid compression randomly accessing entries will be significantly slower
+   * than reading the archive sequentially.
+   *
+   * @param entry the entry to get the stream for.
+   * @return a stream to read the entry from.
+   * @throws IOException if unable to create an input stream from the zipentry
+   * @since 1.20
+   */
+  public InputStream getInputStream(final SevenZArchiveEntry entry) throws IOException {
+    int entryIndex = -1;
+    for (int i = 0; i < this.archive.files.length; i++) {
+      if (entry == this.archive.files[i]) {
+        entryIndex = i;
+        break;
+      }
+    }
+
+    if (entryIndex < 0) {
+      throw new IllegalArgumentException(
+          "Can not find " + entry.getName() + " in " + this.fileName);
+    }
+
+    buildDecodingStream(entryIndex, true);
+    currentEntryIndex = entryIndex;
+    currentFolderIndex = archive.streamMap.fileFolderIndex[entryIndex];
+    return getCurrentStream();
   }
 
   /**
@@ -1111,7 +1964,10 @@ public class SevenZFile implements Closeable {
    * @throws IOException if an I/O error has occurred
    */
   public int read(final byte[] b, final int off, final int len) throws IOException {
-    int cnt = getCurrentStream().read(b, off, len);
+    if (len == 0) {
+      return 0;
+    }
+    final int cnt = getCurrentStream().read(b, off, len);
     if (cnt > 0) {
       uncompressedBytesReadFromCurrentEntry += cnt;
     }
@@ -1145,16 +2001,47 @@ public class SevenZFile implements Closeable {
     long value = 0;
     for (int i = 0; i < 8; i++) {
       if ((firstByte & mask) == 0) {
-        return value | ((firstByte & (mask - 1)) << (8 * i));
+        return value | (firstByte & mask - 1) << 8 * i;
       }
       final long nextByte = getUnsignedByte(in);
-      value |= nextByte << (8 * i);
+      value |= nextByte << 8 * i;
       mask >>>= 1;
     }
     return value;
   }
 
-  private static int getUnsignedByte(ByteBuffer buf) {
+  private static char getChar(final ByteBuffer buf) throws IOException {
+    if (buf.remaining() < 2) {
+      throw new EOFException();
+    }
+    return buf.getChar();
+  }
+
+  private static int getInt(final ByteBuffer buf) throws IOException {
+    if (buf.remaining() < 4) {
+      throw new EOFException();
+    }
+    return buf.getInt();
+  }
+
+  private static long getLong(final ByteBuffer buf) throws IOException {
+    if (buf.remaining() < 8) {
+      throw new EOFException();
+    }
+    return buf.getLong();
+  }
+
+  private static void get(final ByteBuffer buf, final byte[] to) throws IOException {
+    if (buf.remaining() < to.length) {
+      throw new EOFException();
+    }
+    buf.get(to);
+  }
+
+  private static int getUnsignedByte(final ByteBuffer buf) throws IOException {
+    if (!buf.hasRemaining()) {
+      throw new EOFException();
+    }
     return buf.get() & 0xff;
   }
 
@@ -1179,12 +2066,12 @@ public class SevenZFile implements Closeable {
     return true;
   }
 
-  private static long skipBytesFully(final ByteBuffer input, long bytesToSkip) throws IOException {
+  private static long skipBytesFully(final ByteBuffer input, long bytesToSkip) {
     if (bytesToSkip < 1) {
       return 0;
     }
-    int current = input.position();
-    int maxSkip = input.remaining();
+    final int current = input.position();
+    final int maxSkip = input.remaining();
     if (maxSkip < bytesToSkip) {
       bytesToSkip = maxSkip;
     }
@@ -1192,8 +2079,9 @@ public class SevenZFile implements Closeable {
     return bytesToSkip;
   }
 
-  private void readFully(ByteBuffer buf) throws IOException {
+  private void readFully(final ByteBuffer buf) throws IOException {
     buf.rewind();
+
     IOUtils.readFully(channel, buf);
     buf.flip();
   }
@@ -1203,18 +2091,128 @@ public class SevenZFile implements Closeable {
     return archive.toString();
   }
 
-  private static final CharsetEncoder PASSWORD_ENCODER = Charset.forName("UTF-16LE").newEncoder();
+  /**
+   * Derives a default file name from the archive name - if known.
+   *
+   * <p>This implements the same heuristics the 7z tools use. In 7z's case if an archive contains
+   * entries without a name - i.e. {@link SevenZArchiveEntry#getName} returns {@code null} - then
+   * its command line and GUI tools will use this default name when extracting the entries.
+   *
+   * @return null if the name of the archive is unknown. Otherwise if the name of the archive has
+   *     got any extension, it is stripped and the remainder returned. Finally if the name of the
+   *     archive hasn't got any extension then a {@code ~} character is appended to the archive
+   *     name.
+   * @since 1.19
+   */
+  public String getDefaultName() {
+    if (DEFAULT_FILE_NAME.equals(fileName) || fileName == null) {
+      return null;
+    }
 
-  private static byte[] utf16Decode(char[] chars) throws IOException {
+    final String lastSegment = new File(fileName).getName();
+    final int dotPos = lastSegment.lastIndexOf(".");
+    if (dotPos > 0) { // if the file starts with a dot then this is not an extension
+      return lastSegment.substring(0, dotPos);
+    }
+    return lastSegment + "~";
+  }
+
+  private static byte[] utf16Decode(final char[] chars) {
     if (chars == null) {
       return null;
     }
-    ByteBuffer encoded = PASSWORD_ENCODER.encode(CharBuffer.wrap(chars));
+    final ByteBuffer encoded = Charset.forName("UTF-16LE").encode(CharBuffer.wrap(chars));
     if (encoded.hasArray()) {
       return encoded.array();
     }
-    byte[] e = new byte[encoded.remaining()];
+    final byte[] e = new byte[encoded.remaining()];
     encoded.get(e);
     return e;
+  }
+
+  private static int assertFitsIntoNonNegativeInt(final String what, final long value)
+      throws IOException {
+    if (value > Integer.MAX_VALUE || value < 0) {
+      throw new IOException("Cannot handle " + what + " " + value);
+    }
+    return (int) value;
+  }
+
+  private static class ArchiveStatistics {
+    private int numberOfPackedStreams;
+    private long numberOfCoders;
+    private long numberOfOutStreams;
+    private long numberOfInStreams;
+    private long numberOfUnpackSubStreams;
+    private int numberOfFolders;
+    private BitSet folderHasCrc;
+    private int numberOfEntries;
+    private int numberOfEntriesWithStream;
+
+    @Override
+    public String toString() {
+      return "Archive with "
+          + numberOfEntries
+          + " entries in "
+          + numberOfFolders
+          + " folders. Estimated size "
+          + estimateSize() / 1024L
+          + " kB.";
+    }
+
+    long estimateSize() {
+      final long lowerBound =
+          16L * numberOfPackedStreams /* packSizes, packCrcs in Archive */
+              + numberOfPackedStreams / 8 /* packCrcsDefined in Archive */
+              + numberOfFolders * folderSize() /* folders in Archive */
+              + numberOfCoders * coderSize() /* coders in Folder */
+              + (numberOfOutStreams - numberOfFolders) * bindPairSize() /* bindPairs in Folder */
+              + 8L
+                  * (numberOfInStreams
+                      - numberOfOutStreams
+                      + numberOfFolders) /* packedStreams in Folder */
+              + 8L * numberOfOutStreams /* unpackSizes in Folder */
+              + numberOfEntries * entrySize() /* files in Archive */
+              + streamMapSize();
+      return 2 * lowerBound /* conservative guess */;
+    }
+
+    void assertValidity(final int maxMemoryLimitInKb) throws IOException {
+      if (numberOfEntriesWithStream > 0 && numberOfFolders == 0) {
+        throw new IOException("archive with entries but no folders");
+      }
+      if (numberOfEntriesWithStream > numberOfUnpackSubStreams) {
+        throw new IOException("archive doesn't contain enough substreams for entries");
+      }
+
+      final long memoryNeededInKb = estimateSize() / 1024;
+      if (maxMemoryLimitInKb < memoryNeededInKb) {
+        throw new MemoryLimitException(memoryNeededInKb, maxMemoryLimitInKb);
+      }
+    }
+
+    private long folderSize() {
+      return 30; /* nested arrays are accounted for separately */
+    }
+
+    private long coderSize() {
+      return 2 /* methodId is between 1 and four bytes currently, COPY and LZMA2 are the most common with 1 */
+          + 16
+          + 4 /* properties, guess */;
+    }
+
+    private long bindPairSize() {
+      return 16;
+    }
+
+    private long entrySize() {
+      return 100; /* real size depends on name length, everything without name is about 70 bytes */
+    }
+
+    private long streamMapSize() {
+      return 8 * numberOfFolders /* folderFirstPackStreamIndex, folderFirstFileIndex */
+          + 8 * numberOfPackedStreams /* packStreamOffsets */
+          + 4 * numberOfEntries /* fileFolderIndex */;
+    }
   }
 }

--- a/commons_compress_7z/src/main/java/com/amaze/filemanager/filesystem/compressed/sevenz/SevenZFileOptions.java
+++ b/commons_compress_7z/src/main/java/com/amaze/filemanager/filesystem/compressed/sevenz/SevenZFileOptions.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright (C) 2014-2022 Arpit Khurana <arpitkh96@gmail.com>, Vishal Nehra <vishalmeham2@gmail.com>,
+ * Emmanuel Messulam<emmanuelbendavid@gmail.com>, Raymond Lai <airwave209gt at gmail.com> and Contributors.
+ *
+ * This file is part of Amaze File Manager.
+ *
+ * Amaze File Manager is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.amaze.filemanager.filesystem.compressed.sevenz;
+
+/**
+ * Collects options for reading 7z archives.
+ *
+ * @since 1.19 @Immutable
+ */
+public class SevenZFileOptions {
+  private static final int DEFAUL_MEMORY_LIMIT_IN_KB = Integer.MAX_VALUE;
+  private static final boolean DEFAULT_USE_DEFAULTNAME_FOR_UNNAMED_ENTRIES = false;
+  private static final boolean DEFAULT_TRY_TO_RECOVER_BROKEN_ARCHIVES = false;
+
+  private final int maxMemoryLimitInKb;
+  private final boolean useDefaultNameForUnnamedEntries;
+  private final boolean tryToRecoverBrokenArchives;
+
+  private SevenZFileOptions(
+      final int maxMemoryLimitInKb,
+      final boolean useDefaultNameForUnnamedEntries,
+      final boolean tryToRecoverBrokenArchives) {
+    this.maxMemoryLimitInKb = maxMemoryLimitInKb;
+    this.useDefaultNameForUnnamedEntries = useDefaultNameForUnnamedEntries;
+    this.tryToRecoverBrokenArchives = tryToRecoverBrokenArchives;
+  }
+
+  /**
+   * The default options.
+   *
+   * <ul>
+   *   <li>no memory limit
+   *   <li>don't modify the name of unnamed entries
+   * </ul>
+   */
+  public static final SevenZFileOptions DEFAULT =
+      new SevenZFileOptions(
+          DEFAUL_MEMORY_LIMIT_IN_KB,
+          DEFAULT_USE_DEFAULTNAME_FOR_UNNAMED_ENTRIES,
+          DEFAULT_TRY_TO_RECOVER_BROKEN_ARCHIVES);
+
+  /**
+   * Obtains a builder for SevenZFileOptions.
+   *
+   * @return a builder for SevenZFileOptions.
+   */
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  /**
+   * Gets the maximum amount of memory to use for parsing the archive and during extraction.
+   *
+   * <p>Not all codecs will honor this setting. Currently only lzma and lzma2 are supported.
+   *
+   * @return the maximum amount of memory to use for extraction
+   */
+  public int getMaxMemoryLimitInKb() {
+    return maxMemoryLimitInKb;
+  }
+
+  /**
+   * Gets whether entries without a name should get their names set to the archive's default file
+   * name.
+   *
+   * @return whether entries without a name should get their names set to the archive's default file
+   *     name
+   */
+  public boolean getUseDefaultNameForUnnamedEntries() {
+    return useDefaultNameForUnnamedEntries;
+  }
+
+  /**
+   * Whether {@link SevenZFile} shall try to recover from a certain type of broken archive.
+   *
+   * @return whether SevenZFile shall try to recover from a certain type of broken archive.
+   * @since 1.21
+   */
+  public boolean getTryToRecoverBrokenArchives() {
+    return tryToRecoverBrokenArchives;
+  }
+
+  /**
+   * Mutable builder for the immutable {@link SevenZFileOptions}.
+   *
+   * @since 1.19
+   */
+  public static class Builder {
+    private int maxMemoryLimitInKb = DEFAUL_MEMORY_LIMIT_IN_KB;
+    private boolean useDefaultNameForUnnamedEntries = DEFAULT_USE_DEFAULTNAME_FOR_UNNAMED_ENTRIES;
+    private boolean tryToRecoverBrokenArchives = DEFAULT_TRY_TO_RECOVER_BROKEN_ARCHIVES;
+
+    /**
+     * Sets the maximum amount of memory to use for parsing the archive and during extraction.
+     *
+     * <p>Not all codecs will honor this setting. Currently only lzma and lzma2 are supported.
+     *
+     * @param maxMemoryLimitInKb limit of the maximum amount of memory to use
+     * @return the reconfigured builder
+     */
+    public Builder withMaxMemoryLimitInKb(final int maxMemoryLimitInKb) {
+      this.maxMemoryLimitInKb = maxMemoryLimitInKb;
+      return this;
+    }
+
+    /**
+     * Sets whether entries without a name should get their names set to the archive's default file
+     * name.
+     *
+     * @param useDefaultNameForUnnamedEntries if true the name of unnamed entries will be set to the
+     *     archive's default name
+     * @return the reconfigured builder
+     */
+    public Builder withUseDefaultNameForUnnamedEntries(
+        final boolean useDefaultNameForUnnamedEntries) {
+      this.useDefaultNameForUnnamedEntries = useDefaultNameForUnnamedEntries;
+      return this;
+    }
+
+    /**
+     * Sets whether {@link SevenZFile} will try to revover broken archives where the CRC of the
+     * file's metadata is 0.
+     *
+     * <p>This special kind of broken archive is encountered when mutli volume archives are closed
+     * prematurely. If you enable this option SevenZFile will trust data that looks as if it could
+     * contain metadata of an archive and allocate big amounts of memory. It is strongly recommended
+     * to not enable this option without setting {@link #withMaxMemoryLimitInKb} at the same time.
+     *
+     * @param tryToRecoverBrokenArchives if true SevenZFile will try to recover archives that are
+     *     broken in the specific way
+     * @return the reconfigured builder
+     * @since 1.21
+     */
+    public Builder withTryToRecoverBrokenArchives(final boolean tryToRecoverBrokenArchives) {
+      this.tryToRecoverBrokenArchives = tryToRecoverBrokenArchives;
+      return this;
+    }
+
+    /**
+     * Create the {@link SevenZFileOptions}.
+     *
+     * @return configured {@link SevenZFileOptions}.
+     */
+    public SevenZFileOptions build() {
+      return new SevenZFileOptions(
+          maxMemoryLimitInKb, useDefaultNameForUnnamedEntries, tryToRecoverBrokenArchives);
+    }
+  }
+}

--- a/commons_compress_7z/src/main/java/com/amaze/filemanager/filesystem/compressed/sevenz/SevenZMethod.java
+++ b/commons_compress_7z/src/main/java/com/amaze/filemanager/filesystem/compressed/sevenz/SevenZMethod.java
@@ -106,8 +106,9 @@ public enum SevenZMethod {
   }
 
   byte[] getId() {
-    final byte[] copy = new byte[id.length];
-    System.arraycopy(id, 0, copy, 0, id.length);
+    final int idLength = id.length;
+    final byte[] copy = new byte[idLength];
+    System.arraycopy(id, 0, copy, 0, idLength);
     return copy;
   }
 

--- a/commons_compress_7z/src/main/java/com/amaze/filemanager/filesystem/compressed/sevenz/SevenZMethodConfiguration.java
+++ b/commons_compress_7z/src/main/java/com/amaze/filemanager/filesystem/compressed/sevenz/SevenZMethodConfiguration.java
@@ -20,13 +20,16 @@
 
 package com.amaze.filemanager.filesystem.compressed.sevenz;
 
+import java.util.Objects;
+
 /**
  * Combines a SevenZMethod with configuration options for the method.
  *
  * <p>The exact type and interpretation of options depends on the method being configured. Currently
  * supported are:
  *
- * <table summary="Options">
+ * <table>
+ * <caption>Options</caption>
  * <tr><th>Method</th><th>Option Type</th><th>Description</th></tr>
  * <tr><td>BZIP2</td><td>Number</td><td>Block Size - an number between 1 and 9</td></tr>
  * <tr><td>DEFLATE</td><td>Number</td><td>Compression Level - an number between 1 and 9</td></tr>
@@ -84,5 +87,22 @@ public class SevenZMethodConfiguration {
    */
   public Object getOptions() {
     return options;
+  }
+
+  @Override
+  public int hashCode() {
+    return method == null ? 0 : method.hashCode();
+  }
+
+  @Override
+  public boolean equals(final Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (obj == null || getClass() != obj.getClass()) {
+      return false;
+    }
+    final SevenZMethodConfiguration other = (SevenZMethodConfiguration) obj;
+    return Objects.equals(method, other.method) && Objects.equals(options, other.options);
   }
 }

--- a/commons_compress_7z/src/main/java/com/amaze/filemanager/filesystem/compressed/sevenz/package.html
+++ b/commons_compress_7z/src/main/java/com/amaze/filemanager/filesystem/compressed/sevenz/package.html
@@ -1,4 +1,5 @@
-<html>
+<!DOCTYPE html>
+<html lang="en">
 <!--
 
    Licensed to the Apache Software Foundation (ASF) under one or more
@@ -17,6 +18,9 @@
    limitations under the License.
 
 -->
+  <head>
+    <title>7z package</title>
+  </head>
   <body>
     <p>Provides classes for reading and writing archives using
       the 7z format.</p>


### PR DESCRIPTION
## Description
Prevent out of memory errors.

https://security.snyk.io/package/maven/org.apache.commons:commons-compress/1.20

Aside, also backported the sevenz package using classes that are available from API 24 for better compatibility.

#### Issue tracker   
Addresses #3187

#### Automatic tests
- [ ] Added test cases
  
#### Manual tests
- [x] Done  
  
#### Build tasks success  
Successfully running following tasks on local:
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`