### PR TITLE
Fix source tree test failures

### DIFF
--- a/app/src/test/java/com/amaze/filemanager/asynchronous/asynctasks/ssh/PemToKeyPairObservableEd25519Test.kt
+++ b/app/src/test/java/com/amaze/filemanager/asynchronous/asynctasks/ssh/PemToKeyPairObservableEd25519Test.kt
@@ -20,7 +20,7 @@
 
 package com.amaze.filemanager.asynchronous.asynctasks.ssh
 
-import android.os.Build.VERSION_CODES.JELLY_BEAN
+import android.os.Build.VERSION_CODES
 import android.os.Build.VERSION_CODES.KITKAT
 import android.os.Build.VERSION_CODES.P
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -44,7 +44,7 @@ import org.robolectric.annotation.Config
 @RunWith(AndroidJUnit4::class)
 @Config(
     shadows = [ShadowMultiDex::class, ShadowTabHandler::class],
-    sdk = [JELLY_BEAN, KITKAT, P]
+    sdk = [KITKAT, P, VERSION_CODES.R]
 )
 class PemToKeyPairObservableEd25519Test {
 

--- a/app/src/test/java/com/amaze/filemanager/asynchronous/asynctasks/ssh/PemToKeyPairObservableRsaTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/asynchronous/asynctasks/ssh/PemToKeyPairObservableRsaTest.kt
@@ -21,7 +21,7 @@
 package com.amaze.filemanager.asynchronous.asynctasks.ssh
 
 import android.os.Build.VERSION.SDK_INT
-import android.os.Build.VERSION_CODES.JELLY_BEAN
+import android.os.Build.VERSION_CODES
 import android.os.Build.VERSION_CODES.KITKAT
 import android.os.Build.VERSION_CODES.N
 import android.os.Build.VERSION_CODES.P
@@ -64,7 +64,7 @@ import java.util.concurrent.TimeUnit
 @RunWith(AndroidJUnit4::class)
 @Config(
     shadows = [ShadowMultiDex::class, ShadowTabHandler::class],
-    sdk = [JELLY_BEAN, KITKAT, P]
+    sdk = [KITKAT, P, VERSION_CODES.R]
 )
 class PemToKeyPairObservableRsaTest {
 

--- a/commons_compress_7z/build.gradle
+++ b/commons_compress_7z/build.gradle
@@ -5,7 +5,7 @@ android {
     compileSdkVersion 28
 
     defaultConfig {
-        minSdkVersion 14
+        minSdkVersion 19
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 

--- a/file_operations/build.gradle
+++ b/file_operations/build.gradle
@@ -5,7 +5,7 @@ android {
     compileSdkVersion 30
 
     defaultConfig {
-        minSdkVersion 14
+        minSdkVersion 19
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"


### PR DESCRIPTION
## Description
Follow-up fix for #3692.
- Migrate tests that are still testing on JELLY_BEAN
- Update submodules Android version requirement to 4.4 too

#### Manual tests
- [x] Done  

Code base only, full build cycle passes without problem on my Linux Mint Vera desktop
  
#### Build tasks success  
<!-- run these! -->
Successfully running following tasks on local:
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`

#### Related PR  
Related to PR #3718