### PR TITLE
Return the actual path for local files

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/filesystem/HybridFile.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/HybridFile.java
@@ -416,11 +416,15 @@ public class HybridFile {
   }
 
   /**
-   * Path accessor. Avoid direct access to path since path may have been URL encoded.
+   * Path accessor. Avoid direct access to path (for non-local files) since path may have been URL
+   * encoded.
    *
-   * @return URL decoded path
+   * @return URL decoded path (for non-local files); the actual path for local files
    */
   public String getPath() {
+
+    if (isLocal() || isRoot() || isDocumentFile() || isAndroidDataDir()) return path;
+
     try {
       return URLDecoder.decode(path.replace("+", "%2b"), "UTF-8");
     } catch (UnsupportedEncodingException | IllegalArgumentException e) {

--- a/app/src/main/java/com/amaze/filemanager/filesystem/HybridFile.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/HybridFile.java
@@ -426,7 +426,7 @@ public class HybridFile {
     if (isLocal() || isRoot() || isDocumentFile() || isAndroidDataDir()) return path;
 
     try {
-      return URLDecoder.decode(path.replace("+", "%2b"), "UTF-8");
+      return URLDecoder.decode(path, "UTF-8");
     } catch (UnsupportedEncodingException | IllegalArgumentException e) {
       LOG.warn("failed to decode path {}", path, e);
       return path;


### PR DESCRIPTION
## Description

Return the actual path for local files, for the bug was Amaze skipping through paths that contains HTML encoded elements.

#### Issue tracker   
Fixes #3625

#### Automatic tests
- [ ] Added test cases
  
#### Manual tests
- [x] Done  

#### Build tasks success  
Successfully running following tasks on local:
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`

#### Additional info

PS: I have done testing to make sure nothing breaks with this change (and it seemed like it doesn't), please verify this from your end too! :)