### PR TITLE
Migrate widgets to use AppCompat versions where possible

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/adapters/CompressedExplorerAdapter.java
+++ b/app/src/main/java/com/amaze/filemanager/adapters/CompressedExplorerAdapter.java
@@ -53,10 +53,10 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.view.animation.Animation;
 import android.view.animation.AnimationUtils;
-import android.widget.ImageButton;
-import android.widget.ImageView;
 import android.widget.Toast;
 
+import androidx.appcompat.widget.AppCompatImageButton;
+import androidx.appcompat.widget.AppCompatImageView;
 import androidx.recyclerview.widget.RecyclerView;
 
 /** Created by Arpit on 25-01-2015 edited by Emmanuel Messulam<emmanuelbendavid@gmail.com> */
@@ -127,7 +127,7 @@ public class CompressedExplorerAdapter extends RecyclerView.Adapter<CompressedIt
    * @param position the position of the item
    * @param imageView the circular {@link CircleGradientDrawable} that is to be animated
    */
-  private void toggleChecked(int position, ImageView imageView) {
+  private void toggleChecked(int position, AppCompatImageView imageView) {
     compressedExplorerFragment.stopAnim();
     stoppedAnimation = true;
 
@@ -204,7 +204,7 @@ public class CompressedExplorerAdapter extends RecyclerView.Adapter<CompressedIt
     } else if (viewType == TYPE_ITEM) {
       View v = mInflater.inflate(R.layout.rowlayout, parent, false);
       CompressedItemViewHolder vh = new CompressedItemViewHolder(v);
-      ImageButton about = v.findViewById(R.id.properties);
+      AppCompatImageButton about = v.findViewById(R.id.properties);
       about.setVisibility(View.INVISIBLE);
       return vh;
     } else {

--- a/app/src/main/java/com/amaze/filemanager/adapters/RecyclerAdapter.java
+++ b/app/src/main/java/com/amaze/filemanager/adapters/RecyclerAdapter.java
@@ -84,15 +84,15 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.view.animation.Animation;
 import android.view.animation.AnimationUtils;
-import android.widget.ImageView;
 import android.widget.PopupMenu;
-import android.widget.TextView;
 
 import androidx.annotation.IntDef;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.view.ActionMode;
 import androidx.appcompat.view.ContextThemeWrapper;
+import androidx.appcompat.widget.AppCompatImageView;
+import androidx.appcompat.widget.AppCompatTextView;
 import androidx.recyclerview.widget.RecyclerView;
 
 /**
@@ -200,7 +200,7 @@ public class RecyclerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
    * @param position the position of the item
    * @param imageView the check {@link CircleGradientDrawable} that is to be animated
    */
-  public void toggleChecked(int position, ImageView imageView) {
+  public void toggleChecked(int position, AppCompatImageView imageView) {
     if (getItemsDigested().size() <= position || position < 0) {
       AppConfig.toast(context, R.string.operation_not_supported);
       return;
@@ -1192,7 +1192,7 @@ public class RecyclerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
         .setVisibility(View.VISIBLE);
     String rememberMovePreference =
         sharedPrefs.getString(PreferencesConstants.PREFERENCE_DRAG_AND_DROP_REMEMBERED, "");
-    ImageView icon =
+    AppCompatImageView icon =
         mainFragment
             .getMainActivity()
             .getTabFragment()
@@ -1204,7 +1204,7 @@ public class RecyclerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
             .getTabFragment()
             .getDragPlaceholder()
             .findViewById(R.id.files_count_parent);
-    TextView filesCount =
+    AppCompatTextView filesCount =
         mainFragment
             .getMainActivity()
             .getTabFragment()
@@ -1238,7 +1238,7 @@ public class RecyclerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
   private void showThumbnailWithBackground(
       ItemViewHolder viewHolder,
       IconDataParcelable iconData,
-      ImageView view,
+      AppCompatImageView view,
       OnImageProcessed errorListener) {
     if (iconData.isImageBroken()) {
       viewHolder.genericIcon.setVisibility(View.VISIBLE);
@@ -1301,7 +1301,7 @@ public class RecyclerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
   private void showRoundedThumbnail(
       ItemViewHolder viewHolder,
       IconDataParcelable iconData,
-      ImageView view,
+      AppCompatImageView view,
       OnImageProcessed errorListener) {
     if (iconData.isImageBroken()) {
       View iconBackground =

--- a/app/src/main/java/com/amaze/filemanager/adapters/SearchRecyclerViewAdapter.kt
+++ b/app/src/main/java/com/amaze/filemanager/adapters/SearchRecyclerViewAdapter.kt
@@ -24,7 +24,7 @@ import android.content.Context
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.TextView
+import androidx.appcompat.widget.AppCompatTextView
 import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
@@ -81,8 +81,8 @@ class SearchRecyclerViewAdapter :
 
     inner class ViewHolder(view: View) : RecyclerView.ViewHolder(view) {
 
-        val fileNameTV: TextView
-        val filePathTV: TextView
+        val fileNameTV: AppCompatTextView
+        val filePathTV: AppCompatTextView
         val colorView: View
 
         init {

--- a/app/src/main/java/com/amaze/filemanager/adapters/glide/AppsAdapterPreloadModel.java
+++ b/app/src/main/java/com/amaze/filemanager/adapters/glide/AppsAdapterPreloadModel.java
@@ -36,10 +36,10 @@ import com.bumptech.glide.RequestBuilder;
 import android.content.Context;
 import android.content.pm.PackageManager;
 import android.graphics.drawable.Drawable;
-import android.widget.ImageView;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.appcompat.widget.AppCompatImageView;
 import androidx.core.content.ContextCompat;
 import androidx.fragment.app.Fragment;
 
@@ -85,7 +85,7 @@ public class AppsAdapterPreloadModel implements ListPreloader.PreloadModelProvid
     }
   }
 
-  public void loadApkImage(String item, ImageView v) {
+  public void loadApkImage(String item, AppCompatImageView v) {
     if (isBottomSheet) {
       request.load(getApplicationIconFromPackageName(item)).into(v);
     } else {

--- a/app/src/main/java/com/amaze/filemanager/adapters/holders/AppHolder.kt
+++ b/app/src/main/java/com/amaze/filemanager/adapters/holders/AppHolder.kt
@@ -22,10 +22,10 @@ package com.amaze.filemanager.adapters.holders
 
 import android.view.View
 import android.view.ViewGroup
-import android.widget.ImageButton
-import android.widget.ImageView
 import android.widget.RelativeLayout
-import android.widget.TextView
+import androidx.appcompat.widget.AppCompatImageButton
+import androidx.appcompat.widget.AppCompatImageView
+import androidx.appcompat.widget.AppCompatTextView
 import androidx.core.view.marginBottom
 import androidx.core.view.marginLeft
 import androidx.core.view.marginTop
@@ -36,7 +36,7 @@ import com.amaze.filemanager.utils.Utils
 
 class AppHolder(view: View) : RecyclerView.ViewHolder(view) {
     @JvmField
-    val apkIcon: ImageView = view.findViewById(R.id.apk_icon)
+    val apkIcon: AppCompatImageView = view.findViewById(R.id.apk_icon)
 
     @JvmField
     val txtTitle: ThemedTextView = view.findViewById(R.id.firstline)
@@ -45,16 +45,16 @@ class AppHolder(view: View) : RecyclerView.ViewHolder(view) {
     val rl: RelativeLayout = view.findViewById(R.id.second)
 
     @JvmField
-    val txtDesc: TextView = view.findViewById(R.id.date)
+    val txtDesc: AppCompatTextView = view.findViewById(R.id.date)
 
     @JvmField
-    val about: ImageButton = view.findViewById(R.id.properties)
+    val about: AppCompatImageButton = view.findViewById(R.id.properties)
 
     @JvmField
     val summary: RelativeLayout = view.findViewById(R.id.summary)
 
     @JvmField
-    val packageName: TextView = view.findViewById(R.id.appManagerPackageName)
+    val packageName: AppCompatTextView = view.findViewById(R.id.appManagerPackageName)
 
     init {
         apkIcon.visibility = View.VISIBLE
@@ -69,7 +69,7 @@ class AppHolder(view: View) : RecyclerView.ViewHolder(view) {
         )
         txtDesc.layoutParams = layoutParams
 
-        view.findViewById<ImageView>(R.id.picture_icon).visibility = View.GONE
-        view.findViewById<ImageView>(R.id.generic_icon).visibility = View.GONE
+        view.findViewById<AppCompatImageView>(R.id.picture_icon).visibility = View.GONE
+        view.findViewById<AppCompatImageView>(R.id.generic_icon).visibility = View.GONE
     }
 }

--- a/app/src/main/java/com/amaze/filemanager/adapters/holders/CompressedItemViewHolder.kt
+++ b/app/src/main/java/com/amaze/filemanager/adapters/holders/CompressedItemViewHolder.kt
@@ -21,8 +21,8 @@
 package com.amaze.filemanager.adapters.holders
 
 import android.view.View
-import android.widget.ImageView
-import android.widget.TextView
+import androidx.appcompat.widget.AppCompatImageView
+import androidx.appcompat.widget.AppCompatTextView
 import androidx.recyclerview.widget.RecyclerView
 import com.amaze.filemanager.R
 import com.amaze.filemanager.ui.views.ThemedTextView
@@ -30,28 +30,28 @@ import com.amaze.filemanager.ui.views.ThemedTextView
 class CompressedItemViewHolder(view: View) : RecyclerView.ViewHolder(view) {
     // each data item is just a string in this case
     @JvmField
-    val pictureIcon: ImageView = view.findViewById(R.id.picture_icon)
+    val pictureIcon: AppCompatImageView = view.findViewById(R.id.picture_icon)
 
     @JvmField
-    val genericIcon: ImageView = view.findViewById(R.id.generic_icon)
+    val genericIcon: AppCompatImageView = view.findViewById(R.id.generic_icon)
 
     @JvmField
-    val apkIcon: ImageView = view.findViewById(R.id.apk_icon)
+    val apkIcon: AppCompatImageView = view.findViewById(R.id.apk_icon)
 
     @JvmField
     val txtTitle: ThemedTextView = view.findViewById(R.id.firstline)
 
     @JvmField
-    val txtDesc: TextView = view.findViewById(R.id.secondLine)
+    val txtDesc: AppCompatTextView = view.findViewById(R.id.secondLine)
 
     @JvmField
-    val date: TextView = view.findViewById(R.id.date)
+    val date: AppCompatTextView = view.findViewById(R.id.date)
 
-    val perm: TextView = view.findViewById(R.id.permis)
+    val perm: AppCompatTextView = view.findViewById(R.id.permis)
 
     @JvmField
     val rl: View = view.findViewById(R.id.second)
 
     @JvmField
-    val checkImageView: ImageView = view.findViewById(R.id.check_icon)
+    val checkImageView: AppCompatImageView = view.findViewById(R.id.check_icon)
 }

--- a/app/src/main/java/com/amaze/filemanager/adapters/holders/DonationViewHolder.kt
+++ b/app/src/main/java/com/amaze/filemanager/adapters/holders/DonationViewHolder.kt
@@ -22,7 +22,7 @@ package com.amaze.filemanager.adapters.holders
 
 import android.view.View
 import android.widget.LinearLayout
-import android.widget.TextView
+import androidx.appcompat.widget.AppCompatTextView
 import androidx.recyclerview.widget.RecyclerView
 import com.amaze.filemanager.R
 
@@ -31,11 +31,11 @@ class DonationViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
     val ROOT_VIEW: LinearLayout = itemView.findViewById(R.id.adapter_donation_root)
 
     @JvmField
-    val TITLE: TextView = itemView.findViewById(R.id.adapter_donation_title)
+    val TITLE: AppCompatTextView = itemView.findViewById(R.id.adapter_donation_title)
 
     @JvmField
-    val SUMMARY: TextView = itemView.findViewById(R.id.adapter_donation_summary)
+    val SUMMARY: AppCompatTextView = itemView.findViewById(R.id.adapter_donation_summary)
 
     @JvmField
-    val PRICE: TextView = itemView.findViewById(R.id.adapter_donation_price)
+    val PRICE: AppCompatTextView = itemView.findViewById(R.id.adapter_donation_price)
 }

--- a/app/src/main/java/com/amaze/filemanager/adapters/holders/HiddenViewHolder.kt
+++ b/app/src/main/java/com/amaze/filemanager/adapters/holders/HiddenViewHolder.kt
@@ -21,9 +21,9 @@
 package com.amaze.filemanager.adapters.holders
 
 import android.view.View
-import android.widget.ImageButton
 import android.widget.LinearLayout
-import android.widget.TextView
+import androidx.appcompat.widget.AppCompatImageButton
+import androidx.appcompat.widget.AppCompatTextView
 import androidx.recyclerview.widget.RecyclerView
 import com.amaze.filemanager.R
 
@@ -34,13 +34,13 @@ import com.amaze.filemanager.R
  */
 class HiddenViewHolder(view: View) : RecyclerView.ViewHolder(view) {
     @JvmField
-    val deleteButton: ImageButton = view.findViewById(R.id.delete_button)
+    val deleteButton: AppCompatImageButton = view.findViewById(R.id.delete_button)
 
     @JvmField
-    val textTitle: TextView = view.findViewById(R.id.filename)
+    val textTitle: AppCompatTextView = view.findViewById(R.id.filename)
 
     @JvmField
-    val textDescription: TextView = view.findViewById(R.id.file_path)
+    val textDescription: AppCompatTextView = view.findViewById(R.id.file_path)
 
     @JvmField
     val row: LinearLayout = view.findViewById(R.id.bookmarkrow)

--- a/app/src/main/java/com/amaze/filemanager/adapters/holders/ItemViewHolder.kt
+++ b/app/src/main/java/com/amaze/filemanager/adapters/holders/ItemViewHolder.kt
@@ -21,10 +21,10 @@
 package com.amaze.filemanager.adapters.holders
 
 import android.view.View
-import android.widget.ImageButton
-import android.widget.ImageView
 import android.widget.RelativeLayout
-import android.widget.TextView
+import androidx.appcompat.widget.AppCompatImageButton
+import androidx.appcompat.widget.AppCompatImageView
+import androidx.appcompat.widget.AppCompatTextView
 import androidx.recyclerview.widget.RecyclerView
 import com.amaze.filemanager.R
 import com.amaze.filemanager.ui.views.ThemedTextView
@@ -36,43 +36,43 @@ import com.amaze.filemanager.ui.views.ThemedTextView
 class ItemViewHolder(view: View) : RecyclerView.ViewHolder(view) {
     // each data item is just a string in this case
     @JvmField
-    val pictureIcon: ImageView? = view.findViewById(R.id.picture_icon)
+    val pictureIcon: AppCompatImageView? = view.findViewById(R.id.picture_icon)
 
     @JvmField
-    val genericIcon: ImageView = view.findViewById(R.id.generic_icon)
+    val genericIcon: AppCompatImageView = view.findViewById(R.id.generic_icon)
 
     @JvmField
-    val apkIcon: ImageView? = view.findViewById(R.id.apk_icon)
+    val apkIcon: AppCompatImageView? = view.findViewById(R.id.apk_icon)
 
     @JvmField
-    val imageView1: ImageView? = view.findViewById(R.id.icon_thumb)
+    val imageView1: AppCompatImageView? = view.findViewById(R.id.icon_thumb)
 
     @JvmField
     val txtTitle: ThemedTextView = view.findViewById(R.id.firstline)
 
     @JvmField
-    val txtDesc: TextView = view.findViewById(R.id.secondLine)
+    val txtDesc: AppCompatTextView = view.findViewById(R.id.secondLine)
 
     @JvmField
-    val date: TextView = view.findViewById(R.id.date)
+    val date: AppCompatTextView = view.findViewById(R.id.date)
 
     @JvmField
-    val perm: TextView = view.findViewById(R.id.permis)
+    val perm: AppCompatTextView = view.findViewById(R.id.permis)
 
     @JvmField
     val baseItemView: View = view.findViewById(R.id.second)
 
     @JvmField
-    val genericText: TextView? = view.findViewById(R.id.generictext)
+    val genericText: AppCompatTextView? = view.findViewById(R.id.generictext)
 
     @JvmField
-    val about: ImageButton = view.findViewById(R.id.properties)
+    val about: AppCompatImageButton = view.findViewById(R.id.properties)
 
     @JvmField
-    val checkImageView: ImageView? = view.findViewById(R.id.check_icon)
+    val checkImageView: AppCompatImageView? = view.findViewById(R.id.check_icon)
 
     @JvmField
-    val checkImageViewGrid: ImageView? = view.findViewById(R.id.check_icon_grid)
+    val checkImageViewGrid: AppCompatImageView? = view.findViewById(R.id.check_icon_grid)
 
     @JvmField
     val iconLayout: RelativeLayout? = view.findViewById(R.id.icon_frame_grid)

--- a/app/src/main/java/com/amaze/filemanager/adapters/holders/SpecialViewHolder.kt
+++ b/app/src/main/java/com/amaze/filemanager/adapters/holders/SpecialViewHolder.kt
@@ -22,7 +22,7 @@ package com.amaze.filemanager.adapters.holders
 
 import android.content.Context
 import android.view.View
-import android.widget.TextView
+import androidx.appcompat.widget.AppCompatTextView
 import androidx.recyclerview.widget.RecyclerView
 import com.amaze.filemanager.R
 import com.amaze.filemanager.ui.provider.UtilitiesProvider
@@ -39,7 +39,7 @@ class SpecialViewHolder(
     val type: Int
 ) : RecyclerView.ViewHolder(view) {
     // each data item is just a string in this case
-    private val txtTitle: TextView = view.findViewById(R.id.text)
+    private val txtTitle: AppCompatTextView = view.findViewById(R.id.text)
 
     companion object {
         const val HEADER_FILES = 0

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/CountItemsOrAndSizeTask.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/CountItemsOrAndSizeTask.java
@@ -29,8 +29,8 @@ import com.amaze.filemanager.filesystem.files.FileUtils;
 import android.content.Context;
 import android.os.AsyncTask;
 import android.text.format.Formatter;
-import android.widget.TextView;
 
+import androidx.appcompat.widget.AppCompatTextView;
 import androidx.core.util.Pair;
 
 /**
@@ -39,12 +39,12 @@ import androidx.core.util.Pair;
 public class CountItemsOrAndSizeTask extends AsyncTask<Void, Pair<Integer, Long>, String> {
 
   private Context context;
-  private TextView itemsText;
+  private AppCompatTextView itemsText;
   private HybridFileParcelable file;
   private boolean isStorage;
 
   public CountItemsOrAndSizeTask(
-      Context c, TextView itemsText, HybridFileParcelable f, boolean storage) {
+      Context c, AppCompatTextView itemsText, HybridFileParcelable f, boolean storage) {
     this.context = c;
     this.itemsText = itemsText;
     file = f;

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/hashcalculator/CalculateHashTask.kt
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/hashcalculator/CalculateHashTask.kt
@@ -23,8 +23,8 @@ package com.amaze.filemanager.asynchronous.asynctasks.hashcalculator
 import android.content.Context
 import android.view.View
 import android.widget.LinearLayout
-import android.widget.TextView
 import android.widget.Toast
+import androidx.appcompat.widget.AppCompatTextView
 import com.amaze.filemanager.R
 import com.amaze.filemanager.asynchronous.asynctasks.Task
 import com.amaze.filemanager.filesystem.HybridFileParcelable
@@ -32,7 +32,7 @@ import com.amaze.filemanager.filesystem.files.FileUtils
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.lang.ref.WeakReference
-import java.util.*
+import java.util.Locale
 import java.util.concurrent.Callable
 
 data class Hash(val md5: String, val sha: String)
@@ -78,8 +78,8 @@ class CalculateHashTask(
         val md5Text = hashes?.md5 ?: context.getString(R.string.unavailable)
         val shaText = hashes?.sha ?: context.getString(R.string.unavailable)
 
-        val md5HashText = view.findViewById<TextView>(R.id.t9)
-        val sha256Text = view.findViewById<TextView>(R.id.t10)
+        val md5HashText = view.findViewById<AppCompatTextView>(R.id.t9)
+        val sha256Text = view.findViewById<AppCompatTextView>(R.id.t10)
 
         val mMD5LinearLayout = view.findViewById<LinearLayout>(R.id.properties_dialog_md5)
         val mSHA256LinearLayout = view.findViewById<LinearLayout>(R.id.properties_dialog_sha256)

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/movecopy/PrepareCopyTask.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/movecopy/PrepareCopyTask.java
@@ -52,10 +52,10 @@ import android.content.Intent;
 import android.os.AsyncTask;
 import android.view.LayoutInflater;
 import android.view.View;
-import android.widget.CheckBox;
 import android.widget.Toast;
 
 import androidx.annotation.IntDef;
+import androidx.appcompat.widget.AppCompatCheckBox;
 
 /**
  * This AsyncTask works by creating a tree where each folder that can be fusioned together with
@@ -222,7 +222,7 @@ public class PrepareCopyTask extends AsyncTask<Void, String, PrepareCopyTask.Cop
     copyDialogBinding.fileNameText.setText(conflictingFiles.get(counter).getName(context.get()));
 
     // checkBox
-    final CheckBox checkBox = copyDialogBinding.checkBox;
+    final AppCompatCheckBox checkBox = copyDialogBinding.checkBox;
     Utils.setTint(context.get(), checkBox, accentColor);
     dialogBuilder.theme(mainActivity.get().getAppTheme().getMaterialDialogTheme(context.get()));
     dialogBuilder.title(context.get().getResources().getString(R.string.paste));

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/services/ExtractService.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/services/ExtractService.java
@@ -54,12 +54,12 @@ import android.content.SharedPreferences;
 import android.os.AsyncTask;
 import android.os.IBinder;
 import android.text.TextUtils;
-import android.widget.EditText;
 import android.widget.RemoteViews;
 import android.widget.Toast;
 
 import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
+import androidx.appcompat.widget.AppCompatEditText;
 import androidx.core.app.NotificationCompat;
 import androidx.core.app.NotificationManagerCompat;
 import androidx.preference.PreferenceManager;
@@ -391,7 +391,7 @@ public class ExtractService extends AbstractProgressiveService {
           R.string.archive_password_prompt,
           R.string.authenticate_password,
           (dialog, which) -> {
-            EditText editText = dialog.getView().findViewById(R.id.singleedittext_input);
+            AppCompatEditText editText = dialog.getView().findViewById(R.id.singleedittext_input);
             ArchivePasswordCache.getInstance().put(compressedPath, editText.getText().toString());
             ExtractService.this.getDataPackages().clear();
             this.paused = false;

--- a/app/src/main/java/com/amaze/filemanager/crashreport/ErrorActivity.java
+++ b/app/src/main/java/com/amaze/filemanager/crashreport/ErrorActivity.java
@@ -58,13 +58,13 @@ import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
-import android.widget.Button;
-import android.widget.EditText;
-import android.widget.TextView;
 import android.widget.Toast;
 
 import androidx.annotation.StringRes;
 import androidx.appcompat.app.ActionBar;
+import androidx.appcompat.widget.AppCompatButton;
+import androidx.appcompat.widget.AppCompatEditText;
+import androidx.appcompat.widget.AppCompatTextView;
 import androidx.appcompat.widget.Toolbar;
 import androidx.core.app.NavUtils;
 
@@ -109,7 +109,7 @@ public class ErrorActivity extends ThemedActivity {
   private ErrorInfo errorInfo;
   private Class returnActivity;
   private String currentTimeStamp;
-  private EditText userCommentBox;
+  private AppCompatEditText userCommentBox;
 
   public static void reportError(
       final Context context,
@@ -197,14 +197,14 @@ public class ErrorActivity extends ThemedActivity {
       actionBar.setDisplayShowTitleEnabled(true);
     }
 
-    final Button reportEmailButton = findViewById(R.id.errorReportEmailButton);
-    final Button reportTelegramButton = findViewById(R.id.errorReportTelegramButton);
-    final Button copyButton = findViewById(R.id.errorReportCopyButton);
-    final Button reportGithubButton = findViewById(R.id.errorReportGitHubButton);
+    final AppCompatButton reportEmailButton = findViewById(R.id.errorReportEmailButton);
+    final AppCompatButton reportTelegramButton = findViewById(R.id.errorReportTelegramButton);
+    final AppCompatButton copyButton = findViewById(R.id.errorReportCopyButton);
+    final AppCompatButton reportGithubButton = findViewById(R.id.errorReportGitHubButton);
 
     userCommentBox = findViewById(R.id.errorCommentBox);
-    final TextView errorView = findViewById(R.id.errorView);
-    final TextView errorMessageView = findViewById(R.id.errorMessageView);
+    final AppCompatTextView errorView = findViewById(R.id.errorView);
+    final AppCompatTextView errorMessageView = findViewById(R.id.errorMessageView);
 
     returnActivity = MainActivity.class;
     errorInfo = intent.getParcelableExtra(ERROR_INFO);
@@ -306,8 +306,8 @@ public class ErrorActivity extends ThemedActivity {
   }
 
   private void buildInfo(final ErrorInfo info) {
-    final TextView infoLabelView = findViewById(R.id.errorInfoLabelsView);
-    final TextView infoView = findViewById(R.id.errorInfosView);
+    final AppCompatTextView infoLabelView = findViewById(R.id.errorInfoLabelsView);
+    final AppCompatTextView infoView = findViewById(R.id.errorInfosView);
     String text = "";
 
     infoLabelView.setText(getString(R.string.info_labels).replace("\\n", "\n"));
@@ -440,7 +440,7 @@ public class ErrorActivity extends ThemedActivity {
 
   private void addGuruMeditation() {
     // just an easter egg
-    final TextView sorryView = findViewById(R.id.errorSorryView);
+    final AppCompatTextView sorryView = findViewById(R.id.errorSorryView);
     String text = sorryView.getText().toString();
     text += "\n" + getString(R.string.guru_meditation);
     sorryView.setText(text);

--- a/app/src/main/java/com/amaze/filemanager/filesystem/files/EncryptDecryptUtils.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/files/EncryptDecryptUtils.java
@@ -50,10 +50,10 @@ import android.content.Intent;
 import android.content.SharedPreferences;
 import android.os.Build;
 import android.util.Base64;
-import android.widget.EditText;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
+import androidx.appcompat.widget.AppCompatEditText;
 import androidx.preference.PreferenceManager;
 
 /**
@@ -114,7 +114,7 @@ public class EncryptDecryptUtils {
           R.string.crypt_decrypt,
           R.string.authenticate_password,
           (dialog, which) -> {
-            EditText editText = dialog.getView().findViewById(R.id.singleedittext_input);
+            AppCompatEditText editText = dialog.getView().findViewById(R.id.singleedittext_input);
             decryptIntent.putExtra(EncryptService.TAG_PASSWORD, editText.getText().toString());
             ServiceWatcherUtil.runService(main.getContext(), decryptIntent);
             dialog.dismiss();

--- a/app/src/main/java/com/amaze/filemanager/ui/Extensions.kt
+++ b/app/src/main/java/com/amaze/filemanager/ui/Extensions.kt
@@ -27,8 +27,8 @@ import android.content.pm.PackageManager
 import android.text.TextUtils
 import android.view.View
 import android.view.inputmethod.InputMethodManager
-import android.widget.EditText
 import android.widget.Toast
+import androidx.appcompat.widget.AppCompatEditText
 import com.amaze.filemanager.R
 import com.amaze.filemanager.application.AppConfig
 import com.google.android.material.textfield.TextInputLayout
@@ -82,7 +82,7 @@ fun Context.updateAUAlias(shouldEnable: Boolean) {
 /**
  * Force keyboard pop up on focus
  */
-fun EditText.openKeyboard(context: Context) {
+fun AppCompatEditText.openKeyboard(context: Context) {
     this.requestFocus()
 
     this.postDelayed(

--- a/app/src/main/java/com/amaze/filemanager/ui/activities/AboutActivity.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/activities/AboutActivity.java
@@ -49,9 +49,9 @@ import android.os.Build;
 import android.os.Bundle;
 import android.view.MenuItem;
 import android.view.View;
-import android.widget.TextView;
 
 import androidx.annotation.Nullable;
+import androidx.appcompat.widget.AppCompatTextView;
 import androidx.appcompat.widget.Toolbar;
 import androidx.coordinatorlayout.widget.CoordinatorLayout;
 import androidx.core.content.FileProvider;
@@ -66,7 +66,7 @@ public class AboutActivity extends ThemedActivity implements View.OnClickListene
 
   private AppBarLayout mAppBarLayout;
   private CollapsingToolbarLayout mCollapsingToolbarLayout;
-  private TextView mTitleTextView;
+  private AppCompatTextView mTitleTextView;
   private View mAuthorsDivider, mDeveloper1Divider;
   private Billing billing;
 

--- a/app/src/main/java/com/amaze/filemanager/ui/activities/texteditor/TextEditorActivity.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/activities/texteditor/TextEditorActivity.java
@@ -70,20 +70,20 @@ import android.view.ViewAnimationUtils;
 import android.view.animation.AccelerateDecelerateInterpolator;
 import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputMethodManager;
-import android.widget.EditText;
-import android.widget.ImageButton;
 import android.widget.RelativeLayout;
 import android.widget.ScrollView;
 import android.widget.Toast;
 
 import androidx.annotation.ColorInt;
+import androidx.appcompat.widget.AppCompatEditText;
+import androidx.appcompat.widget.AppCompatImageButton;
 import androidx.lifecycle.ViewModelProvider;
 
 public class TextEditorActivity extends ThemedActivity
     implements TextWatcher, View.OnClickListener {
 
-  public EditText mainTextView;
-  public EditText searchEditText;
+  public AppCompatEditText mainTextView;
+  public AppCompatEditText searchEditText;
   private Typeface inputTypefaceDefault;
   private Typeface inputTypefaceMono;
   private androidx.appcompat.widget.Toolbar toolbar;
@@ -96,9 +96,9 @@ public class TextEditorActivity extends ThemedActivity
   private static final String KEY_MONOFONT = "monofont";
 
   private RelativeLayout searchViewLayout;
-  public ImageButton upButton;
-  public ImageButton downButton;
-  public ImageButton closeButton;
+  public AppCompatImageButton upButton;
+  public AppCompatImageButton downButton;
+  public AppCompatImageButton closeButton;
 
   private Snackbar loadingSnackbar;
 

--- a/app/src/main/java/com/amaze/filemanager/ui/dialogs/ColorPickerDialog.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/dialogs/ColorPickerDialog.java
@@ -43,10 +43,10 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.LinearLayout;
 import android.widget.RadioButton;
-import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.StringRes;
+import androidx.appcompat.widget.AppCompatTextView;
 import androidx.core.util.Pair;
 import androidx.preference.Preference.BaseSavedState;
 import androidx.preference.PreferenceDialogFragmentCompat;
@@ -167,7 +167,7 @@ public class ColorPickerDialog extends PreferenceDialogFragmentCompat {
         select(selectedItem, true);
       }
 
-      ((TextView) child.findViewById(R.id.text)).setText(COLORS[i].first);
+      ((AppCompatTextView) child.findViewById(R.id.text)).setText(COLORS[i].first);
       CircularColorsView colorsView = child.findViewById(R.id.circularColorsView);
       colorsView.setColors(getColor(i, 0), getColor(i, 1), getColor(i, 2), getColor(i, 3));
       AppTheme appTheme =
@@ -185,7 +185,7 @@ public class ColorPickerDialog extends PreferenceDialogFragmentCompat {
         select(selectedItem, true);
       }
 
-      ((TextView) child.findViewById(R.id.text)).setText(R.string.custom);
+      ((AppCompatTextView) child.findViewById(R.id.text)).setText(R.string.custom);
       child.findViewById(R.id.circularColorsView).setVisibility(View.INVISIBLE);
       container.addView(child);
     }
@@ -197,7 +197,7 @@ public class ColorPickerDialog extends PreferenceDialogFragmentCompat {
         select(selectedItem, true);
       }
 
-      ((TextView) child.findViewById(R.id.text)).setText(R.string.random);
+      ((AppCompatTextView) child.findViewById(R.id.text)).setText(R.string.random);
       child.findViewById(R.id.circularColorsView).setVisibility(View.INVISIBLE);
       container.addView(child);
     }
@@ -249,9 +249,9 @@ public class ColorPickerDialog extends PreferenceDialogFragmentCompat {
         ((UserColorPreferences) requireArguments().getParcelable(ARG_COLOR_PREF)).getAccent();
 
     // Button views
-    ((TextView) dialog.findViewById(res.getIdentifier("button1", "id", "android")))
+    ((AppCompatTextView) dialog.findViewById(res.getIdentifier("button1", "id", "android")))
         .setTextColor(accentColor);
-    ((TextView) dialog.findViewById(res.getIdentifier("button2", "id", "android")))
+    ((AppCompatTextView) dialog.findViewById(res.getIdentifier("button2", "id", "android")))
         .setTextColor(accentColor);
 
     return dialog;

--- a/app/src/main/java/com/amaze/filemanager/ui/dialogs/DecryptFingerprintDialog.kt
+++ b/app/src/main/java/com/amaze/filemanager/ui/dialogs/DecryptFingerprintDialog.kt
@@ -25,8 +25,8 @@ import android.content.Intent
 import android.hardware.fingerprint.FingerprintManager
 import android.os.Build
 import android.view.View
-import android.widget.Button
 import androidx.annotation.RequiresApi
+import androidx.appcompat.widget.AppCompatButton
 import com.afollestad.materialdialogs.MaterialDialog
 import com.amaze.filemanager.R
 import com.amaze.filemanager.filesystem.files.CryptUtil
@@ -62,7 +62,9 @@ object DecryptFingerprintDialog {
         val builder = MaterialDialog.Builder(c)
         builder.title(c.getString(R.string.crypt_decrypt))
         val rootView = View.inflate(c, R.layout.dialog_decrypt_fingerprint_authentication, null)
-        val cancelButton = rootView.findViewById<Button>(R.id.button_decrypt_fingerprint_cancel)
+        val cancelButton = rootView.findViewById<AppCompatButton>(
+            R.id.button_decrypt_fingerprint_cancel
+        )
         cancelButton.setTextColor(accentColor)
         builder.customView(rootView, true)
         builder.canceledOnTouchOutside(false)

--- a/app/src/main/java/com/amaze/filemanager/ui/dialogs/DragAndDropDialog.kt
+++ b/app/src/main/java/com/amaze/filemanager/ui/dialogs/DragAndDropDialog.kt
@@ -24,8 +24,8 @@ import android.app.Dialog
 import android.content.Context
 import android.os.AsyncTask
 import android.os.Bundle
-import android.widget.Button
-import android.widget.CheckBox
+import androidx.appcompat.widget.AppCompatButton
+import androidx.appcompat.widget.AppCompatCheckBox
 import androidx.fragment.app.DialogFragment
 import com.afollestad.materialdialogs.DialogAction
 import com.afollestad.materialdialogs.MaterialDialog
@@ -152,8 +152,8 @@ class DragAndDropDialog : DialogFragment() {
 
             dialog.customView?.run {
                 // Get views from custom layout to set text values.
-                val rememberCheckbox = this.findViewById<CheckBox>(R.id.remember_drag)
-                val moveButton = this.findViewById<Button>(R.id.button_move)
+                val rememberCheckbox = this.findViewById<AppCompatCheckBox>(R.id.remember_drag)
+                val moveButton = this.findViewById<AppCompatButton>(R.id.button_move)
                 moveButton.setOnClickListener {
                     mainActivity?.run {
                         if (rememberCheckbox.isChecked) {
@@ -163,7 +163,7 @@ class DragAndDropDialog : DialogFragment() {
                         dismiss()
                     }
                 }
-                val copyButton = this.findViewById<Button>(R.id.button_copy)
+                val copyButton = this.findViewById<AppCompatButton>(R.id.button_copy)
                 copyButton.setOnClickListener {
                     mainActivity?.run {
                         if (rememberCheckbox.isChecked) {

--- a/app/src/main/java/com/amaze/filemanager/ui/dialogs/GeneralDialogCreation.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/dialogs/GeneralDialogCreation.java
@@ -93,16 +93,16 @@ import android.text.TextUtils;
 import android.text.format.Formatter;
 import android.view.LayoutInflater;
 import android.view.View;
-import android.widget.CheckBox;
-import android.widget.EditText;
 import android.widget.LinearLayout;
-import android.widget.TextView;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
 import androidx.appcompat.widget.AppCompatButton;
+import androidx.appcompat.widget.AppCompatCheckBox;
+import androidx.appcompat.widget.AppCompatEditText;
+import androidx.appcompat.widget.AppCompatTextView;
 import androidx.core.text.TextUtilsCompat;
 import androidx.core.view.ViewCompat;
 import androidx.preference.PreferenceManager;
@@ -153,7 +153,7 @@ public class GeneralDialogCreation {
     MaterialDialog.Builder builder = new MaterialDialog.Builder(m);
 
     View dialogView = m.getLayoutInflater().inflate(R.layout.dialog_singleedittext, null);
-    EditText textfield = dialogView.findViewById(R.id.singleedittext_input);
+    AppCompatEditText textfield = dialogView.findViewById(R.id.singleedittext_input);
     textfield.setHint(hint);
     textfield.setText(prefill);
 
@@ -227,12 +227,14 @@ public class GeneralDialogCreation {
             .build();
 
     // Get views from custom layout to set text values.
-    final TextView categoryDirectories =
+    final AppCompatTextView categoryDirectories =
         dialog.getCustomView().findViewById(R.id.category_directories);
-    final TextView categoryFiles = dialog.getCustomView().findViewById(R.id.category_files);
-    final TextView listDirectories = dialog.getCustomView().findViewById(R.id.list_directories);
-    final TextView listFiles = dialog.getCustomView().findViewById(R.id.list_files);
-    final TextView total = dialog.getCustomView().findViewById(R.id.total);
+    final AppCompatTextView categoryFiles =
+        dialog.getCustomView().findViewById(R.id.category_files);
+    final AppCompatTextView listDirectories =
+        dialog.getCustomView().findViewById(R.id.list_directories);
+    final AppCompatTextView listFiles = dialog.getCustomView().findViewById(R.id.list_files);
+    final AppCompatTextView total = dialog.getCustomView().findViewById(R.id.total);
 
     new AsyncTask<Void, Object, Void>() {
 
@@ -446,33 +448,33 @@ public class GeneralDialogCreation {
     builder.theme(appTheme.getMaterialDialogTheme(c));
 
     View v = themedActivity.getLayoutInflater().inflate(R.layout.properties_dialog, null);
-    TextView itemsText = v.findViewById(R.id.t7);
-    CheckBox nomediaCheckBox = v.findViewById(R.id.nomediacheckbox);
+    AppCompatTextView itemsText = v.findViewById(R.id.t7);
+    AppCompatCheckBox nomediaCheckBox = v.findViewById(R.id.nomediacheckbox);
 
     /*View setup*/
     {
-      TextView mNameTitle = v.findViewById(R.id.title_name);
+      AppCompatTextView mNameTitle = v.findViewById(R.id.title_name);
       mNameTitle.setTextColor(accentColor);
 
-      TextView mDateTitle = v.findViewById(R.id.title_date);
+      AppCompatTextView mDateTitle = v.findViewById(R.id.title_date);
       mDateTitle.setTextColor(accentColor);
 
-      TextView mSizeTitle = v.findViewById(R.id.title_size);
+      AppCompatTextView mSizeTitle = v.findViewById(R.id.title_size);
       mSizeTitle.setTextColor(accentColor);
 
-      TextView mLocationTitle = v.findViewById(R.id.title_location);
+      AppCompatTextView mLocationTitle = v.findViewById(R.id.title_location);
       mLocationTitle.setTextColor(accentColor);
 
-      TextView md5Title = v.findViewById(R.id.title_md5);
+      AppCompatTextView md5Title = v.findViewById(R.id.title_md5);
       md5Title.setTextColor(accentColor);
 
-      TextView sha256Title = v.findViewById(R.id.title_sha256);
+      AppCompatTextView sha256Title = v.findViewById(R.id.title_sha256);
       sha256Title.setTextColor(accentColor);
 
-      ((TextView) v.findViewById(R.id.t5)).setText(name);
-      ((TextView) v.findViewById(R.id.t6)).setText(parent);
+      ((AppCompatTextView) v.findViewById(R.id.t5)).setText(name);
+      ((AppCompatTextView) v.findViewById(R.id.t6)).setText(parent);
       itemsText.setText(items);
-      ((TextView) v.findViewById(R.id.t8)).setText(date);
+      ((AppCompatTextView) v.findViewById(R.id.t8)).setText(date);
 
       if (baseFile.isDirectory() && baseFile.isLocal()) {
         nomediaCheckBox.setVisibility(View.VISIBLE);
@@ -740,7 +742,7 @@ public class GeneralDialogCreation {
         R.string.crypt_decrypt,
         R.string.authenticate_password,
         ((dialog, which) -> {
-          EditText editText = dialog.getView().findViewById(R.id.singleedittext_input);
+          AppCompatEditText editText = dialog.getView().findViewById(R.id.singleedittext_input);
 
           if (editText.getText().toString().equals(password))
             decryptButtonCallbackInterface.confirm(intent);
@@ -765,7 +767,7 @@ public class GeneralDialogCreation {
     View dialogLayout = View.inflate(main, R.layout.dialog_singleedittext, null);
     WarnableTextInputLayout wilTextfield =
         dialogLayout.findViewById(R.id.singleedittext_warnabletextinputlayout);
-    EditText textfield = dialogLayout.findViewById(R.id.singleedittext_input);
+    AppCompatEditText textfield = dialogLayout.findViewById(R.id.singleedittext_input);
     textfield.setHint(promptText);
     textfield.setInputType(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_PASSWORD);
 
@@ -885,7 +887,7 @@ public class GeneralDialogCreation {
 
     View dialogView =
         mainActivity.getLayoutInflater().inflate(R.layout.dialog_singleedittext, null);
-    EditText etFilename = dialogView.findViewById(R.id.singleedittext_input);
+    AppCompatEditText etFilename = dialogView.findViewById(R.id.singleedittext_input);
     etFilename.setHint(R.string.enterzipname);
     etFilename.setText(".zip"); // TODO: Put the file/folder name here
     etFilename.setInputType(InputType.TYPE_TEXT_FLAG_CAP_SENTENCES);
@@ -1021,15 +1023,15 @@ public class GeneralDialogCreation {
       final String f,
       final Context context,
       final MainFragment mainFrag) {
-    final CheckBox readown = v.findViewById(R.id.creadown);
-    final CheckBox readgroup = v.findViewById(R.id.creadgroup);
-    final CheckBox readother = v.findViewById(R.id.creadother);
-    final CheckBox writeown = v.findViewById(R.id.cwriteown);
-    final CheckBox writegroup = v.findViewById(R.id.cwritegroup);
-    final CheckBox writeother = v.findViewById(R.id.cwriteother);
-    final CheckBox exeown = v.findViewById(R.id.cexeown);
-    final CheckBox exegroup = v.findViewById(R.id.cexegroup);
-    final CheckBox exeother = v.findViewById(R.id.cexeother);
+    final AppCompatCheckBox readown = v.findViewById(R.id.creadown);
+    final AppCompatCheckBox readgroup = v.findViewById(R.id.creadgroup);
+    final AppCompatCheckBox readother = v.findViewById(R.id.creadother);
+    final AppCompatCheckBox writeown = v.findViewById(R.id.cwriteown);
+    final AppCompatCheckBox writegroup = v.findViewById(R.id.cwritegroup);
+    final AppCompatCheckBox writeother = v.findViewById(R.id.cwriteother);
+    final AppCompatCheckBox exeown = v.findViewById(R.id.cexeown);
+    final AppCompatCheckBox exegroup = v.findViewById(R.id.cexegroup);
+    final AppCompatCheckBox exeother = v.findViewById(R.id.cexeother);
     String perm = f;
     if (perm.length() < 6) {
       v.setVisibility(View.GONE);

--- a/app/src/main/java/com/amaze/filemanager/ui/dialogs/SmbConnectDialog.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/dialogs/SmbConnectDialog.java
@@ -60,7 +60,6 @@ import android.os.Bundle;
 import android.text.Editable;
 import android.text.TextUtils;
 import android.view.LayoutInflater;
-import android.widget.TextView;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
@@ -68,6 +67,7 @@ import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
 import androidx.appcompat.widget.AppCompatCheckBox;
 import androidx.appcompat.widget.AppCompatEditText;
+import androidx.appcompat.widget.AppCompatTextView;
 import androidx.fragment.app.DialogFragment;
 
 import jcifs.smb.SmbFile;
@@ -225,7 +225,7 @@ public class SmbConnectDialog extends DialogFragment {
     final AppCompatEditText pass = binding.passwordET;
     final AppCompatCheckBox chkSmbAnonymous = binding.chkSmbAnonymous;
     final AppCompatCheckBox chkSmbDisableIpcSignature = binding.chkSmbDisableIpcSignature;
-    TextView help = binding.wanthelp;
+    AppCompatTextView help = binding.wanthelp;
 
     EditTextColorStateUtil.setTint(getActivity(), conName, accentColor);
     EditTextColorStateUtil.setTint(getActivity(), user, accentColor);

--- a/app/src/main/java/com/amaze/filemanager/ui/dialogs/SmbSearchDialog.kt
+++ b/app/src/main/java/com/amaze/filemanager/ui/dialogs/SmbSearchDialog.kt
@@ -28,9 +28,9 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.ImageView
-import android.widget.TextView
 import android.widget.Toast
+import androidx.appcompat.widget.AppCompatImageView
+import androidx.appcompat.widget.AppCompatTextView
 import androidx.fragment.app.DialogFragment
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
@@ -247,9 +247,9 @@ class SmbSearchDialog : DialogFragment() {
 
     private class ElementViewHolder(rootView: View) :
         ViewHolder(rootView) {
-        val image: ImageView = rootView.findViewById(R.id.icon)
-        val txtTitle: TextView = rootView.findViewById(R.id.firstline)
-        val txtDesc: TextView = rootView.findViewById(R.id.secondLine)
+        val image: AppCompatImageView = rootView.findViewById(R.id.icon)
+        val txtTitle: AppCompatTextView = rootView.findViewById(R.id.firstline)
+        val txtDesc: AppCompatTextView = rootView.findViewById(R.id.secondLine)
     }
 
     private class ComputerParcelableViewModel : ViewModel() {

--- a/app/src/main/java/com/amaze/filemanager/ui/dialogs/share/ShareAdapter.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/dialogs/share/ShareAdapter.java
@@ -32,10 +32,10 @@ import android.graphics.drawable.Drawable;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.ImageView;
-import android.widget.TextView;
 import android.widget.Toast;
 
+import androidx.appcompat.widget.AppCompatImageView;
+import androidx.appcompat.widget.AppCompatTextView;
 import androidx.recyclerview.widget.RecyclerView;
 
 /** Created by Arpit on 01-07-2015 edited by Emmanuel Messulam <emmanuelbendavid@gmail.com> */
@@ -77,8 +77,8 @@ class ShareAdapter extends RecyclerView.Adapter<ShareAdapter.ViewHolder> {
   class ViewHolder extends RecyclerView.ViewHolder {
     private View rootView;
 
-    private TextView textView;
-    private ImageView imageView;
+    private AppCompatTextView textView;
+    private AppCompatImageView imageView;
 
     ViewHolder(View view) {
       super(view);

--- a/app/src/main/java/com/amaze/filemanager/ui/fragments/CompressedExplorerFragment.kt
+++ b/app/src/main/java/com/amaze/filemanager/ui/fragments/CompressedExplorerFragment.kt
@@ -40,11 +40,11 @@ import android.view.MenuItem
 import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
-import android.widget.EditText
-import android.widget.TextView
 import android.widget.Toast
 import androidx.annotation.ColorInt
 import androidx.annotation.StringRes
+import androidx.appcompat.widget.AppCompatEditText
+import androidx.appcompat.widget.AppCompatTextView
 import androidx.core.view.children
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
@@ -426,7 +426,7 @@ class CompressedExplorerFragment : Fragment(), BottomBarButtonPath {
         // may be called multiple times if the mode is invalidated.
         override fun onPrepareActionMode(mode: ActionMode, menu: Menu): Boolean {
             compressedExplorerAdapter?.checkedItemPositions?.let { positions ->
-                (mode.customView.findViewById<View>(R.id.item_count) as TextView).text =
+                (mode.customView.findViewById<View>(R.id.item_count) as AppCompatTextView).text =
                     positions.size.toString()
                 menu.findItem(R.id.all)
                     .setTitle(
@@ -591,9 +591,11 @@ class CompressedExplorerFragment : Fragment(), BottomBarButtonPath {
 
     private fun dialogGetPasswordFromUser(filePath: String) {
         val positiveCallback =
-            SingleButtonCallback { dialog: MaterialDialog, action: DialogAction? ->
-                val editText = dialog.view.findViewById<EditText>(R.id.singleedittext_input)
-                val password: String = editText.getText().toString()
+            SingleButtonCallback { dialog: MaterialDialog, _: DialogAction? ->
+                val editText = dialog.view.findViewById<AppCompatEditText>(
+                    R.id.singleedittext_input
+                )
+                val password: String = editText.text.toString()
                 ArchivePasswordCache.getInstance()[filePath] = password
                 dialog.dismiss()
                 changePath(filePath)

--- a/app/src/main/java/com/amaze/filemanager/ui/fragments/DbViewerFragment.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/fragments/DbViewerFragment.java
@@ -34,9 +34,9 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.webkit.WebView;
 import android.widget.RelativeLayout;
-import android.widget.TextView;
 
 import androidx.annotation.Nullable;
+import androidx.appcompat.widget.AppCompatTextView;
 import androidx.fragment.app.Fragment;
 
 /** Created by Vishal on 06-02-2015. */
@@ -46,7 +46,7 @@ public class DbViewerFragment extends Fragment {
   private View rootView;
   private Cursor schemaCursor, contentCursor;
   private RelativeLayout relativeLayout;
-  public TextView loadingText;
+  public AppCompatTextView loadingText;
   private WebView webView;
 
   @Override

--- a/app/src/main/java/com/amaze/filemanager/ui/fragments/FtpServerFragment.kt
+++ b/app/src/main/java/com/amaze/filemanager/ui/fragments/FtpServerFragment.kt
@@ -48,13 +48,13 @@ import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
-import android.widget.Button
 import android.widget.CompoundButton
-import android.widget.ImageButton
-import android.widget.TextView
 import android.widget.Toast
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.appcompat.widget.AppCompatButton
+import androidx.appcompat.widget.AppCompatImageButton
+import androidx.appcompat.widget.AppCompatTextView
 import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.core.text.HtmlCompat
 import androidx.core.text.HtmlCompat.FROM_HTML_MODE_COMPACT
@@ -102,14 +102,14 @@ class FtpServerFragment : Fragment(R.layout.fragment_ftp) {
 
     private val log: Logger = LoggerFactory.getLogger(FtpServerFragment::class.java)
 
-    private val statusText: TextView get() = binding.textViewFtpStatus
-    private val url: TextView get() = binding.textViewFtpUrl
-    private val username: TextView get() = binding.textViewFtpUsername
-    private val password: TextView get() = binding.textViewFtpPassword
-    private val port: TextView get() = binding.textViewFtpPort
-    private val sharedPath: TextView get() = binding.textViewFtpPath
-    private val ftpBtn: Button get() = binding.startStopButton
-    private val ftpPasswordVisibleButton: ImageButton get() = binding.ftpPasswordVisible
+    private val statusText: AppCompatTextView get() = binding.textViewFtpStatus
+    private val url: AppCompatTextView get() = binding.textViewFtpUrl
+    private val username: AppCompatTextView get() = binding.textViewFtpUsername
+    private val password: AppCompatTextView get() = binding.textViewFtpPassword
+    private val port: AppCompatTextView get() = binding.textViewFtpPort
+    private val sharedPath: AppCompatTextView get() = binding.textViewFtpPath
+    private val ftpBtn: AppCompatButton get() = binding.startStopButton
+    private val ftpPasswordVisibleButton: AppCompatImageButton get() = binding.ftpPasswordVisible
     private var accentColor = 0
     private var spannedStatusNoConnection: Spanned? = null
     private var spannedStatusConnected: Spanned? = null

--- a/app/src/main/java/com/amaze/filemanager/ui/fragments/MainFragment.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/fragments/MainFragment.java
@@ -105,9 +105,6 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.ViewTreeObserver;
-import android.widget.EditText;
-import android.widget.ImageView;
-import android.widget.TextView;
 import android.widget.Toast;
 
 import androidx.activity.result.ActivityResultLauncher;
@@ -115,6 +112,9 @@ import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
+import androidx.appcompat.widget.AppCompatEditText;
+import androidx.appcompat.widget.AppCompatImageView;
+import androidx.appcompat.widget.AppCompatTextView;
 import androidx.core.content.pm.ShortcutInfoCompat;
 import androidx.core.content.pm.ShortcutManagerCompat;
 import androidx.core.graphics.drawable.IconCompat;
@@ -438,7 +438,7 @@ public class MainFragment extends Fragment
       boolean isBackButton,
       int position,
       LayoutElementParcelable layoutElementParcelable,
-      ImageView imageView) {
+      AppCompatImageView imageView) {
     if (mainFragmentViewModel.getResults()) {
       // check to initialize search results
       // if search task is been running, cancel it
@@ -714,14 +714,14 @@ public class MainFragment extends Fragment
               return true;
             });
     if (utilsProvider.getAppTheme().equals(AppTheme.LIGHT)) {
-      ((ImageView) nofilesview.findViewById(R.id.image))
+      ((AppCompatImageView) nofilesview.findViewById(R.id.image))
           .setColorFilter(Color.parseColor("#666666"));
     } else if (utilsProvider.getAppTheme().equals(AppTheme.BLACK)) {
       nofilesview.setBackgroundColor(Utils.getColor(getContext(), android.R.color.black));
-      ((TextView) nofilesview.findViewById(R.id.nofiletext)).setTextColor(Color.WHITE);
+      ((AppCompatTextView) nofilesview.findViewById(R.id.nofiletext)).setTextColor(Color.WHITE);
     } else {
       nofilesview.setBackgroundColor(Utils.getColor(getContext(), R.color.holo_dark_background));
-      ((TextView) nofilesview.findViewById(R.id.nofiletext)).setTextColor(Color.WHITE);
+      ((AppCompatTextView) nofilesview.findViewById(R.id.nofiletext)).setTextColor(Color.WHITE);
     }
   }
 
@@ -967,7 +967,8 @@ public class MainFragment extends Fragment
             null,
             getResources().getString(R.string.cancel),
             (dialog, which) -> {
-              EditText textfield = dialog.getCustomView().findViewById(R.id.singleedittext_input);
+              AppCompatEditText textfield =
+                  dialog.getCustomView().findViewById(R.id.singleedittext_input);
               String name1 = textfield.getText().toString().trim();
 
               getMainActivity()
@@ -998,7 +999,8 @@ public class MainFragment extends Fragment
     // place cursor at the starting of edit text by posting a runnable to edit text
     // this is done because in case android has not populated the edit text layouts yet, it'll
     // reset calls to selection if not posted in message queue
-    EditText textfield = renameDialog.getCustomView().findViewById(R.id.singleedittext_input);
+    AppCompatEditText textfield =
+        renameDialog.getCustomView().findViewById(R.id.singleedittext_input);
     textfield.post(
         () -> {
           if (!f.isDirectory()) {

--- a/app/src/main/java/com/amaze/filemanager/ui/fragments/TabFragment.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/fragments/TabFragment.java
@@ -60,10 +60,10 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.animation.DecelerateInterpolator;
-import android.widget.ImageView;
 
 import androidx.annotation.ColorInt;
 import androidx.annotation.NonNull;
+import androidx.appcompat.widget.AppCompatImageView;
 import androidx.constraintlayout.widget.ConstraintLayout;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentActivity;
@@ -94,7 +94,7 @@ public class TabFragment extends Fragment {
   private Indicator indicator;
 
   /** views for circlular drawables below android lollipop */
-  private ImageView circleDrawable1, circleDrawable2;
+  private AppCompatImageView circleDrawable1, circleDrawable2;
 
   /** color drawable for action bar background */
   private final ColorDrawable colorDrawable = new ColorDrawable();
@@ -459,7 +459,7 @@ public class TabFragment extends Fragment {
     final MainFragment mainFragment = requireMainActivity().getCurrentMainFragment();
     View leftPlaceholder = rootView.findViewById(R.id.placeholder_drag_left);
     View rightPlaceholder = rootView.findViewById(R.id.placeholder_drag_right);
-    ImageView dragToTrash = rootView.findViewById(R.id.placeholder_trash_bottom);
+    AppCompatImageView dragToTrash = rootView.findViewById(R.id.placeholder_trash_bottom);
     DataUtils dataUtils = DataUtils.getInstance();
     if (destroy) {
       leftPlaceholder.setOnDragListener(null);

--- a/app/src/main/java/com/amaze/filemanager/ui/fragments/preferencefragments/BookmarksPrefsFragment.kt
+++ b/app/src/main/java/com/amaze/filemanager/ui/fragments/preferencefragments/BookmarksPrefsFragment.kt
@@ -23,7 +23,7 @@ package com.amaze.filemanager.ui.fragments.preferencefragments
 import android.os.Bundle
 import android.text.Editable
 import android.view.LayoutInflater
-import android.widget.EditText
+import androidx.appcompat.widget.AppCompatEditText
 import androidx.preference.Preference
 import androidx.preference.PreferenceCategory
 import com.afollestad.materialdialogs.DialogAction
@@ -37,7 +37,6 @@ import com.amaze.filemanager.filesystem.files.FileUtils
 import com.amaze.filemanager.ui.views.preference.PathSwitchPreference
 import com.amaze.filemanager.utils.DataUtils
 import com.amaze.filemanager.utils.SimpleTextWatcher
-import java.util.HashMap
 
 class BookmarksPrefsFragment : BasePrefsFragment() {
     override val title = R.string.show_bookmarks_pref
@@ -215,7 +214,7 @@ class BookmarksPrefsFragment : BasePrefsFragment() {
         dialog.show()
     }
 
-    private fun disableButtonIfNotPath(path: EditText, dialog: MaterialDialog) {
+    private fun disableButtonIfNotPath(path: AppCompatEditText, dialog: MaterialDialog) {
         path.addTextChangedListener(
             object : SimpleTextWatcher() {
                 override fun afterTextChanged(s: Editable) {
@@ -226,7 +225,7 @@ class BookmarksPrefsFragment : BasePrefsFragment() {
         )
     }
 
-    private fun disableButtonIfTitleEmpty(title: EditText, dialog: MaterialDialog) {
+    private fun disableButtonIfTitleEmpty(title: AppCompatEditText, dialog: MaterialDialog) {
         title.addTextChangedListener(
             object : SimpleTextWatcher() {
                 override fun afterTextChanged(s: Editable) {

--- a/app/src/main/java/com/amaze/filemanager/ui/selection/SelectionPopupMenu.kt
+++ b/app/src/main/java/com/amaze/filemanager/ui/selection/SelectionPopupMenu.kt
@@ -24,13 +24,12 @@ import android.content.Context
 import android.view.MenuItem
 import android.view.View
 import android.widget.PopupMenu
-import android.widget.TextView
 import androidx.appcompat.view.ContextThemeWrapper
+import androidx.appcompat.widget.AppCompatTextView
 import com.amaze.filemanager.R
 import com.amaze.filemanager.adapters.RecyclerAdapter
 import com.amaze.filemanager.ui.activities.MainActivity
 import com.amaze.filemanager.ui.theme.AppTheme
-import java.util.*
 
 class SelectionPopupMenu(
     private val recyclerAdapter: RecyclerAdapter,
@@ -102,7 +101,7 @@ class SelectionPopupMenu(
             }
         }
         actionModeView.invalidate()
-        actionModeView.findViewById<TextView>(R.id.item_count).text = recyclerAdapter
+        actionModeView.findViewById<AppCompatTextView>(R.id.item_count).text = recyclerAdapter
             .checkedItems.size.toString()
         return true
     }

--- a/app/src/main/java/com/amaze/filemanager/ui/views/FastScroller.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/views/FastScroller.java
@@ -33,17 +33,17 @@ import android.util.AttributeSet;
 import android.view.MotionEvent;
 import android.view.View;
 import android.widget.FrameLayout;
-import android.widget.ImageView;
 
 import androidx.annotation.AttrRes;
 import androidx.annotation.NonNull;
+import androidx.appcompat.widget.AppCompatImageView;
 import androidx.core.content.ContextCompat;
 import androidx.recyclerview.widget.RecyclerView;
 import androidx.recyclerview.widget.RecyclerView.OnScrollListener;
 
 public class FastScroller extends FrameLayout {
   private View bar;
-  private ImageView handle;
+  private AppCompatImageView handle;
   private RecyclerView recyclerView;
   private final ScrollListener scrollListener;
   boolean manuallyChangingPosition = false;

--- a/app/src/main/java/com/amaze/filemanager/ui/views/ThemedTextView.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/views/ThemedTextView.java
@@ -28,7 +28,6 @@ import com.amaze.filemanager.utils.Utils;
 
 import android.content.Context;
 import android.util.AttributeSet;
-import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 import androidx.appcompat.widget.AppCompatTextView;
@@ -46,7 +45,8 @@ public class ThemedTextView extends AppCompatTextView {
     setTextViewColor(this, context);
   }
 
-  public static void setTextViewColor(@NotNull TextView textView, @NonNull Context context) {
+  public static void setTextViewColor(
+      @NotNull AppCompatTextView textView, @NonNull Context context) {
     if (((MainActivity) context).getAppTheme().equals(AppTheme.LIGHT)) {
       textView.setTextColor(Utils.getColor(context, android.R.color.black));
     } else if (((MainActivity) context).getAppTheme().equals(AppTheme.DARK)

--- a/app/src/main/java/com/amaze/filemanager/ui/views/WarnableTextInputValidator.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/views/WarnableTextInputValidator.java
@@ -27,15 +27,15 @@ import android.content.Context;
 import android.text.Editable;
 import android.view.MotionEvent;
 import android.view.View;
-import android.widget.EditText;
 
 import androidx.annotation.DrawableRes;
 import androidx.annotation.StringRes;
+import androidx.appcompat.widget.AppCompatEditText;
 
 public final class WarnableTextInputValidator extends SimpleTextWatcher
     implements View.OnFocusChangeListener, View.OnTouchListener {
   private final Context context;
-  private final EditText editText;
+  private final AppCompatEditText editText;
   private final View button;
   private final WarnableTextInputLayout textInputLayout;
   private final OnTextValidate validator;
@@ -43,7 +43,7 @@ public final class WarnableTextInputValidator extends SimpleTextWatcher
 
   public WarnableTextInputValidator(
       Context context,
-      EditText editText,
+      AppCompatEditText editText,
       WarnableTextInputLayout textInputLayout,
       View positiveButton,
       OnTextValidate validator) {

--- a/app/src/main/java/com/amaze/filemanager/ui/views/appbar/BottomBar.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/views/appbar/BottomBar.java
@@ -52,16 +52,16 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.view.animation.Animation;
 import android.view.animation.AnimationUtils;
-import android.widget.Button;
 import android.widget.FrameLayout;
 import android.widget.HorizontalScrollView;
-import android.widget.ImageButton;
-import android.widget.ImageView;
 import android.widget.LinearLayout;
-import android.widget.TextView;
 
 import androidx.annotation.ColorInt;
 import androidx.annotation.NonNull;
+import androidx.appcompat.widget.AppCompatButton;
+import androidx.appcompat.widget.AppCompatImageButton;
+import androidx.appcompat.widget.AppCompatImageView;
+import androidx.appcompat.widget.AppCompatTextView;
 import androidx.fragment.app.Fragment;
 
 /**
@@ -84,14 +84,14 @@ public class BottomBar implements View.OnTouchListener {
   private LinearLayout pathLayout;
   private LinearLayout buttons;
   private HorizontalScrollView scroll, pathScroll;
-  private TextView pathText, fullPathText, fullPathAnim;
+  private AppCompatTextView pathText, fullPathText, fullPathAnim;
 
   private LinearLayout.LayoutParams buttonParams;
-  private ImageButton buttonRoot;
-  private ImageButton buttonStorage;
-  private ArrayList<ImageView> arrowButtons = new ArrayList<>();
+  private AppCompatImageButton buttonRoot;
+  private AppCompatImageButton buttonStorage;
+  private ArrayList<AppCompatImageView> arrowButtons = new ArrayList<>();
   private int lastUsedArrowButton = 0;
-  private ArrayList<Button> folderButtons = new ArrayList<>();
+  private ArrayList<AppCompatButton> folderButtons = new ArrayList<>();
   private int lastUsedFolderButton = 0;
   private Drawable arrow;
 
@@ -138,11 +138,11 @@ public class BottomBar implements View.OnTouchListener {
             LinearLayout.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT);
     buttonParams.gravity = Gravity.CENTER_VERTICAL;
 
-    buttonRoot = new ImageButton(a);
+    buttonRoot = new AppCompatImageButton(a);
     buttonRoot.setBackgroundColor(Color.TRANSPARENT);
     buttonRoot.setLayoutParams(buttonParams);
 
-    buttonStorage = new ImageButton(a);
+    buttonStorage = new AppCompatImageButton(a);
     buttonStorage.setImageDrawable(
         a.getResources().getDrawable(R.drawable.ic_sd_storage_white_24dp));
     buttonStorage.setBackgroundColor(Color.TRANSPARENT);
@@ -281,7 +281,7 @@ public class BottomBar implements View.OnTouchListener {
               });
           buttons.addView(buttonStorage);
         } else {
-          Button button = createFolderButton(names[i]);
+          AppCompatButton button = createFolderButton(names[i]);
           button.setOnClickListener(
               p1 -> {
                 buttonPathInterface.changePath(paths[k]);
@@ -313,11 +313,11 @@ public class BottomBar implements View.OnTouchListener {
     return this.frame;
   }
 
-  private ImageView createArrow() {
-    ImageView buttonArrow;
+  private AppCompatImageView createArrow() {
+    AppCompatImageView buttonArrow;
 
     if (lastUsedArrowButton >= arrowButtons.size()) {
-      buttonArrow = new ImageView(mainActivity);
+      buttonArrow = new AppCompatImageView(mainActivity);
       buttonArrow.setImageDrawable(arrow);
       buttonArrow.setLayoutParams(buttonParams);
       arrowButtons.add(buttonArrow);
@@ -330,11 +330,11 @@ public class BottomBar implements View.OnTouchListener {
     return buttonArrow;
   }
 
-  private Button createFolderButton(String text) {
-    Button button;
+  private AppCompatButton createFolderButton(String text) {
+    AppCompatButton button;
 
     if (lastUsedFolderButton >= folderButtons.size()) {
-      button = new Button(mainActivity);
+      button = new AppCompatButton(mainActivity);
       button.setTextColor(Utils.getColor(mainActivity, android.R.color.white));
       button.setTextSize(13);
       button.setLayoutParams(buttonParams);

--- a/app/src/main/java/com/amaze/filemanager/ui/views/appbar/SearchView.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/views/appbar/SearchView.java
@@ -54,10 +54,10 @@ import android.view.ViewAnimationUtils;
 import android.view.animation.AccelerateDecelerateInterpolator;
 import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputMethodManager;
-import android.widget.ImageView;
-import android.widget.TextView;
 
 import androidx.appcompat.widget.AppCompatEditText;
+import androidx.appcompat.widget.AppCompatImageView;
+import androidx.appcompat.widget.AppCompatTextView;
 import androidx.core.content.ContextCompat;
 import androidx.core.widget.NestedScrollView;
 import androidx.preference.PreferenceManager;
@@ -76,12 +76,12 @@ public class SearchView {
   private final NestedScrollView searchViewLayout;
   private final AppCompatEditText searchViewEditText;
 
-  private final ImageView clearImageView;
-  private final ImageView backImageView;
+  private final AppCompatImageView clearImageView;
+  private final AppCompatImageView backImageView;
 
-  private final TextView recentHintTV;
-  private final TextView searchResultsHintTV;
-  private final TextView deepSearchTV;
+  private final AppCompatTextView recentHintTV;
+  private final AppCompatTextView searchResultsHintTV;
+  private final AppCompatTextView deepSearchTV;
 
   private final ChipGroup recentChipGroup;
   private final RecyclerView recyclerView;

--- a/app/src/main/java/com/amaze/filemanager/ui/views/drawer/ActionViewStateManager.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/views/drawer/ActionViewStateManager.java
@@ -21,9 +21,9 @@
 package com.amaze.filemanager.ui.views.drawer;
 
 import android.view.MenuItem;
-import android.widget.ImageButton;
 
 import androidx.annotation.ColorInt;
+import androidx.appcompat.widget.AppCompatImageButton;
 
 /**
  * This manages to set the color of the selected ActionView and unset the ActionView that is not
@@ -31,7 +31,7 @@ import androidx.annotation.ColorInt;
  */
 public class ActionViewStateManager {
 
-  private ImageButton lastItemSelected = null;
+  private AppCompatImageButton lastItemSelected = null;
   private @ColorInt int idleIconColor;
   private @ColorInt int selectedIconColor;
 
@@ -52,7 +52,7 @@ public class ActionViewStateManager {
       lastItemSelected.setColorFilter(idleIconColor);
     }
     if (item.getActionView() != null) {
-      lastItemSelected = (ImageButton) item.getActionView();
+      lastItemSelected = (AppCompatImageButton) item.getActionView();
       lastItemSelected.setColorFilter(selectedIconColor);
     }
   }

--- a/app/src/main/java/com/amaze/filemanager/ui/views/drawer/Drawer.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/views/drawer/Drawer.java
@@ -90,16 +90,17 @@ import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.animation.DecelerateInterpolator;
-import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.RelativeLayout;
-import android.widget.TextView;
 
 import androidx.annotation.ColorInt;
 import androidx.annotation.DrawableRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
+import androidx.appcompat.widget.AppCompatImageButton;
+import androidx.appcompat.widget.AppCompatImageView;
+import androidx.appcompat.widget.AppCompatTextView;
 import androidx.drawerlayout.widget.DrawerLayout;
 import androidx.fragment.app.FragmentTransaction;
 import androidx.legacy.app.ActionBarDrawerToggle;
@@ -135,10 +136,10 @@ public class Drawer implements NavigationView.OnNavigationItemSelectedListener {
   private CustomNavigationView navView;
   private RelativeLayout drawerHeaderParent;
   private View drawerHeaderLayout, drawerHeaderView;
-  private ImageView donateImageView;
-  private ImageView telegramImageView;
-  private ImageView instagramImageView;
-  private TextView appVersion;
+  private AppCompatImageView donateImageView;
+  private AppCompatImageView telegramImageView;
+  private AppCompatImageView instagramImageView;
+  private AppCompatTextView appVersion;
 
   /** Tablet is defined as 'width > 720dp' */
   private boolean isOnTablet = false;
@@ -660,7 +661,7 @@ public class Drawer implements NavigationView.OnNavigationItemSelectedListener {
         });
   }
 
-  public ImageView getDonateImageView() {
+  public AppCompatImageView getDonateImageView() {
     return this.donateImageView;
   }
 
@@ -722,7 +723,7 @@ public class Drawer implements NavigationView.OnNavigationItemSelectedListener {
     if (actionViewIcon != null) {
       item.setActionView(R.layout.layout_draweractionview);
 
-      ImageView imageView = item.getActionView().findViewById(R.id.imageButton);
+      AppCompatImageButton imageView = item.getActionView().findViewById(R.id.imageButton);
       imageView.setImageResource(actionViewIcon);
       if (!mainActivity.getAppTheme().equals(AppTheme.LIGHT)) {
         imageView.setColorFilter(Color.WHITE);

--- a/app/src/main/java/com/amaze/filemanager/utils/MainActivityActionMode.kt
+++ b/app/src/main/java/com/amaze/filemanager/utils/MainActivityActionMode.kt
@@ -27,9 +27,9 @@ import android.os.Build
 import android.view.Menu
 import android.view.MenuItem
 import android.view.View
-import android.widget.TextView
 import android.widget.Toast
 import androidx.appcompat.view.ActionMode
+import androidx.appcompat.widget.AppCompatTextView
 import androidx.drawerlayout.widget.DrawerLayout
 import androidx.fragment.app.FragmentActivity
 import com.amaze.filemanager.R
@@ -43,7 +43,6 @@ import com.amaze.filemanager.ui.dialogs.GeneralDialogCreation
 import com.amaze.filemanager.ui.selection.SelectionPopupMenu.Companion.invokeSelectionDropdown
 import java.io.File
 import java.lang.ref.WeakReference
-import java.util.ArrayList
 
 class MainActivityActionMode(private val mainActivityReference: WeakReference<MainActivity>) :
     ActionMode.Callback {
@@ -120,7 +119,7 @@ class MainActivityActionMode(private val mainActivityReference: WeakReference<Ma
                     mainActivity
                 )
             }
-            val textView: TextView = actionModeView!!.findViewById(R.id.item_count)
+            val textView: AppCompatTextView = actionModeView!!.findViewById(R.id.item_count)
             textView.text = checkedItems.size.toString()
             hideOption(R.id.openmulti, menu)
             menu.findItem(R.id.all)

--- a/app/src/main/java/com/amaze/filemanager/utils/MainActivityHelper.java
+++ b/app/src/main/java/com/amaze/filemanager/utils/MainActivityHelper.java
@@ -81,13 +81,13 @@ import android.os.Bundle;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
-import android.widget.EditText;
-import android.widget.ImageView;
-import android.widget.TextView;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.StringRes;
+import androidx.appcompat.widget.AppCompatEditText;
+import androidx.appcompat.widget.AppCompatImageView;
+import androidx.appcompat.widget.AppCompatTextView;
 import androidx.documentfile.provider.DocumentFile;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
@@ -166,7 +166,8 @@ public class MainActivityHelper {
         R.string.newfolder,
         "",
         (dialog, which) -> {
-          EditText textfield = dialog.getCustomView().findViewById(R.id.singleedittext_input);
+          AppCompatEditText textfield =
+              dialog.getCustomView().findViewById(R.id.singleedittext_input);
           String parentPath = path;
           if (OpenMode.DOCUMENT_FILE.equals(openMode)
               && Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
@@ -204,7 +205,8 @@ public class MainActivityHelper {
         R.string.newfile,
         AppConstants.NEW_FILE_DELIMITER.concat(AppConstants.NEW_FILE_EXTENSION_TXT),
         (dialog, which) -> {
-          EditText textfield = dialog.getCustomView().findViewById(R.id.singleedittext_input);
+          AppCompatEditText textfield =
+              dialog.getCustomView().findViewById(R.id.singleedittext_input);
           mkFile(
               new HybridFile(openMode, path),
               new HybridFile(openMode, path, textfield.getText().toString().trim(), false),
@@ -263,7 +265,7 @@ public class MainActivityHelper {
     dialog.show();
 
     // place cursor at the beginning
-    EditText textfield = dialog.getCustomView().findViewById(R.id.singleedittext_input);
+    AppCompatEditText textfield = dialog.getCustomView().findViewById(R.id.singleedittext_input);
     textfield.post(
         () -> {
           textfield.setSelection(0);
@@ -312,12 +314,13 @@ public class MainActivityHelper {
     View view = layoutInflater.inflate(R.layout.lexadrawer, null);
     x.customView(view, true);
     // textView
-    TextView textView = view.findViewById(R.id.description);
+    AppCompatTextView textView = view.findViewById(R.id.description);
     textView.setText(
         mainActivity.getString(R.string.needs_access_summary)
             + path
             + mainActivity.getString(R.string.needs_access_summary1));
-    ((ImageView) view.findViewById(R.id.icon)).setImageResource(R.drawable.sd_operate_step);
+    ((AppCompatImageView) view.findViewById(R.id.icon))
+        .setImageResource(R.drawable.sd_operate_step);
     x.positiveText(R.string.open)
         .negativeText(R.string.cancel)
         .positiveColor(accentColor)

--- a/app/src/main/java/com/amaze/filemanager/utils/Utils.java
+++ b/app/src/main/java/com/amaze/filemanager/utils/Utils.java
@@ -52,13 +52,13 @@ import android.util.DisplayMetrics;
 import android.view.View;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.Button;
-import android.widget.CheckBox;
-import android.widget.TextView;
 import android.widget.Toast;
 
 import androidx.annotation.ColorRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.StringRes;
+import androidx.appcompat.widget.AppCompatCheckBox;
+import androidx.appcompat.widget.AppCompatTextView;
 import androidx.cardview.widget.CardView;
 import androidx.core.content.ContextCompat;
 import androidx.core.content.FileProvider;
@@ -103,7 +103,7 @@ public class Utils {
     return location[1];
   }
 
-  public static void setTint(Context context, CheckBox box, int color) {
+  public static void setTint(Context context, AppCompatCheckBox box, int color) {
     if (Build.VERSION.SDK_INT >= 21) return;
     ColorStateList sl =
         new ColorStateList(
@@ -353,7 +353,7 @@ public class Utils {
 
     Button actionButton = customSnackView.findViewById(R.id.snackBarActionButton);
     Button cancelButton = customSnackView.findViewById(R.id.snackBarCancelButton);
-    TextView textView = customSnackView.findViewById(R.id.snackBarTextTV);
+    AppCompatTextView textView = customSnackView.findViewById(R.id.snackBarTextTV);
 
     actionButton.setText(actionTextId);
     textView.setText(text);

--- a/app/src/main/res/layout-v16/grid_header.xml
+++ b/app/src/main/res/layout-v16/grid_header.xml
@@ -6,7 +6,7 @@
     android:layout_height="@dimen/list_header_height"
     android:layout_width="match_parent" >
 
-    <TextView
+    <androidx.appcompat.widget.AppCompatTextView
         android:id="@+id/text"
         android:gravity="center_vertical"
         android:layout_height="wrap_content"
@@ -15,6 +15,6 @@
         android:paddingLeft="@dimen/material_generic"
         android:paddingRight="@dimen/material_generic"
         android:textSize="@dimen/list_header_textsize">
-    </TextView>
+    </androidx.appcompat.widget.AppCompatTextView>
 
 </RelativeLayout>

--- a/app/src/main/res/layout-v16/list_header.xml
+++ b/app/src/main/res/layout-v16/list_header.xml
@@ -6,7 +6,7 @@
     android:layout_height="@dimen/list_header_height"
     android:layout_width="match_parent" >
 
-    <TextView
+    <androidx.appcompat.widget.AppCompatTextView
         android:id="@+id/text"
         android:gravity="center_vertical"
         android:layout_height="wrap_content"
@@ -15,6 +15,6 @@
         android:paddingLeft="@dimen/icon_width"
         android:paddingRight="@dimen/icon_width"
         android:textSize="@dimen/list_header_textsize">
-    </TextView>
+    </androidx.appcompat.widget.AppCompatTextView>
 
 </RelativeLayout>

--- a/app/src/main/res/layout-v21/layout_appbar.xml
+++ b/app/src/main/res/layout-v21/layout_appbar.xml
@@ -76,14 +76,14 @@
                     android:layout_height="wrap_content"
                     >
 
-                    <TextView
+                    <androidx.appcompat.widget.AppCompatTextView
                         android:clickable="false"
                         android:layout_width="wrap_content"
                         style="@android:style/TextAppearance.Medium"
                         android:textColor="@android:color/white"
                         android:layout_height="wrap_content"
                         android:id="@+id/fullpath" />
-                    <TextView
+                    <androidx.appcompat.widget.AppCompatTextView
                         android:clickable="false"
                         android:layout_width="wrap_content"
                         style="@android:style/TextAppearance.Medium"
@@ -93,7 +93,7 @@
                         android:visibility="gone"/>
                 </LinearLayout>
             </HorizontalScrollView>
-            <TextView
+            <androidx.appcompat.widget.AppCompatTextView
                 android:clickable="false"
                 android:layout_width="wrap_content"
                 android:textSize="12sp"

--- a/app/src/main/res/layout-v21/layout_search.xml
+++ b/app/src/main/res/layout-v21/layout_search.xml
@@ -17,14 +17,14 @@
         android:layout_height="wrap_content"
         tools:ignore="ContentDescription">
 
-        <ImageButton
+        <androidx.appcompat.widget.AppCompatImageView
             android:id="@+id/img_view_back"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginLeft="@dimen/search_view_back_margin_left_right"
             android:layout_marginRight="@dimen/search_view_back_margin_left_right"
             android:background="@drawable/ripple"
-            android:src="@drawable/ic_arrow_back_black_24dp"
+            app:srcCompat="@drawable/ic_arrow_back_black_24dp"
             app:layout_constraintBottom_toBottomOf="@id/search_edit_text"
             app:layout_constraintEnd_toStartOf="@id/search_edit_text"
             app:layout_constraintStart_toStartOf="parent"
@@ -46,14 +46,14 @@
             app:layout_constraintStart_toEndOf="@id/img_view_back"
             app:layout_constraintTop_toTopOf="parent" />
 
-        <ImageButton
+        <androidx.appcompat.widget.AppCompatImageView
             android:id="@+id/search_close_btn"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginLeft="@dimen/search_view_info_margin_left_right"
             android:layout_marginRight="@dimen/search_view_info_margin_left_right"
             android:background="@drawable/ripple"
-            android:src="@drawable/ic_close_black_24dp"
+            app:srcCompat="@drawable/ic_close_black_24dp"
             app:layout_constraintBottom_toBottomOf="@id/search_edit_text"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toEndOf="@id/search_edit_text"

--- a/app/src/main/res/layout-w500dp/properties_dialog.xml
+++ b/app/src/main/res/layout-w500dp/properties_dialog.xml
@@ -20,7 +20,7 @@
             android:background="?selectableItemBackground"
             android:orientation="vertical">
 
-            <TextView
+            <androidx.appcompat.widget.AppCompatTextView
                 android:id="@+id/title_name"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
@@ -28,7 +28,7 @@
                 android:text="@string/name"
                 android:textSize="@dimen/material_generic_title"/>
 
-            <TextView
+            <androidx.appcompat.widget.AppCompatTextView
                 android:id="@+id/t5"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
@@ -45,7 +45,7 @@
             android:background="?selectableItemBackground"
             android:orientation="vertical">
 
-            <TextView
+            <androidx.appcompat.widget.AppCompatTextView
                 android:id="@+id/title_location"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
@@ -53,7 +53,7 @@
                 android:text="@string/location"
                 android:textSize="@dimen/material_generic_title"/>
 
-            <TextView
+            <androidx.appcompat.widget.AppCompatTextView
                 android:id="@+id/t6"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
@@ -69,7 +69,7 @@
             android:background="?selectableItemBackground"
             android:orientation="vertical">
 
-            <TextView
+            <androidx.appcompat.widget.AppCompatTextView
                 android:id="@+id/title_size"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
@@ -77,7 +77,7 @@
                 android:text="@string/size_capitalized"
                 android:textSize="@dimen/material_generic_title"/>
 
-            <TextView
+            <androidx.appcompat.widget.AppCompatTextView
                 android:id="@+id/t7"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
@@ -93,7 +93,7 @@
             android:background="?selectableItemBackground"
             android:orientation="vertical">
 
-            <TextView
+            <androidx.appcompat.widget.AppCompatTextView
                 android:id="@+id/title_date"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
@@ -101,7 +101,7 @@
                 android:text="@string/date"
                 android:textSize="@dimen/material_generic_title"/>
 
-            <TextView
+            <androidx.appcompat.widget.AppCompatTextView
                 android:id="@+id/t8"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
@@ -117,7 +117,7 @@
             android:background="?selectableItemBackground"
             android:orientation="vertical">
 
-            <TextView
+            <androidx.appcompat.widget.AppCompatTextView
                 android:id="@+id/title_md5"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
@@ -125,7 +125,7 @@
                 android:text="@string/md5"
                 android:textSize="@dimen/material_generic_title"/>
 
-            <TextView
+            <androidx.appcompat.widget.AppCompatTextView
                 android:id="@+id/t9"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
@@ -141,7 +141,7 @@
             android:background="?selectableItemBackground"
             android:orientation="vertical">
 
-            <TextView
+            <androidx.appcompat.widget.AppCompatTextView
                 android:id="@+id/title_sha256"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
@@ -149,7 +149,7 @@
                 android:text="@string/hash_sha256"
                 android:textSize="@dimen/material_generic_title"/>
 
-            <TextView
+            <androidx.appcompat.widget.AppCompatTextView
                 android:id="@+id/t10"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"

--- a/app/src/main/res/layout-w720dp/layout_appbar.xml
+++ b/app/src/main/res/layout-w720dp/layout_appbar.xml
@@ -74,14 +74,14 @@
                     android:layout_height="wrap_content"
                     >
 
-                    <TextView
+                    <androidx.appcompat.widget.AppCompatTextView
                         android:clickable="false"
                         android:layout_width="wrap_content"
                         style="@android:style/TextAppearance.Medium"
                         android:textColor="@android:color/white"
                         android:layout_height="wrap_content"
                         android:id="@+id/fullpath"/>
-                    <TextView
+                    <androidx.appcompat.widget.AppCompatTextView
                         android:clickable="false"
                         android:layout_width="wrap_content"
                         style="@android:style/TextAppearance.Medium"
@@ -91,7 +91,7 @@
                         android:visibility="gone"/>
                 </LinearLayout>
             </HorizontalScrollView>
-            <TextView
+            <androidx.appcompat.widget.AppCompatTextView
                 android:layout_width="wrap_content"
                 android:textSize="12sp"
                 android:paddingBottom="10dp"

--- a/app/src/main/res/layout-w720dp/layout_search.xml
+++ b/app/src/main/res/layout-w720dp/layout_search.xml
@@ -16,13 +16,13 @@
         android:layout_height="wrap_content"
         tools:ignore="ContentDescription">
 
-        <ImageView
+        <androidx.appcompat.widget.AppCompatImageView
             android:id="@+id/img_view_back"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginLeft="@dimen/search_view_back_margin_left_right"
             android:layout_marginRight="@dimen/search_view_back_margin_left_right"
-            android:src="@drawable/ic_arrow_back_black_24dp"
+            app:srcCompat="@drawable/ic_arrow_back_black_24dp"
             app:layout_constraintBottom_toBottomOf="@id/search_edit_text"
             app:layout_constraintEnd_toStartOf="@id/search_edit_text"
             app:layout_constraintStart_toStartOf="parent"
@@ -44,13 +44,13 @@
             app:layout_constraintStart_toEndOf="@id/img_view_back"
             app:layout_constraintTop_toTopOf="parent" />
 
-        <ImageView
+        <androidx.appcompat.widget.AppCompatImageView
             android:id="@+id/search_close_btn"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginLeft="@dimen/search_view_info_margin_left_right"
             android:layout_marginRight="@dimen/search_view_info_margin_left_right"
-            android:src="@drawable/ic_close_black_24dp"
+            app:srcCompat="@drawable/ic_close_black_24dp"
             app:layout_constraintBottom_toBottomOf="@id/search_edit_text"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toEndOf="@id/search_edit_text"

--- a/app/src/main/res/layout-w720dp/main_toolbar.xml
+++ b/app/src/main/res/layout-w720dp/main_toolbar.xml
@@ -57,14 +57,14 @@
             android:id="@+id/indicator_layout"
             android:layout_height="2dp">
 
-            <ImageView
+            <androidx.appcompat.widget.AppCompatImageView
                 android:id="@+id/tab_indicator1"
                 android:layout_width="wrap_content"
                 android:minWidth="50dp"
                 android:layout_marginRight="2dp"
                 android:layout_height="match_parent" />
 
-            <ImageView
+            <androidx.appcompat.widget.AppCompatImageView
                 android:id="@+id/tab_indicator2"
                 android:layout_width="wrap_content"
                 android:minWidth="50dp"

--- a/app/src/main/res/layout/actionmode.xml
+++ b/app/src/main/res/layout/actionmode.xml
@@ -7,14 +7,14 @@
     android:focusable="true"
     android:background="@drawable/ripple_focusable"
     >
-    <TextView
+    <androidx.appcompat.widget.AppCompatTextView
         android:layout_width="wrap_content"
         android:textColor="@android:color/white"
         android:textSize="20sp"
         android:gravity="start|center_vertical"
         android:layout_height="match_parent"
         android:id="@+id/item_count"/>
-    <ImageView
+    <androidx.appcompat.widget.AppCompatImageView
         android:layout_width="wrap_content"
         android:layout_height="match_parent"
         android:layout_marginLeft="@dimen/material_generic"

--- a/app/src/main/res/layout/actionmode_textviewer.xml
+++ b/app/src/main/res/layout/actionmode_textviewer.xml
@@ -14,23 +14,23 @@
         android:layout_alignParentRight="true"
         android:orientation="horizontal"
         >
-        <ImageButton
+        <androidx.appcompat.widget.AppCompatImageButton
             android:id="@+id/prev"
             android:layout_width="50dp"
             android:layout_height="match_parent"
             android:layout_gravity="center_vertical"
             android:background="?android:selectableItemBackground"
-            android:src="@drawable/ic_keyboard_arrow_up_white"
+            app:srcCompat="@drawable/ic_keyboard_arrow_up_white"
             />
-        <ImageButton
+        <androidx.appcompat.widget.AppCompatImageButton
             android:id="@+id/next"
             android:layout_width="50dp"
             android:layout_gravity="center_vertical"
             android:layout_height="match_parent"
             android:background="?android:selectableItemBackground"
-            android:src="@drawable/ic_keyboard_arrow_down_white"
+            app:srcCompat="@drawable/ic_keyboard_arrow_down_white"
             />
-        <ImageButton
+        <androidx.appcompat.widget.AppCompatImageButton
             android:id="@+id/close"
             android:layout_width="50dp"
             android:layout_gravity="center_vertical"

--- a/app/src/main/res/layout/activity_about.xml
+++ b/app/src/main/res/layout/activity_about.xml
@@ -21,10 +21,10 @@
             app:titleEnabled="false"
             >
 
-            <ImageView
+            <androidx.appcompat.widget.AppCompatImageView
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
-                android:src="@drawable/about_header"
+                app:srcCompat="@drawable/about_header"
                 app:layout_collapseMode="parallax"
                 android:scaleType="centerCrop"
                 android:fitsSystemWindows="true"
@@ -39,7 +39,7 @@
                 android:theme="?attr/toolbar_theme"
                 app:popupTheme="?attr/popup"
                 >
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     android:id="@+id/text_view_title"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
@@ -90,7 +90,7 @@
                         android:gravity="center_vertical"
                         android:nextFocusUp="@id/appBarLayout"
                         >
-                        <ImageView
+                        <androidx.appcompat.widget.AppCompatImageView
                             android:id="@+id/image_version"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
@@ -107,14 +107,14 @@
                             android:gravity="center_vertical"
                             >
 
-                            <TextView
+                            <androidx.appcompat.widget.AppCompatTextView
                                 android:id="@+id/text_view_version_title"
                                 android:layout_width="wrap_content"
                                 android:layout_height="wrap_content"
                                 android:text="@string/version"
                                 android:textSize="@dimen/material_generic_title"
                                 />
-                            <TextView
+                            <androidx.appcompat.widget.AppCompatTextView
                                 android:layout_width="wrap_content"
                                 android:layout_height="wrap_content"
                                 android:layout_below="@+id/text_view_version_title"
@@ -133,7 +133,7 @@
                         android:gravity="center_vertical"
                         android:onClick="onClick"
                         >
-                        <ImageView
+                        <androidx.appcompat.widget.AppCompatImageView
                             android:id="@+id/image_view_changelog"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
@@ -150,7 +150,7 @@
                             android:gravity="center_vertical"
                             >
 
-                            <TextView
+                            <androidx.appcompat.widget.AppCompatTextView
                                 android:layout_width="wrap_content"
                                 android:layout_height="wrap_content"
                                 android:text="@string/changelog"
@@ -168,7 +168,7 @@
                         android:gravity="center_vertical"
                         android:onClick="onClick"
                         >
-                        <ImageView
+                        <androidx.appcompat.widget.AppCompatImageView
                             android:id="@+id/image_view_license"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
@@ -184,8 +184,7 @@
                             android:layout_toRightOf="@+id/image_view_license"
                             android:gravity="center_vertical"
                             >
-
-                            <TextView
+                            <androidx.appcompat.widget.AppCompatTextView
                                 android:layout_width="wrap_content"
                                 android:layout_height="wrap_content"
                                 android:text="@string/libraries"
@@ -218,8 +217,7 @@
                         android:layout_height="@dimen/material_generic_large"
                         android:paddingLeft="@dimen/material_generic"
                         >
-
-                        <TextView
+                        <androidx.appcompat.widget.AppCompatTextView
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:layout_centerVertical="true"
@@ -235,7 +233,7 @@
                         android:background="?android:attr/selectableItemBackground"
                         android:gravity="center_vertical"
                         >
-                        <ImageView
+                        <androidx.appcompat.widget.AppCompatImageView
                             android:id="@+id/image_person"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
@@ -253,7 +251,7 @@
                             android:gravity="center_vertical"
                             >
 
-                            <TextView
+                            <androidx.appcompat.widget.AppCompatTextView
                                 android:id="@+id/text_view_author_1_title"
                                 android:layout_width="wrap_content"
                                 android:layout_height="wrap_content"
@@ -266,7 +264,7 @@
                                 android:layout_height="wrap_content"
                                 android:layout_below="@+id/text_view_author_1_title"
                                 android:layout_marginTop="@dimen/material_generic">
-                                <TextView
+                                <androidx.appcompat.widget.AppCompatTextView
                                     android:id="@+id/text_view_author_1_github"
                                     android:layout_width="wrap_content"
                                     android:layout_height="wrap_content"
@@ -298,7 +296,7 @@
                         android:background="?android:attr/selectableItemBackground"
                         android:gravity="center_vertical"
                         >
-                        <ImageView
+                        <androidx.appcompat.widget.AppCompatImageView
                             android:id="@+id/image_person_author_2"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
@@ -316,7 +314,7 @@
                             android:gravity="center_vertical"
                             >
 
-                            <TextView
+                            <androidx.appcompat.widget.AppCompatTextView
                                 android:id="@+id/text_view_author_2_title"
                                 android:layout_width="wrap_content"
                                 android:layout_height="wrap_content"
@@ -329,7 +327,7 @@
                                 android:layout_height="wrap_content"
                                 android:layout_below="@+id/text_view_author_2_title"
                                 android:layout_marginTop="@dimen/material_generic">
-                                <TextView
+                                <androidx.appcompat.widget.AppCompatTextView
                                     android:id="@+id/text_view_author_2_github"
                                     android:layout_width="wrap_content"
                                     android:layout_height="wrap_content"
@@ -348,7 +346,7 @@
                         android:layout_height="@dimen/material_generic_large"
                         android:paddingLeft="@dimen/material_generic">
 
-                        <TextView
+                        <androidx.appcompat.widget.AppCompatTextView
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:layout_centerVertical="true"
@@ -368,7 +366,7 @@
                             android:layout_height="match_parent"
                             android:gravity="center_vertical">
 
-                            <TextView
+                            <androidx.appcompat.widget.AppCompatTextView
                                 android:id="@+id/text_view_developer_1_title"
                                 android:layout_width="wrap_content"
                                 android:layout_height="wrap_content"
@@ -380,7 +378,7 @@
                                 android:layout_height="wrap_content"
                                 android:layout_below="@+id/text_view_developer_1_title"
                                 android:layout_marginTop="@dimen/material_generic">
-                                <TextView
+                                <androidx.appcompat.widget.AppCompatTextView
                                     android:id="@+id/text_view_developer_1_github"
                                     android:layout_width="wrap_content"
                                     android:layout_height="wrap_content"
@@ -418,7 +416,7 @@
                             android:layout_height="match_parent"
                             android:gravity="center_vertical">
 
-                            <TextView
+                            <androidx.appcompat.widget.AppCompatTextView
                                 android:id="@+id/text_view_developer_2_title"
                                 android:layout_width="wrap_content"
                                 android:layout_height="wrap_content"
@@ -430,7 +428,7 @@
                                 android:layout_height="wrap_content"
                                 android:layout_below="@+id/text_view_developer_2_title"
                                 android:layout_marginTop="@dimen/material_generic">
-                                <TextView
+                                <androidx.appcompat.widget.AppCompatTextView
                                     android:id="@+id/text_view_developer_2_github"
                                     android:layout_width="wrap_content"
                                     android:layout_height="wrap_content"
@@ -469,7 +467,7 @@
                         android:paddingLeft="@dimen/material_generic"
                         >
 
-                        <TextView
+                        <androidx.appcompat.widget.AppCompatTextView
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:layout_centerVertical="true"
@@ -489,7 +487,7 @@
                         android:onClick="onClick"
                         >
 
-                        <ImageView
+                        <androidx.appcompat.widget.AppCompatImageView
                             android:id="@+id/image_source"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
@@ -506,14 +504,14 @@
                             android:layout_toRightOf="@+id/image_source"
                             android:gravity="center_vertical"
                             >
-                            <TextView
+                            <androidx.appcompat.widget.AppCompatTextView
                                 android:id="@+id/text_view_source"
                                 android:layout_width="wrap_content"
                                 android:layout_height="wrap_content"
                                 android:text="@string/source_title"
                                 android:textSize="@dimen/material_generic_title"
                                 />
-                            <TextView
+                            <androidx.appcompat.widget.AppCompatTextView
                                 android:layout_width="wrap_content"
                                 android:layout_height="wrap_content"
                                 android:layout_below="@+id/text_view_source"
@@ -532,7 +530,7 @@
                         android:onClick="onClick"
                         >
 
-                        <ImageView
+                        <androidx.appcompat.widget.AppCompatImageView
                             android:id="@+id/image_dev_1_title"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
@@ -549,14 +547,14 @@
                             android:layout_toRightOf="@+id/image_dev_1_title"
                             android:gravity="center_vertical"
                             >
-                            <TextView
+                            <androidx.appcompat.widget.AppCompatTextView
                                 android:id="@+id/text_view_dev_1_title"
                                 android:layout_width="wrap_content"
                                 android:layout_height="wrap_content"
                                 android:text="@string/report_bugs_title"
                                 android:textSize="@dimen/material_generic_title"
                                 />
-                            <TextView
+                            <androidx.appcompat.widget.AppCompatTextView
                                 android:layout_width="wrap_content"
                                 android:layout_height="wrap_content"
                                 android:layout_below="@+id/text_view_dev_1_title"
@@ -575,7 +573,7 @@
                         android:onClick="onClick"
                         >
 
-                        <ImageView
+                        <androidx.appcompat.widget.AppCompatImageView
                             android:id="@+id/image_share_logs_title"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
@@ -592,14 +590,14 @@
                             android:layout_toRightOf="@+id/image_share_logs_title"
                             android:gravity="center_vertical"
                             >
-                            <TextView
+                            <androidx.appcompat.widget.AppCompatTextView
                                 android:id="@+id/text_view_share_logs_title"
                                 android:layout_width="wrap_content"
                                 android:layout_height="wrap_content"
                                 android:text="@string/share_logs"
                                 android:textSize="@dimen/material_generic_title"
                                 />
-                            <TextView
+                            <androidx.appcompat.widget.AppCompatTextView
                                 android:layout_width="wrap_content"
                                 android:layout_height="wrap_content"
                                 android:layout_below="@+id/text_view_share_logs_title"
@@ -618,7 +616,7 @@
                         android:onClick="onClick"
                         >
 
-                        <ImageView
+                        <androidx.appcompat.widget.AppCompatImageView
                             android:id="@+id/image_dev_2_title"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
@@ -635,14 +633,14 @@
                             android:layout_toRightOf="@+id/image_dev_2_title"
                             android:gravity="center_vertical"
                             >
-                            <TextView
+                            <androidx.appcompat.widget.AppCompatTextView
                                 android:id="@+id/text_view_dev_2_title"
                                 android:layout_width="wrap_content"
                                 android:layout_height="wrap_content"
                                 android:text="@string/translate_title"
                                 android:textSize="@dimen/material_generic_title"
                                 />
-                            <TextView
+                            <androidx.appcompat.widget.AppCompatTextView
                                 android:layout_width="wrap_content"
                                 android:layout_height="wrap_content"
                                 android:layout_below="@+id/text_view_dev_2_title"
@@ -661,7 +659,7 @@
                         android:onClick="onClick"
                         >
 
-                        <ImageView
+                        <androidx.appcompat.widget.AppCompatImageView
                             android:id="@+id/image_dev_4_title"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
@@ -678,14 +676,14 @@
                             android:layout_toRightOf="@+id/image_dev_4_title"
                             android:gravity="center_vertical"
                             >
-                            <TextView
+                            <androidx.appcompat.widget.AppCompatTextView
                                 android:id="@+id/text_view_dev_4_title"
                                 android:layout_width="wrap_content"
                                 android:layout_height="wrap_content"
                                 android:text="@string/xda_title"
                                 android:textSize="@dimen/material_generic_title"
                                 />
-                            <TextView
+                            <androidx.appcompat.widget.AppCompatTextView
                                 android:layout_width="wrap_content"
                                 android:layout_height="wrap_content"
                                 android:layout_below="@+id/text_view_dev_4_title"
@@ -703,7 +701,7 @@
                         android:gravity="center_vertical"
                         android:onClick="onClick">
 
-                        <ImageView
+                        <androidx.appcompat.widget.AppCompatImageView
                             android:id="@+id/image_dev_5_title"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
@@ -720,7 +718,7 @@
                             android:layout_toRightOf="@+id/image_dev_5_title"
                             android:gravity="center_vertical"
                             >
-                            <TextView
+                            <androidx.appcompat.widget.AppCompatTextView
                                 android:layout_width="wrap_content"
                                 android:layout_height="wrap_content"
                                 android:text="@string/rate"
@@ -738,7 +736,7 @@
                         android:onClick="onClick"
                         >
 
-                        <ImageView
+                        <androidx.appcompat.widget.AppCompatImageView
                             android:id="@+id/image_dev_6_title"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
@@ -755,7 +753,7 @@
                             android:layout_toRightOf="@+id/image_dev_6_title"
                             android:gravity="center_vertical"
                             >
-                            <TextView
+                            <androidx.appcompat.widget.AppCompatTextView
                                 android:layout_width="wrap_content"
                                 android:layout_height="wrap_content"
                                 android:text="@string/donate"
@@ -789,7 +787,7 @@
                         android:paddingLeft="@dimen/material_generic"
                         >
 
-                        <TextView
+                        <androidx.appcompat.widget.AppCompatTextView
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:layout_centerVertical="true"
@@ -806,14 +804,14 @@
                         android:gravity="center_vertical"
                         >
 
-                        <TextView
+                        <androidx.appcompat.widget.AppCompatTextView
                             android:id="@+id/text_view_translator_1_title"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:text="@string/german_translation_title"
                             android:textSize="@dimen/material_generic_title"
                             />
-                        <TextView
+                        <androidx.appcompat.widget.AppCompatTextView
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:layout_below="@+id/text_view_translator_1_title"
@@ -830,14 +828,14 @@
                         android:gravity="center_vertical"
                         >
 
-                        <TextView
+                        <androidx.appcompat.widget.AppCompatTextView
                             android:id="@+id/text_view_translator_2_title"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:text="@string/italian_translation_title"
                             android:textSize="@dimen/material_generic_title"
                             />
-                        <TextView
+                        <androidx.appcompat.widget.AppCompatTextView
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:layout_below="@+id/text_view_translator_2_title"
@@ -854,14 +852,14 @@
                         android:gravity="center_vertical"
                         >
 
-                        <TextView
+                        <androidx.appcompat.widget.AppCompatTextView
                             android:id="@+id/text_view_translator_3_title"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:text="@string/french_translation_title"
                             android:textSize="@dimen/material_generic_title"
                             />
-                        <TextView
+                        <androidx.appcompat.widget.AppCompatTextView
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:layout_below="@+id/text_view_translator_3_title"
@@ -878,14 +876,14 @@
                         android:gravity="center_vertical"
                         >
 
-                        <TextView
+                        <androidx.appcompat.widget.AppCompatTextView
                             android:id="@+id/text_view_translator_4_title"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:text="@string/russian_translation_title"
                             android:textSize="@dimen/material_generic_title"
                             />
-                        <TextView
+                        <androidx.appcompat.widget.AppCompatTextView
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:layout_below="@+id/text_view_translator_4_title"
@@ -901,14 +899,14 @@
                         android:gravity="center_vertical"
                         >
 
-                        <TextView
+                        <androidx.appcompat.widget.AppCompatTextView
                             android:id="@+id/text_view_translator_5_title"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:text="@string/spanish_translation_title"
                             android:textSize="@dimen/material_generic_title"
                             />
-                        <TextView
+                        <androidx.appcompat.widget.AppCompatTextView
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:layout_below="@+id/text_view_translator_5_title"
@@ -925,14 +923,14 @@
                         android:gravity="center_vertical"
                         >
 
-                        <TextView
+                        <androidx.appcompat.widget.AppCompatTextView
                             android:id="@+id/text_view_translator_6_title"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:text="@string/basque_translation_title"
                             android:textSize="@dimen/material_generic_title"
                             />
-                        <TextView
+                        <androidx.appcompat.widget.AppCompatTextView
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:layout_below="@+id/text_view_translator_6_title"
@@ -949,14 +947,14 @@
                         android:gravity="center_vertical"
                         >
 
-                        <TextView
+                        <androidx.appcompat.widget.AppCompatTextView
                             android:id="@+id/text_view_translator_7_title"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:text="@string/chinese_translation_title"
                             android:textSize="@dimen/material_generic_title"
                             />
-                        <TextView
+                        <androidx.appcompat.widget.AppCompatTextView
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:layout_below="@+id/text_view_translator_7_title"
@@ -973,14 +971,14 @@
                         android:gravity="center_vertical"
                         >
 
-                        <TextView
+                        <androidx.appcompat.widget.AppCompatTextView
                             android:id="@+id/text_view_translator_8_title"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:text="@string/serbian_translation_title"
                             android:textSize="@dimen/material_generic_title"
                             />
-                        <TextView
+                        <androidx.appcompat.widget.AppCompatTextView
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:layout_below="@+id/text_view_translator_8_title"
@@ -997,14 +995,14 @@
                         android:gravity="center_vertical"
                         >
 
-                        <TextView
+                        <androidx.appcompat.widget.AppCompatTextView
                             android:id="@+id/text_view_translator_9_title"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:text="@string/turkish_translation_title"
                             android:textSize="@dimen/material_generic_title"
                             />
-                        <TextView
+                        <androidx.appcompat.widget.AppCompatTextView
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:layout_below="@+id/text_view_translator_9_title"
@@ -1021,14 +1019,14 @@
                         android:gravity="center_vertical"
                         >
 
-                        <TextView
+                        <androidx.appcompat.widget.AppCompatTextView
                             android:id="@+id/text_view_translator_10_title"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:text="@string/ukrainian_translation_title"
                             android:textSize="@dimen/material_generic_title"
                             />
-                        <TextView
+                        <androidx.appcompat.widget.AppCompatTextView
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:layout_below="@+id/text_view_translator_10_title"
@@ -1045,14 +1043,14 @@
                         android:gravity="center_vertical"
                         >
 
-                        <TextView
+                        <androidx.appcompat.widget.AppCompatTextView
                             android:id="@+id/text_view_translator_11_title"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:text="@string/portuguese_translation_title"
                             android:textSize="@dimen/material_generic_title"
                             />
-                        <TextView
+                        <androidx.appcompat.widget.AppCompatTextView
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:layout_below="@+id/text_view_translator_11_title"
@@ -1069,14 +1067,14 @@
                         android:gravity="center_vertical"
                         >
 
-                        <TextView
+                        <androidx.appcompat.widget.AppCompatTextView
                             android:id="@+id/text_view_translator_12_title"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:text="@string/polish_translation_title"
                             android:textSize="@dimen/material_generic_title"
                             />
-                        <TextView
+                        <androidx.appcompat.widget.AppCompatTextView
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:layout_below="@+id/text_view_translator_12_title"
@@ -1093,14 +1091,14 @@
                         android:gravity="center_vertical"
                         >
 
-                        <TextView
+                        <androidx.appcompat.widget.AppCompatTextView
                             android:id="@+id/text_view_translator_13_title"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:text="@string/korean_translation_title"
                             android:textSize="@dimen/material_generic_title"
                             />
-                        <TextView
+                        <androidx.appcompat.widget.AppCompatTextView
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:layout_below="@+id/text_view_translator_13_title"
@@ -1117,14 +1115,14 @@
                         android:gravity="center_vertical"
                         >
 
-                        <TextView
+                        <androidx.appcompat.widget.AppCompatTextView
                             android:id="@+id/text_view_translator_14_title"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:text="@string/greek_translation_title"
                             android:textSize="@dimen/material_generic_title"
                             />
-                        <TextView
+                        <androidx.appcompat.widget.AppCompatTextView
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:layout_below="@+id/text_view_translator_14_title"
@@ -1141,14 +1139,14 @@
                         android:gravity="center_vertical"
                         >
 
-                        <TextView
+                        <androidx.appcompat.widget.AppCompatTextView
                             android:id="@+id/text_view_translator_15_title"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:text="@string/dutch_translation_title"
                             android:textSize="@dimen/material_generic_title"
                             />
-                        <TextView
+                        <androidx.appcompat.widget.AppCompatTextView
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:layout_below="@+id/text_view_translator_15_title"
@@ -1165,14 +1163,14 @@
                         android:gravity="center_vertical"
                         >
 
-                        <TextView
+                        <androidx.appcompat.widget.AppCompatTextView
                             android:id="@+id/text_view_translator_16_title"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:text="@string/romanian_translation_title"
                             android:textSize="@dimen/material_generic_title"
                             />
-                        <TextView
+                        <androidx.appcompat.widget.AppCompatTextView
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:layout_below="@+id/text_view_translator_16_title"
@@ -1189,14 +1187,14 @@
                         android:gravity="center_vertical"
                         >
 
-                        <TextView
+                        <androidx.appcompat.widget.AppCompatTextView
                             android:id="@+id/text_view_translator_17_title"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:text="@string/vietnamese_translation_title"
                             android:textSize="@dimen/material_generic_title"
                             />
-                        <TextView
+                        <androidx.appcompat.widget.AppCompatTextView
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:layout_below="@+id/text_view_translator_17_title"
@@ -1213,14 +1211,14 @@
                         android:gravity="center_vertical"
                         >
 
-                        <TextView
+                        <androidx.appcompat.widget.AppCompatTextView
                             android:id="@+id/text_view_translator_18_title"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:text="@string/japanese_translation_title"
                             android:textSize="@dimen/material_generic_title"
                             />
-                        <TextView
+                        <androidx.appcompat.widget.AppCompatTextView
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:layout_below="@+id/text_view_translator_18_title"
@@ -1236,14 +1234,14 @@
                         android:gravity="center_vertical"
                         >
 
-                        <TextView
+                        <androidx.appcompat.widget.AppCompatTextView
                             android:id="@+id/text_view_translator_19_title"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:text="@string/tamil_translation_title"
                             android:textSize="@dimen/material_generic_title"
                             />
-                        <TextView
+                        <androidx.appcompat.widget.AppCompatTextView
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:layout_below="@+id/text_view_translator_19_title"
@@ -1279,7 +1277,7 @@
                         android:paddingLeft="@dimen/material_generic"
                         >
 
-                        <TextView
+                        <androidx.appcompat.widget.AppCompatTextView
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:layout_centerVertical="true"
@@ -1296,14 +1294,14 @@
                         android:gravity="center_vertical"
                         >
 
-                        <TextView
+                        <androidx.appcompat.widget.AppCompatTextView
                             android:id="@+id/text_view_contributor_1_title"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:text="@string/contributor_1_title"
                             android:textSize="@dimen/material_generic_title"
                             />
-                        <TextView
+                        <androidx.appcompat.widget.AppCompatTextView
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:layout_below="@+id/text_view_contributor_1_title"
@@ -1320,14 +1318,14 @@
                         android:gravity="center_vertical"
                         >
 
-                        <TextView
+                        <androidx.appcompat.widget.AppCompatTextView
                             android:id="@+id/text_view_contributor_2_title"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:text="@string/contributor_2_title"
                             android:textSize="@dimen/material_generic_title"
                             />
-                        <TextView
+                        <androidx.appcompat.widget.AppCompatTextView
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:layout_below="@+id/text_view_contributor_2_title"
@@ -1344,14 +1342,14 @@
                         android:gravity="center_vertical"
                         >
 
-                        <TextView
+                        <androidx.appcompat.widget.AppCompatTextView
                             android:id="@+id/text_view_contributor_3_title"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:text="@string/contributor_3_title"
                             android:textSize="@dimen/material_generic_title"
                             />
-                        <TextView
+                        <androidx.appcompat.widget.AppCompatTextView
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:layout_below="@+id/text_view_contributor_3_title"
@@ -1368,14 +1366,14 @@
                         android:gravity="center_vertical"
                         >
 
-                        <TextView
+                        <androidx.appcompat.widget.AppCompatTextView
                             android:id="@+id/text_view_contributor_4_title"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:text="@string/contributor_4_title"
                             android:textSize="@dimen/material_generic_title"
                             />
-                        <TextView
+                        <androidx.appcompat.widget.AppCompatTextView
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:layout_below="@+id/text_view_contributor_4_title"
@@ -1391,14 +1389,14 @@
                         android:gravity="center_vertical"
                         >
 
-                        <TextView
+                        <androidx.appcompat.widget.AppCompatTextView
                             android:id="@+id/text_view_contributor_5_title"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:text="@string/contributor_5_title"
                             android:textSize="@dimen/material_generic_title"
                             />
-                        <TextView
+                        <androidx.appcompat.widget.AppCompatTextView
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:layout_below="@+id/text_view_contributor_5_title"
@@ -1415,14 +1413,14 @@
                         android:gravity="center_vertical"
                         >
 
-                        <TextView
+                        <androidx.appcompat.widget.AppCompatTextView
                             android:id="@+id/text_view_contributor_6_title"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:text="@string/contributor_6_title"
                             android:textSize="@dimen/material_generic_title"
                             />
-                        <TextView
+                        <androidx.appcompat.widget.AppCompatTextView
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:layout_below="@+id/text_view_contributor_6_title"
@@ -1439,14 +1437,14 @@
                         android:gravity="center_vertical"
                         >
 
-                        <TextView
+                        <androidx.appcompat.widget.AppCompatTextView
                             android:id="@+id/text_view_contributor_7_title"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:text="@string/contributor_7_title"
                             android:textSize="@dimen/material_generic_title"
                             />
-                        <TextView
+                        <androidx.appcompat.widget.AppCompatTextView
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:layout_below="@+id/text_view_contributor_7_title"

--- a/app/src/main/res/layout/activity_error.xml
+++ b/app/src/main/res/layout/activity_error.xml
@@ -28,7 +28,7 @@
             android:descendantFocusability="afterDescendants"
             >
 
-            <TextView
+            <androidx.appcompat.widget.AppCompatTextView
                 android:id="@+id/errorSorryView"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
@@ -37,7 +37,7 @@
                 android:textAppearance="?android:attr/textAppearanceLarge"
                 android:textStyle="bold" />
 
-            <TextView
+            <androidx.appcompat.widget.AppCompatTextView
                 android:id="@+id/messageWhatHappenedView"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
@@ -45,14 +45,14 @@
                 android:text="@string/what_happened_headline"
                 android:textAppearance="?android:attr/textAppearanceMedium" />
 
-            <TextView
+            <androidx.appcompat.widget.AppCompatTextView
                 android:id="@+id/errorMessageView"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="@string/info_labels"
                 android:textColor="?attr/colorAccent" />
 
-            <TextView
+            <androidx.appcompat.widget.AppCompatTextView
                 android:id="@+id/errorDeviceHeadlineView"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
@@ -66,7 +66,7 @@
                 android:layout_height="wrap_content"
                 android:orientation="horizontal">
 
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     android:id="@+id/errorInfoLabelsView"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
@@ -78,7 +78,7 @@
                     android:layout_height="wrap_content"
                     android:paddingLeft="16dp">
 
-                    <TextView
+                    <androidx.appcompat.widget.AppCompatTextView
                         android:id="@+id/errorInfosView"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content" />
@@ -87,7 +87,7 @@
 
             </LinearLayout>
 
-            <TextView
+            <androidx.appcompat.widget.AppCompatTextView
                 android:id="@+id/errorYourComment"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
@@ -95,13 +95,13 @@
                 android:text="@string/your_comment"
                 android:textAppearance="?android:attr/textAppearanceMedium" />
 
-            <EditText
+            <androidx.appcompat.widget.AppCompatEditText
                 android:id="@+id/errorCommentBox"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:inputType="" />
 
-            <TextView
+            <androidx.appcompat.widget.AppCompatTextView
                 android:id="@+id/errorDetailView"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
@@ -115,7 +115,7 @@
                 android:layout_height="wrap_content"
                 android:layout_gravity="center">
 
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     android:id="@+id/errorView"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
@@ -123,26 +123,26 @@
                     android:typeface="monospace" />
             </HorizontalScrollView>
 
-            <Button
+            <androidx.appcompat.widget.AppCompatButton
                 android:id="@+id/errorReportCopyButton"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/activity_vertical_margin"
                 android:text="@string/copy_for_github" />
 
-            <Button
+            <androidx.appcompat.widget.AppCompatButton
                 android:id="@+id/errorReportTelegramButton"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:text="@string/error_report_button_telegram" />
 
-            <Button
+            <androidx.appcompat.widget.AppCompatButton
                 android:id="@+id/errorReportEmailButton"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:text="@string/error_report_button_text" />
 
-            <TextView
+            <androidx.appcompat.widget.AppCompatTextView
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="10dp"
@@ -150,7 +150,7 @@
                 android:text="@string/error_report_open_github_notice"
                 android:textStyle="bold" />
 
-            <Button
+            <androidx.appcompat.widget.AppCompatButton
                 android:id="@+id/errorReportGitHubButton"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"

--- a/app/src/main/res/layout/bookmarkrow.xml
+++ b/app/src/main/res/layout/bookmarkrow.xml
@@ -18,16 +18,17 @@
     -->
     
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="fill_parent"
     android:layout_height="wrap_content"
     android:minHeight="60dp">
-    <ImageButton
+    <androidx.appcompat.widget.AppCompatImageView
         android:id="@+id/delete_button"
         android:layout_width="48dp"
         android:gravity="center_vertical"
         android:layout_alignParentRight="true"
         android:layout_height="fill_parent"
-        android:src="@drawable/ic_action_cancel_light"
+        app:srcCompat="@drawable/ic_action_cancel_light"
         android:background="?android:selectableItemBackground"
         android:contentDescription="@string/delbook" />
 

--- a/app/src/main/res/layout/copy_dialog.xml
+++ b/app/src/main/res/layout/copy_dialog.xml
@@ -26,7 +26,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <TextView
+    <androidx.appcompat.widget.AppCompatTextView
         android:id="@+id/fileAlreadyExists"
         android:layout_width="@dimen/zero_dp"
         android:layout_height="wrap_content"
@@ -36,7 +36,7 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
-    <TextView
+    <androidx.appcompat.widget.AppCompatTextView
         android:id="@+id/fileNameText"
         android:layout_width="@dimen/zero_dp"
         android:layout_height="wrap_content"
@@ -47,7 +47,7 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/fileAlreadyExists" />
 
-    <CheckBox
+    <androidx.appcompat.widget.AppCompatCheckBox
         android:id="@+id/checkBox"
         android:layout_width="@dimen/zero_dp"
         android:layout_height="wrap_content"

--- a/app/src/main/res/layout/dialog_decrypt_fingerprint_authentication.xml
+++ b/app/src/main/res/layout/dialog_decrypt_fingerprint_authentication.xml
@@ -20,7 +20,7 @@
         android:layout_marginTop="@dimen/material_generic"
         />
 
-    <Button
+    <androidx.appcompat.widget.AppCompatButton
         android:layout_width="match_parent"
         android:layout_height="@dimen/material_generic_medium"
         android:text="@string/cancel"

--- a/app/src/main/res/layout/dialog_twoedittexts.xml
+++ b/app/src/main/res/layout/dialog_twoedittexts.xml
@@ -15,7 +15,7 @@
         android:layout_height="wrap_content"
         app:errorEnabled="false">
 
-        <EditText
+        <androidx.appcompat.widget.AppCompatEditText
             android:id="@+id/text1"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
@@ -29,7 +29,7 @@
         android:layout_height="wrap_content"
         app:errorEnabled="true">
 
-        <EditText
+        <androidx.appcompat.widget.AppCompatEditText
             android:id="@+id/text2"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/app/src/main/res/layout/drag_placeholder.xml
+++ b/app/src/main/res/layout/drag_placeholder.xml
@@ -12,7 +12,7 @@
         app:layout_constraintRight_toRightOf="parent"
         app:layout_constraintTop_toTopOf="parent">
 
-        <ImageView
+        <androidx.appcompat.widget.AppCompatImageView
             android:id="@+id/icon"
             android:layout_width="@dimen/sixty_four"
             android:layout_height="@dimen/sixty_four"
@@ -30,7 +30,7 @@
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintRight_toRightOf="parent">
 
-            <TextView
+            <androidx.appcompat.widget.AppCompatTextView
                 android:id="@+id/files_count"
                 android:layout_width="@dimen/material_generic_medium"
                 android:layout_height="@dimen/material_generic_medium"

--- a/app/src/main/res/layout/drawerheader.xml
+++ b/app/src/main/res/layout/drawerheader.xml
@@ -31,7 +31,7 @@
             android:visibility="gone"
             android:textSize="@dimen/md_content_textsize"
             />
-        <ImageView
+        <androidx.appcompat.widget.AppCompatImageView
             android:id="@+id/donate"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
@@ -43,7 +43,7 @@
             android:background="@drawable/ripple_focusable"
             android:nextFocusRight="@+id/action_bar"
             />
-        <ImageView
+        <androidx.appcompat.widget.AppCompatImageView
             android:id="@+id/telegram"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
@@ -54,7 +54,7 @@
             android:layout_toStartOf="@+id/donate"
             android:background="@drawable/ripple_focusable"
             />
-        <ImageView
+        <androidx.appcompat.widget.AppCompatImageView
             android:id="@+id/instagram"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/app/src/main/res/layout/fastscroller.xml
+++ b/app/src/main/res/layout/fastscroller.xml
@@ -3,7 +3,16 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="wrap_content"
     android:layout_height="match_parent">
-    <View android:layout_gravity="center_horizontal" android:id="@+id/scroll_bar" android:layout_width="10dp" android:layout_height="match_parent" android:alpha="0.3" />
-    <ImageView android:layout_gravity="center_horizontal" android:id="@+id/scroll_handle" android:layout_width="10dp" android:layout_height="@dimen/fastscroller_track_height" />
+    <View
+        android:layout_gravity="center_horizontal"
+        android:id="@+id/scroll_bar"
+        android:layout_width="10dp"
+        android:layout_height="match_parent"
+        android:alpha="0.3" />
+    <androidx.appcompat.widget.AppCompatImageView
+        android:layout_gravity="center_horizontal"
+        android:id="@+id/scroll_handle"
+        android:layout_width="10dp"
+        android:layout_height="@dimen/fastscroller_track_height" />
 </FrameLayout>
 

--- a/app/src/main/res/layout/fragment_app_list.xml
+++ b/app/src/main/res/layout/fragment_app_list.xml
@@ -35,7 +35,7 @@
         app:layout_constraintBottom_toBottomOf="parent"
         android:visibility="visible"
         />
-    <TextView
+    <androidx.appcompat.widget.AppCompatTextView
         android:id="@+id/empty_text_view"
         android:layout_width="@dimen/zero_dp"
         android:layout_height="@dimen/zero_dp"

--- a/app/src/main/res/layout/fragment_db_viewer.xml
+++ b/app/src/main/res/layout/fragment_db_viewer.xml
@@ -4,7 +4,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <TextView
+    <androidx.appcompat.widget.AppCompatTextView
         android:id="@+id/loadingText"
         android:layout_centerHorizontal="true"
         android:layout_centerVertical="true"

--- a/app/src/main/res/layout/fragment_ftp.xml
+++ b/app/src/main/res/layout/fragment_ftp.xml
@@ -27,7 +27,7 @@
             android:descendantFocusability="afterDescendants">
 
             <!-- status -->
-            <TextView
+            <androidx.appcompat.widget.AppCompatTextView
                 android:id="@+id/text_view_ftp_status"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
@@ -38,7 +38,7 @@
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent" />
 
-            <TextView
+            <androidx.appcompat.widget.AppCompatTextView
                 android:id="@+id/text_view_ftp_url"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
@@ -63,7 +63,7 @@
                 app:layout_constraintTop_toBottomOf="@id/text_view_ftp_url" />
 
             <!-- username -->
-            <TextView
+            <androidx.appcompat.widget.AppCompatTextView
                 android:id="@+id/text_view_ftp_username"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
@@ -76,7 +76,7 @@
             <!-- password -->
 
 
-            <TextView
+            <androidx.appcompat.widget.AppCompatTextView
                 android:id="@+id/text_view_ftp_password"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
@@ -88,12 +88,12 @@
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/text_view_ftp_username"/>
 
-            <ImageButton
+            <androidx.appcompat.widget.AppCompatImageButton
                 android:id="@+id/ftp_password_visible"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:background="?selectableItemBackground"
-                android:src="@drawable/ic_eye_grey600_24dp"
+                app:srcCompat="@drawable/ic_eye_grey600_24dp"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/text_view_ftp_username"
@@ -101,7 +101,7 @@
 
 
             <!-- port -->
-            <TextView
+            <androidx.appcompat.widget.AppCompatTextView
                 android:id="@+id/text_view_ftp_port"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
@@ -114,7 +114,7 @@
                 app:layout_constraintTop_toBottomOf="@id/text_view_ftp_password"/>
 
             <!-- shared path -->
-            <TextView
+            <androidx.appcompat.widget.AppCompatTextView
                 android:id="@+id/text_view_ftp_path"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
@@ -138,7 +138,7 @@
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/text_view_ftp_path" />
 
-            <Button
+            <androidx.appcompat.widget.AppCompatButton
                 android:id="@+id/startStopButton"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"

--- a/app/src/main/res/layout/fragment_open_file_dialog.xml
+++ b/app/src/main/res/layout/fragment_open_file_dialog.xml
@@ -9,7 +9,7 @@
     android:background="@drawable/shape_dialog_bottomsheet_white"
     android:elevation="@dimen/material_generic_card_elevation"
     >
-    <ImageView
+    <androidx.appcompat.widget.AppCompatImageView
         android:id="@+id/last_app_image"
         android:layout_width="60dp"
         android:layout_height="60dp"
@@ -19,7 +19,7 @@
         android:layout_marginStart="@dimen/material_generic"
         android:layout_marginTop="@dimen/material_generic_medium"
         />
-    <TextView
+    <androidx.appcompat.widget.AppCompatTextView
         android:id="@+id/last_app_title"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
@@ -30,7 +30,7 @@
         android:layout_marginTop="@dimen/material_generic_medium"
         android:textAppearance="@style/TextAppearance.AppCompat.Large"
         />
-    <ImageButton
+    <androidx.appcompat.widget.AppCompatImageButton
         android:id="@+id/open_as_button"
         android:layout_width="50dp"
         android:layout_height="50dp"
@@ -41,7 +41,7 @@
         android:focusable="true"
         android:layout_margin="@dimen/material_generic"
         />
-    <TextView
+    <androidx.appcompat.widget.AppCompatTextView
         android:id="@+id/always_button"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
@@ -55,7 +55,7 @@
         android:layout_marginEnd="@dimen/material_generic"
         android:textAppearance="@style/TextAppearance.AppCompat.Medium"
         />
-    <TextView
+    <androidx.appcompat.widget.AppCompatTextView
         android:id="@+id/just_once_button"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
@@ -78,7 +78,7 @@
         android:layout_marginTop="@dimen/material_generic"
         />
 
-    <TextView
+    <androidx.appcompat.widget.AppCompatTextView
         android:id="@+id/choose_different_app_text_view"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"

--- a/app/src/main/res/layout/fragment_sheet_cloud.xml
+++ b/app/src/main/res/layout/fragment_sheet_cloud.xml
@@ -20,7 +20,7 @@
             android:gravity="center_vertical"
             >
 
-            <TextView
+            <androidx.appcompat.widget.AppCompatTextView
                 android:text="@string/cloud_connection_new"
                 android:textColor="@android:color/darker_gray"
                 android:textSize="@dimen/material_generic_title"

--- a/app/src/main/res/layout/grid_header.xml
+++ b/app/src/main/res/layout/grid_header.xml
@@ -6,7 +6,7 @@
     android:layout_height="@dimen/list_header_height"
     android:layout_width="match_parent" >
 
-    <TextView
+    <androidx.appcompat.widget.AppCompatTextView
         android:id="@+id/text"
         android:gravity="center_vertical"
         android:layout_height="wrap_content"
@@ -15,6 +15,6 @@
         android:paddingLeft="@dimen/material_generic"
         android:paddingRight="@dimen/material_generic"
         android:textSize="@dimen/list_header_textsize">
-    </TextView>
+    </androidx.appcompat.widget.AppCompatTextView>
 
 </RelativeLayout>

--- a/app/src/main/res/layout/griditem.xml
+++ b/app/src/main/res/layout/griditem.xml
@@ -1,4 +1,5 @@
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/second"
     android:layout_width="match_parent"
     android:layout_height="170dp"
@@ -44,12 +45,12 @@
                 android:layout_height="match_parent"
                 android:gravity="center">
 
-                <ImageView
+                <androidx.appcompat.widget.AppCompatImageView
                     android:id="@+id/check_icon_grid"
                     android:layout_width="@dimen/check_icon_size_grid"
                     android:layout_height="@dimen/check_icon_size_grid"
                     android:alpha="0.7"
-                    android:src="@drawable/ic_grid_selection_check"
+                    app:srcCompat="@drawable/ic_grid_selection_check"
                     android:visibility="invisible" />
             </RelativeLayout>
 
@@ -73,7 +74,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content">
 
-            <ImageButton
+            <androidx.appcompat.widget.AppCompatImageButton
                 android:id="@+id/properties"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
@@ -83,7 +84,7 @@
                 android:background="@drawable/ripple"
                 android:clickable="true"
                 android:padding="1dp"
-                android:src="@drawable/ic_more_vert_black_48dp"
+                app:srcCompat="@drawable/ic_more_vert_black_48dp"
                 android:nextFocusUp="@id/second"
                 android:focusable="true" />
 

--- a/app/src/main/res/layout/griditem.xml
+++ b/app/src/main/res/layout/griditem.xml
@@ -24,7 +24,7 @@
             android:background="#fff"
             android:foregroundGravity="fill">
 
-            <ImageView
+            <androidx.appcompat.widget.AppCompatImageView
                 android:id="@+id/generic_icon"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
@@ -33,7 +33,7 @@
                 android:contentDescription="@string/icon"
                 android:scaleType="centerInside" />
 
-            <ImageView
+            <androidx.appcompat.widget.AppCompatImageView
                 android:id="@+id/icon_thumb"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"

--- a/app/src/main/res/layout/layout_appbar.xml
+++ b/app/src/main/res/layout/layout_appbar.xml
@@ -76,14 +76,14 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content">
 
-                    <TextView
+                    <androidx.appcompat.widget.AppCompatTextView
                         android:clickable="false"
                         android:layout_width="wrap_content"
                         style="@android:style/TextAppearance.Medium"
                         android:textColor="@android:color/white"
                         android:layout_height="wrap_content"
                         android:id="@+id/fullpath" />
-                    <TextView
+                    <androidx.appcompat.widget.AppCompatTextView
                         android:clickable="false"
                         android:layout_width="wrap_content"
                         style="@android:style/TextAppearance.Medium"
@@ -93,7 +93,7 @@
                         android:visibility="gone"/>
                 </LinearLayout>
             </HorizontalScrollView>
-            <TextView
+            <androidx.appcompat.widget.AppCompatTextView
                 android:clickable="false"
                 android:layout_width="wrap_content"
                 android:textSize="12sp"

--- a/app/src/main/res/layout/layout_draweractionview.xml
+++ b/app/src/main/res/layout/layout_draweractionview.xml
@@ -17,7 +17,7 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
     -->
 
-<ImageButton xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.appcompat.widget.AppCompatImageButton xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/imageButton"
     android:layout_width="match_parent"
     android:layout_height="match_parent"

--- a/app/src/main/res/layout/layout_search.xml
+++ b/app/src/main/res/layout/layout_search.xml
@@ -56,7 +56,7 @@
             app:layout_constraintTop_toTopOf="@id/search_edit_text"
             app:srcCompat="@drawable/ic_close_black_24dp" />
 
-        <TextView
+        <androidx.appcompat.widget.AppCompatTextView
             android:id="@+id/searchRecentHintTV"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
@@ -100,7 +100,7 @@
 
         </HorizontalScrollView>
 
-        <TextView
+        <androidx.appcompat.widget.AppCompatTextView
             android:id="@+id/searchDeepSearchTV"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
@@ -116,7 +116,7 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/searchRecentItemsScrollView" />
 
-        <TextView
+        <androidx.appcompat.widget.AppCompatTextView
             android:id="@+id/searchResultsHintTV"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/app/src/main/res/layout/lexadrawer.xml
+++ b/app/src/main/res/layout/lexadrawer.xml
@@ -6,7 +6,7 @@
         android:id="@+id/description"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content" />
-    <ImageView
+    <androidx.appcompat.widget.AppCompatImageView
         android:id="@+id/icon"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"/>

--- a/app/src/main/res/layout/lexadrawer.xml
+++ b/app/src/main/res/layout/lexadrawer.xml
@@ -6,8 +6,8 @@
         android:id="@+id/description"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content" />
-<ImageView
-    android:id="@+id/icon"
-    android:layout_width="wrap_content"
-    android:layout_height="wrap_content"/>
+    <ImageView
+        android:id="@+id/icon"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"/>
 </LinearLayout>

--- a/app/src/main/res/layout/list_header.xml
+++ b/app/src/main/res/layout/list_header.xml
@@ -6,7 +6,7 @@
     android:layout_height="@dimen/list_header_height"
     android:layout_width="match_parent" >
 
-    <TextView
+    <androidx.appcompat.widget.AppCompatTextView
         android:id="@+id/text"
         android:gravity="center_vertical"
         android:layout_height="wrap_content"
@@ -15,6 +15,6 @@
         android:paddingLeft="@dimen/icon_width"
         android:paddingRight="@dimen/icon_width"
         android:textSize="@dimen/list_header_textsize">
-    </TextView>
+    </androidx.appcompat.widget.AppCompatTextView>
 
 </RelativeLayout>

--- a/app/src/main/res/layout/main_frag.xml
+++ b/app/src/main/res/layout/main_frag.xml
@@ -21,9 +21,9 @@
     -->
 
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    >
+    android:layout_height="match_parent">
 
     <!--
      As the main content view, the view below consumes the entire
@@ -78,16 +78,16 @@
                 android:background="@drawable/ripple_focusable"
                 >
 
-                <ImageView
+                <androidx.appcompat.widget.AppCompatImageView
                     android:id="@+id/image"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_centerHorizontal="true"
                     android:layout_centerVertical="true"
                     android:layout_marginBottom="@dimen/material_generic_medium"
-                    android:src="@drawable/ic_insert_drive_file_white_36dp"/>
+                    app:srcCompat="@drawable/ic_insert_drive_file_white_36dp"/>
 
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     style="@android:style/TextAppearance.Medium"
                     android:layout_width="wrap_content"
                     android:textColor="#666666"

--- a/app/src/main/res/layout/main_toolbar.xml
+++ b/app/src/main/res/layout/main_toolbar.xml
@@ -54,14 +54,14 @@
             android:id="@+id/indicator_layout"
             android:layout_height="wrap_content">
 
-            <ImageView
+            <androidx.appcompat.widget.AppCompatImageView
                 android:id="@+id/tab_indicator1"
                 android:layout_width="wrap_content"
                 android:minWidth="50dp"
                 android:layout_marginRight="2dp"
                 android:layout_height="match_parent" />
 
-            <ImageView
+            <androidx.appcompat.widget.AppCompatImageView
                 android:id="@+id/tab_indicator2"
                 android:layout_width="wrap_content"
                 android:minWidth="50dp"

--- a/app/src/main/res/layout/permissiontable.xml
+++ b/app/src/main/res/layout/permissiontable.xml
@@ -25,21 +25,21 @@
     <TableRow
         android:layout_width="fill_parent"
         android:layout_height="fill_parent">
-        <TextView
+        <androidx.appcompat.widget.AppCompatTextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:padding="5dp" />
-        <TextView
+        <androidx.appcompat.widget.AppCompatTextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:padding="5dp"
             android:text="@string/permission_read" />
-        <TextView
+        <androidx.appcompat.widget.AppCompatTextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:padding="5dp"
             android:text="@string/permission_write" />
-        <TextView
+        <androidx.appcompat.widget.AppCompatTextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:padding="5dp"
@@ -50,27 +50,27 @@
         android:layout_width="fill_parent"
         android:layout_height="fill_parent">
 
-        <TextView
+        <androidx.appcompat.widget.AppCompatTextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="@string/permission_owner"
             />
 
-        <CheckBox
+        <androidx.appcompat.widget.AppCompatCheckBox
             android:id="@+id/creadown"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:padding="5dp"
             />
 
-        <CheckBox
+        <androidx.appcompat.widget.AppCompatCheckBox
             android:id="@+id/cwriteown"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:padding="5dp"
             />
 
-        <CheckBox
+        <androidx.appcompat.widget.AppCompatCheckBox
             android:id="@+id/cexeown"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
@@ -81,22 +81,22 @@
         android:layout_width="fill_parent"
         android:layout_height="fill_parent">
 
-        <TextView
+        <androidx.appcompat.widget.AppCompatTextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="@string/permission_group" />
 
-        <CheckBox
+        <androidx.appcompat.widget.AppCompatCheckBox
             android:id="@+id/creadgroup"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content" />
 
-        <CheckBox
+        <androidx.appcompat.widget.AppCompatCheckBox
             android:id="@+id/cwritegroup"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content" />
 
-        <CheckBox
+        <androidx.appcompat.widget.AppCompatCheckBox
             android:id="@+id/cexegroup"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content" />
@@ -105,22 +105,22 @@
         android:layout_width="fill_parent"
         android:layout_height="fill_parent">
 
-        <TextView
+        <androidx.appcompat.widget.AppCompatTextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="@string/permission_other" />
 
-        <CheckBox
+        <androidx.appcompat.widget.AppCompatCheckBox
             android:id="@+id/creadother"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content" />
 
-        <CheckBox
+        <androidx.appcompat.widget.AppCompatCheckBox
             android:id="@+id/cwriteother"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content" />
 
-        <CheckBox
+        <androidx.appcompat.widget.AppCompatCheckBox
             android:id="@+id/cexeother"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content" />

--- a/app/src/main/res/layout/processparent.xml
+++ b/app/src/main/res/layout/processparent.xml
@@ -18,6 +18,7 @@
     -->
 
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
@@ -53,7 +54,7 @@
                     android:padding="@dimen/material_generic"
                     >
 
-                    <ImageView
+                    <androidx.appcompat.widget.AppCompatImageView
                         android:id="@+id/progress_image"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
@@ -62,9 +63,9 @@
                         android:layout_alignParentLeft="true"
                         />
 
-                    <ImageButton
+                    <androidx.appcompat.widget.AppCompatImageButton
                         android:id="@+id/delete_button"
-                        android:src="@drawable/ic_action_cancel_light"
+                        app:srcCompat="@drawable/ic_action_cancel_light"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_centerVertical="true"
@@ -81,7 +82,7 @@
                         android:orientation="vertical"
                         >
 
-                        <TextView
+                        <androidx.appcompat.widget.AppCompatTextView
                             android:id="@+id/text_view_progress_type"
                             android:layout_width="match_parent"
                             android:layout_height="match_parent"

--- a/app/src/main/res/layout/properties_audio.xml
+++ b/app/src/main/res/layout/properties_audio.xml
@@ -25,7 +25,7 @@
                 android:paddingBottom="@dimen/material_generic"
                 >
 
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_centerVertical="true"
@@ -43,14 +43,14 @@
                 android:gravity="center_vertical"
                 >
 
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     android:id="@+id/text_view_audio_codec_title"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="@string/codec"
                     android:textSize="@dimen/material_generic_title"
                     />
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_below="@+id/text_view_audio_codec_title"
@@ -75,14 +75,14 @@
                 android:gravity="center_vertical"
                 >
 
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     android:id="@+id/text_view_audio_channels_title"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="@string/channels"
                     android:textSize="@dimen/material_generic_title"
                     />
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_below="@+id/text_view_audio_channels_title"
@@ -107,14 +107,14 @@
                 android:gravity="center_vertical"
                 >
 
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     android:id="@+id/text_view_audio_sample_rate_title"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="@string/sample_rate"
                     android:textSize="@dimen/material_generic_title"
                     />
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_below="@+id/text_view_audio_sample_rate_title"
@@ -139,14 +139,14 @@
                 android:gravity="center_vertical"
                 >
 
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     android:id="@+id/text_view_audio_bitrate_title"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="@string/bitrate"
                     android:textSize="@dimen/material_generic_title"
                     />
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_below="@+id/text_view_audio_bitrate_title"

--- a/app/src/main/res/layout/properties_dialog.xml
+++ b/app/src/main/res/layout/properties_dialog.xml
@@ -20,7 +20,7 @@
             android:background="?selectableItemBackground"
             android:orientation="vertical">
 
-            <TextView
+            <androidx.appcompat.widget.AppCompatTextView
                 android:id="@+id/title_name"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
@@ -28,7 +28,7 @@
                 android:text="@string/name"
                 android:textSize="@dimen/material_generic_title"/>
 
-            <TextView
+            <androidx.appcompat.widget.AppCompatTextView
                 android:id="@+id/t5"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
@@ -45,7 +45,7 @@
             android:background="?selectableItemBackground"
             android:orientation="vertical">
 
-            <TextView
+            <androidx.appcompat.widget.AppCompatTextView
                 android:id="@+id/title_location"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
@@ -53,7 +53,7 @@
                 android:text="@string/location"
                 android:textSize="@dimen/material_generic_title"/>
 
-            <TextView
+            <androidx.appcompat.widget.AppCompatTextView
                 android:id="@+id/t6"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
@@ -69,7 +69,7 @@
             android:background="?selectableItemBackground"
             android:orientation="vertical">
 
-            <TextView
+            <androidx.appcompat.widget.AppCompatTextView
                 android:id="@+id/title_size"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
@@ -77,7 +77,7 @@
                 android:text="@string/size_capitalized"
                 android:textSize="@dimen/material_generic_title"/>
 
-            <TextView
+            <androidx.appcompat.widget.AppCompatTextView
                 android:id="@+id/t7"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
@@ -93,7 +93,7 @@
             android:background="?selectableItemBackground"
             android:orientation="vertical">
 
-            <TextView
+            <androidx.appcompat.widget.AppCompatTextView
                 android:id="@+id/title_date"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
@@ -101,7 +101,7 @@
                 android:text="@string/date"
                 android:textSize="@dimen/material_generic_title"/>
 
-            <TextView
+            <androidx.appcompat.widget.AppCompatTextView
                 android:id="@+id/t8"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
@@ -117,7 +117,7 @@
             android:background="?selectableItemBackground"
             android:orientation="vertical">
 
-            <TextView
+            <androidx.appcompat.widget.AppCompatTextView
                 android:id="@+id/title_md5"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
@@ -125,7 +125,7 @@
                 android:text="@string/md5"
                 android:textSize="@dimen/material_generic_title"/>
 
-            <TextView
+            <androidx.appcompat.widget.AppCompatTextView
                 android:id="@+id/t9"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
@@ -141,7 +141,7 @@
             android:background="?selectableItemBackground"
             android:orientation="vertical">
 
-            <TextView
+            <androidx.appcompat.widget.AppCompatTextView
                 android:id="@+id/title_sha256"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
@@ -149,7 +149,7 @@
                 android:text="@string/hash_sha256"
                 android:textSize="@dimen/material_generic_title"/>
 
-            <TextView
+            <androidx.appcompat.widget.AppCompatTextView
                 android:id="@+id/t10"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"

--- a/app/src/main/res/layout/properties_document.xml
+++ b/app/src/main/res/layout/properties_document.xml
@@ -25,7 +25,7 @@
                 android:paddingBottom="@dimen/material_generic"
                 >
 
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_centerVertical="true"
@@ -43,14 +43,14 @@
                 android:gravity="center_vertical"
                 >
 
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     android:id="@+id/text_view_document_type_title"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="@string/type"
                     android:textSize="@dimen/material_generic_title"
                     />
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_below="@+id/text_view_document_type_title"
@@ -75,14 +75,14 @@
                 android:gravity="center_vertical"
                 >
 
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     android:id="@+id/text_view_document_location_title"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="@string/location"
                     android:textSize="@dimen/material_generic_title"
                     />
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_below="@+id/text_view_document_location_title"
@@ -107,14 +107,14 @@
                 android:gravity="center_vertical"
                 >
 
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     android:id="@+id/text_view_document_subject_title"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="@string/subject"
                     android:textSize="@dimen/material_generic_title"
                     />
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_below="@+id/text_view_document_subject_title"
@@ -139,14 +139,14 @@
                 android:gravity="center_vertical"
                 >
 
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     android:id="@+id/text_view_document_author_title"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="@string/author"
                     android:textSize="@dimen/material_generic_title"
                     />
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_below="@+id/text_view_document_author_title"
@@ -171,14 +171,14 @@
                 android:gravity="center_vertical"
                 >
 
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     android:id="@+id/text_view_document_keywords_title"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="@string/keywords"
                     android:textSize="@dimen/material_generic_title"
                     />
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_below="@+id/text_view_document_keywords_title"
@@ -203,14 +203,14 @@
                 android:gravity="center_vertical"
                 >
 
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     android:id="@+id/text_view_document_producer_title"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="@string/producer"
                     android:textSize="@dimen/material_generic_title"
                     />
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_below="@+id/text_view_document_producer_title"
@@ -235,14 +235,14 @@
                 android:gravity="center_vertical"
                 >
 
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     android:id="@+id/text_view_document_creator_title"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="@string/creator"
                     android:textSize="@dimen/material_generic_title"
                     />
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_below="@+id/text_view_document_creator_title"
@@ -267,14 +267,14 @@
                 android:gravity="center_vertical"
                 >
 
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     android:id="@+id/text_view_document_created_title"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="@string/created"
                     android:textSize="@dimen/material_generic_title"
                     />
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_below="@+id/text_view_document_created_title"
@@ -299,14 +299,14 @@
                 android:gravity="center_vertical"
                 >
 
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     android:id="@+id/text_view_document_modified_title"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="@string/modified"
                     android:textSize="@dimen/material_generic_title"
                     />
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_below="@+id/text_view_document_modified_title"
@@ -331,14 +331,14 @@
                 android:gravity="center_vertical"
                 >
 
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     android:id="@+id/text_view_document_format_title"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="@string/format"
                     android:textSize="@dimen/material_generic_title"
                     />
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_below="@+id/text_view_document_format_title"
@@ -363,14 +363,14 @@
                 android:gravity="center_vertical"
                 >
 
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     android:id="@+id/text_view_document_pages_title"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="@string/pages"
                     android:textSize="@dimen/material_generic_title"
                     />
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_below="@+id/text_view_document_pages_title"
@@ -395,14 +395,14 @@
                 android:gravity="center_vertical"
                 >
 
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     android:id="@+id/text_view_document_optimized_title"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="@string/optimized"
                     android:textSize="@dimen/material_generic_title"
                     />
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_below="@+id/text_view_document_optimized_title"
@@ -427,14 +427,14 @@
                 android:gravity="center_vertical"
                 >
 
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     android:id="@+id/text_view_document_security_title"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="@string/security"
                     android:textSize="@dimen/material_generic_title"
                     />
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_below="@+id/text_view_document_security_title"
@@ -459,14 +459,14 @@
                 android:gravity="center_vertical"
                 >
 
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     android:id="@+id/text_view_document_paper_size_title"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="@string/paper_size"
                     android:textSize="@dimen/material_generic_title"
                     />
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_below="@+id/text_view_document_paper_size_title"
@@ -491,14 +491,14 @@
                 android:gravity="center_vertical"
                 >
 
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     android:id="@+id/text_view_document_size_title"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="@string/size"
                     android:textSize="@dimen/material_generic_title"
                     />
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_below="@+id/text_view_document_size_title"

--- a/app/src/main/res/layout/properties_general.xml
+++ b/app/src/main/res/layout/properties_general.xml
@@ -25,7 +25,7 @@
                 android:paddingBottom="@dimen/material_generic"
                 >
 
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_centerVertical="true"
@@ -43,14 +43,14 @@
                 android:gravity="center_vertical"
                 >
 
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     android:id="@+id/text_view_general_title_title"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="@string/title"
                     android:textSize="@dimen/material_generic_title"
                     />
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_below="@+id/text_view_general_title_title"
@@ -75,14 +75,14 @@
                 android:gravity="center_vertical"
                 >
 
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     android:id="@+id/text_view_general_artist_title"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="@string/artist"
                     android:textSize="@dimen/material_generic_title"
                     />
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_below="@+id/text_view_general_artist_title"
@@ -107,14 +107,14 @@
                 android:gravity="center_vertical"
                 >
 
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     android:id="@+id/text_view_general_album_title"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="@string/album"
                     android:textSize="@dimen/material_generic_title"
                     />
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_below="@+id/text_view_general_album_title"
@@ -139,14 +139,14 @@
                 android:gravity="center_vertical"
                 >
 
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     android:id="@+id/text_view_general_year_title"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="@string/year"
                     android:textSize="@dimen/material_generic_title"
                     />
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_below="@+id/text_view_general_year_title"
@@ -172,14 +172,14 @@
                 android:gravity="center_vertical"
                 >
 
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     android:id="@+id/text_view_general_duration_title"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="@string/duration"
                     android:textSize="@dimen/material_generic_title"
                     />
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_below="@+id/text_view_general_duration_title"
@@ -204,14 +204,14 @@
                 android:gravity="center_vertical"
                 >
 
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     android:id="@+id/text_view_general_comment_title"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="@string/comment"
                     android:textSize="@dimen/material_generic_title"
                     />
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_below="@+id/text_view_general_comment_title"
@@ -236,14 +236,14 @@
                 android:gravity="center_vertical"
                 >
 
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     android:id="@+id/text_view_general_container_title"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="@string/container"
                     android:textSize="@dimen/material_generic_title"
                     />
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_below="@+id/text_view_general_container_title"

--- a/app/src/main/res/layout/properties_image.xml
+++ b/app/src/main/res/layout/properties_image.xml
@@ -25,7 +25,7 @@
                 android:paddingBottom="@dimen/material_generic"
                 >
 
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_centerVertical="true"
@@ -43,14 +43,14 @@
                 android:gravity="center_vertical"
                 >
 
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     android:id="@+id/text_view_image_type_title"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="@string/image_type"
                     android:textSize="@dimen/material_generic_title"
                     />
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_below="@+id/text_view_image_type_title"
@@ -75,14 +75,14 @@
                 android:gravity="center_vertical"
                 >
 
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     android:id="@+id/text_view_image_width_title"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="@string/width"
                     android:textSize="@dimen/material_generic_title"
                     />
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_below="@+id/text_view_image_width_title"
@@ -107,14 +107,14 @@
                 android:gravity="center_vertical"
                 >
 
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     android:id="@+id/text_view_image_height_title"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="@string/height"
                     android:textSize="@dimen/material_generic_title"
                     />
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_below="@+id/text_view_image_height_title"
@@ -141,14 +141,14 @@
                 android:visibility="gone"
                 >
 
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     android:id="@+id/text_view_image_date_modified_title"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="@string/date_modified"
                     android:textSize="@dimen/material_generic_title"
                     />
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_below="@+id/text_view_image_date_modified_title"
@@ -175,14 +175,14 @@
                 android:visibility="gone"
                 >
 
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     android:id="@+id/text_view_image_software_title"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="@string/software"
                     android:textSize="@dimen/material_generic_title"
                     />
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_below="@+id/text_view_image_software_title"
@@ -209,14 +209,14 @@
                 android:visibility="gone"
                 >
 
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     android:id="@+id/text_view_image_creator_title"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="@string/creator"
                     android:textSize="@dimen/material_generic_title"
                     />
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_below="@+id/text_view_image_creator_title"
@@ -243,14 +243,14 @@
                 android:visibility="gone"
                 >
 
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     android:id="@+id/text_view_image_camera_brand_title"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="@string/camera_brand"
                     android:textSize="@dimen/material_generic_title"
                     />
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_below="@+id/text_view_image_camera_brand_title"
@@ -277,14 +277,14 @@
                 android:visibility="gone"
                 >
 
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     android:id="@+id/text_view_image_camera_model_title"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="@string/camera_model"
                     android:textSize="@dimen/material_generic_title"
                     />
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_below="@+id/text_view_image_camera_model_title"
@@ -311,14 +311,14 @@
                 android:visibility="gone"
                 >
 
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     android:id="@+id/text_view_image_date_taken_title"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="@string/date_taken"
                     android:textSize="@dimen/material_generic_title"
                     />
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_below="@+id/text_view_image_date_taken_title"
@@ -345,14 +345,14 @@
                 android:visibility="gone"
                 >
 
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     android:id="@+id/text_view_image_exposure_time_title"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="@string/exposure_time"
                     android:textSize="@dimen/material_generic_title"
                     />
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_below="@+id/text_view_image_exposure_time_title"
@@ -379,14 +379,14 @@
                 android:visibility="gone"
                 >
 
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     android:id="@+id/text_view_image_aperture_value_title"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="@string/aperture_value"
                     android:textSize="@dimen/material_generic_title"
                     />
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_below="@+id/text_view_image_aperture_value_title"
@@ -413,14 +413,14 @@
                 android:visibility="gone"
                 >
 
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     android:id="@+id/text_view_image_iso_title"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="@string/image_iso"
                     android:textSize="@dimen/material_generic_title"
                     />
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_below="@+id/text_view_image_iso_title"
@@ -447,14 +447,14 @@
                 android:visibility="gone"
                 >
 
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     android:id="@+id/text_view_image_flash_title"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="@string/flash_fired"
                     android:textSize="@dimen/material_generic_title"
                     />
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_below="@+id/text_view_image_flash_title"
@@ -481,14 +481,14 @@
                 android:visibility="gone"
                 >
 
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     android:id="@+id/text_view_image_focal_length_title"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="@string/focal_length"
                     android:textSize="@dimen/material_generic_title"
                     />
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_below="@+id/text_view_image_focal_length_title"

--- a/app/src/main/res/layout/properties_information.xml
+++ b/app/src/main/res/layout/properties_information.xml
@@ -25,7 +25,7 @@
                 android:paddingBottom="@dimen/material_generic"
                 >
 
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_centerVertical="true"
@@ -43,14 +43,14 @@
                 android:gravity="center_vertical"
                 >
 
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     android:id="@+id/text_view_name_title"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="@string/name"
                     android:textSize="@dimen/material_generic_title"
                     />
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     android:id="@+id/text_view_file_name"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
@@ -76,14 +76,14 @@
                 android:gravity="center_vertical"
                 >
 
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     android:id="@+id/text_view_type_title"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="@string/type"
                     android:textSize="@dimen/material_generic_title"
                     />
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     android:id="@+id/text_view_file_type"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
@@ -109,14 +109,14 @@
                 android:gravity="center_vertical"
                 >
 
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     android:id="@+id/text_view_size_title"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="@string/size"
                     android:textSize="@dimen/material_generic_title"
                     />
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     android:id="@+id/text_view_file_size"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
@@ -142,14 +142,14 @@
                 android:gravity="center_vertical"
                 >
 
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     android:id="@+id/text_view_location_title"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="@string/location"
                     android:textSize="@dimen/material_generic_title"
                     />
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     android:id="@+id/text_view_file_location"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
@@ -176,14 +176,14 @@
                 android:gravity="center_vertical"
                 >
 
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     android:id="@+id/text_view_accessed_title"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="@string/accessed"
                     android:textSize="@dimen/material_generic_title"
                     />
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     android:id="@+id/text_view_file_accessed"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
@@ -209,14 +209,14 @@
                 android:gravity="center_vertical"
                 >
 
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     android:id="@+id/text_view_modified_title"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="@string/modified"
                     android:textSize="@dimen/material_generic_title"
                     />
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     android:id="@+id/text_view_file_modified"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"

--- a/app/src/main/res/layout/properties_video.xml
+++ b/app/src/main/res/layout/properties_video.xml
@@ -25,7 +25,7 @@
                 android:paddingBottom="@dimen/material_generic"
                 >
 
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_centerVertical="true"
@@ -43,14 +43,14 @@
                 android:gravity="center_vertical"
                 >
 
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     android:id="@+id/text_view_video_dimensions_title"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="@string/dimensions"
                     android:textSize="@dimen/material_generic_title"
                     />
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_below="@+id/text_view_video_dimensions_title"
@@ -75,14 +75,14 @@
                 android:gravity="center_vertical"
                 >
 
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     android:id="@+id/text_view_video_codec_title"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="@string/codec"
                     android:textSize="@dimen/material_generic_title"
                     />
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_below="@+id/text_view_video_codec_title"
@@ -107,14 +107,14 @@
                 android:gravity="center_vertical"
                 >
 
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     android:id="@+id/text_view_video_frame_rate_title"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="@string/frame_rate"
                     android:textSize="@dimen/material_generic_title"
                     />
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_below="@+id/text_view_video_frame_rate_title"
@@ -139,14 +139,14 @@
                 android:gravity="center_vertical"
                 >
 
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     android:id="@+id/text_view_video_bitrate_title"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="@string/bitrate"
                     android:textSize="@dimen/material_generic_title"
                     />
-                <TextView
+                <androidx.appcompat.widget.AppCompatTextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_below="@+id/text_view_video_bitrate_title"

--- a/app/src/main/res/layout/rowlayout.xml
+++ b/app/src/main/res/layout/rowlayout.xml
@@ -18,6 +18,7 @@
     -->
 
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/second"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
@@ -28,8 +29,7 @@
     android:paddingStart="@dimen/minimal_material_padding"
     android:paddingRight="@dimen/minimal_material_padding"
     android:paddingEnd="@dimen/minimal_material_padding"
-    android:nextFocusRight="@id/properties"
-    >
+    android:nextFocusRight="@id/properties">
     <RelativeLayout
         android:id="@+id/icon_frame_grid"
         android:layout_width="@dimen/minimal_icon_parent_width"
@@ -44,28 +44,27 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/icon_margin_top"
             >
-            <ImageView
+            <androidx.appcompat.widget.AppCompatImageView
                 android:layout_width="@dimen/minimal_icon_size"
                 android:layout_height="@dimen/minimal_icon_size"
                 android:visibility="gone"
                 android:scaleType="centerCrop"
                 android:layout_gravity="center"
                 android:id="@+id/apk_icon"/>
-            <ImageView
+            <androidx.appcompat.widget.AppCompatImageView
                 android:id="@+id/picture_icon"
                 android:layout_width="@dimen/minimal_icon_size"
                 android:layout_height="@dimen/minimal_icon_size"
                 android:scaleType="centerCrop"
                 android:contentDescription="@string/icon" />
-            <ImageView
+            <androidx.appcompat.widget.AppCompatImageView
                 android:layout_width="40dp"
                 android:layout_height="40dp"
                 android:padding="8dp"
                 android:background="@drawable/circle_shape"
                 android:layout_gravity="center_vertical"
                 android:id="@+id/generic_icon"/>
-
-            <TextView
+            <androidx.appcompat.widget.AppCompatTextView
                 android:layout_width="@dimen/minimal_icon_size"
                 android:layout_height="@dimen/minimal_icon_size"
                 android:textSize="12dp"
@@ -78,12 +77,12 @@
                 />
         </FrameLayout>
 
-        <ImageView
+        <androidx.appcompat.widget.AppCompatImageView
             android:id="@+id/check_icon"
             android:layout_width="@dimen/tick_icon_size"
             android:layout_height="@dimen/tick_icon_size"
             android:padding="@dimen/check_icon_padding"
-            android:src="@drawable/ic_checkmark_selected"
+            app:srcCompat="@drawable/ic_checkmark_selected"
             android:layout_marginBottom="@dimen/check_icon_margin_bottom_right"
             android:layout_marginRight="@dimen/check_icon_margin_bottom_right"
             android:layout_marginEnd="@dimen/check_icon_margin_bottom_right"
@@ -93,7 +92,7 @@
             android:visibility="invisible" />
     </RelativeLayout>
 
-    <ImageButton
+    <androidx.appcompat.widget.AppCompatImageButton
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:id="@+id/properties"
@@ -105,7 +104,7 @@
         android:layout_marginStart="16dp"
         android:padding="8dp"
         android:clickable="true"
-        android:src="@drawable/ic_more_vert_black_48dp"
+        app:srcCompat="@drawable/ic_more_vert_black_48dp"
         android:nextFocusLeft="@id/second"
         android:focusable="true"
         />
@@ -140,7 +139,7 @@
             android:layout_below="@id/firstline"
             android:layout_marginTop="5dp">
 
-            <TextView
+            <androidx.appcompat.widget.AppCompatTextView
                 android:id="@+id/date"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
@@ -165,7 +164,7 @@
                 android:textSize="13sp"
                 android:visibility="gone" />
 
-            <TextView
+            <androidx.appcompat.widget.AppCompatTextView
                 android:id="@+id/secondLine"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
@@ -175,7 +174,7 @@
                 android:textColor="?android:attr/textColorTertiary"
                 />
 
-            <TextView
+            <androidx.appcompat.widget.AppCompatTextView
                 android:id="@+id/permis"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"

--- a/app/src/main/res/layout/search.xml
+++ b/app/src/main/res/layout/search.xml
@@ -46,7 +46,7 @@
         android:id="@+id/editscroll"
         android:layout_height="match_parent"
         android:fillViewport="true">
-        <EditText
+        <androidx.appcompat.widget.AppCompatEditText
             android:id="@+id/fname"
             android:layout_width="match_parent"
             android:layout_height="match_parent"

--- a/app/src/main/res/layout/search_row_item.xml
+++ b/app/src/main/res/layout/search_row_item.xml
@@ -20,7 +20,7 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
-        <TextView
+        <androidx.appcompat.widget.AppCompatTextView
             android:id="@+id/searchItemFileNameTV"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
@@ -35,7 +35,7 @@
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintVertical_bias="0" />
 
-        <TextView
+        <androidx.appcompat.widget.AppCompatTextView
             android:id="@+id/searchItemFilePathTV"
             android:layout_width="0dp"
             android:layout_height="wrap_content"

--- a/app/src/main/res/layout/simplerow.xml
+++ b/app/src/main/res/layout/simplerow.xml
@@ -26,7 +26,7 @@
     android:background="?selectableItemBackground"
     android:padding="6dip">
 
-    <ImageView
+    <androidx.appcompat.widget.AppCompatTextView
         android:id="@+id/icon"
         android:padding="10dip"
         android:layout_width="50dip"
@@ -36,7 +36,7 @@
         android:layout_gravity="center"
         android:contentDescription="@string/icon" />
 
-    <TextView
+    <androidx.appcompat.widget.AppCompatTextView
         android:id="@+id/firstline"
         android:layout_width="wrap_content"
         android:layout_toRightOf="@id/icon"

--- a/app/src/main/res/layout/smb_computers_row.xml
+++ b/app/src/main/res/layout/smb_computers_row.xml
@@ -7,7 +7,7 @@
     android:background="?selectableItemBackground"
     android:padding="@dimen/material_generic">
 
-    <ImageView
+    <androidx.appcompat.widget.AppCompatTextView
         android:id="@+id/icon"
         android:padding="10dp"
         android:layout_width="48dip"
@@ -21,7 +21,7 @@
     android:orientation="vertical"
     android:layout_toRightOf="@id/icon"
     android:layout_height="match_parent">
-    <TextView
+    <androidx.appcompat.widget.AppCompatTextView
         android:id="@+id/firstline"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
@@ -33,7 +33,7 @@
         android:gravity="center_vertical"
 
         />
-    <TextView
+    <androidx.appcompat.widget.AppCompatTextView
         android:id="@+id/secondLine"
         android:textColor="?android:attr/textColorTertiary"
         android:layout_width="wrap_content"

--- a/app/src/main/res/layout/smb_dialog.xml
+++ b/app/src/main/res/layout/smb_dialog.xml
@@ -104,7 +104,7 @@
         android:layout_height="wrap_content"
         android:text="@string/disableIpcSignature" />
 
-    <TextView
+    <androidx.appcompat.widget.AppCompatTextView
         android:layout_width="wrap_content"
         android:id="@+id/wanthelp"
         android:layout_height="wrap_content"

--- a/app/src/main/res/layout/snackbar_view.xml
+++ b/app/src/main/res/layout/snackbar_view.xml
@@ -45,7 +45,7 @@
             android:layout_height="match_parent"
             android:descendantFocusability="afterDescendants">
 
-            <TextView
+            <androidx.appcompat.widget.AppCompatTextView
                 android:id="@+id/snackBarTextTV"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
@@ -62,7 +62,7 @@
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent" />
 
-            <Button
+            <androidx.appcompat.widget.AppCompatButton
                 android:id="@+id/snackBarCancelButton"
                 style="@style/Widget.AppCompat.Button.ButtonBar.AlertDialog"
                 android:layout_width="wrap_content"
@@ -81,7 +81,7 @@
                 android:background="@drawable/ripple_focusable"
                 />
 
-            <Button
+            <androidx.appcompat.widget.AppCompatButton
                 android:id="@+id/snackBarActionButton"
                 style="@style/Widget.AppCompat.Button.ButtonBar.AlertDialog"
                 android:layout_width="wrap_content"

--- a/app/src/main/res/layout/tabfragment.xml
+++ b/app/src/main/res/layout/tabfragment.xml
@@ -60,11 +60,11 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintRight_toRightOf="parent"
         />
-    <ImageView
+    <androidx.appcompat.widget.AppCompatImageView
         android:id="@+id/placeholder_trash_bottom"
         android:layout_width="@dimen/zero_dp"
         android:layout_height="@dimen/material_generic_large"
-        android:src="@drawable/ic_drag_to_trash"
+        app:srcCompat="@drawable/ic_drag_to_trash"
         android:visibility="gone"
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintBottom_toBottomOf="parent"

--- a/app/src/main/res/layout/utilities_alias_layout.xml
+++ b/app/src/main/res/layout/utilities_alias_layout.xml
@@ -4,7 +4,7 @@
     android:layout_height="wrap_content"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:padding="@dimen/material_generic">
-    <TextView
+    <androidx.appcompat.widget.AppCompatTextView
         android:id="@+id/title"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
@@ -15,7 +15,7 @@
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintLeft_toLeftOf="parent"
         />
-    <TextView
+    <androidx.appcompat.widget.AppCompatTextView
         android:id="@+id/content"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
@@ -35,7 +35,7 @@
         app:layout_constraintTop_toBottomOf="@id/content"
         app:layout_constraintRight_toRightOf="parent"
         >
-        <Button
+        <androidx.appcompat.widget.AppCompatButton
             android:id="@+id/cancel_button"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
@@ -46,7 +46,7 @@
             android:layout_marginRight="@dimen/material_generic"
             android:layout_marginEnd="@dimen/material_generic"
             />
-        <Button
+        <androidx.appcompat.widget.AppCompatButton
             android:id="@+id/download_button"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/app/src/test/java/com/amaze/filemanager/asynchronous/asynctasks/DbViewerTaskTest.java
+++ b/app/src/test/java/com/amaze/filemanager/asynchronous/asynctasks/DbViewerTaskTest.java
@@ -50,8 +50,8 @@ import android.database.sqlite.SQLiteDatabase;
 import android.os.Build;
 import android.view.View;
 import android.webkit.WebView;
-import android.widget.TextView;
 
+import androidx.appcompat.widget.AppCompatTextView;
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
@@ -76,7 +76,8 @@ public class DbViewerTaskTest {
   @Test
   public void testOnPreExecute() {
     DbViewerFragment mock = mock(DbViewerFragment.class);
-    TextView loadingText = new TextView(ApplicationProvider.getApplicationContext());
+    AppCompatTextView loadingText =
+        new AppCompatTextView(ApplicationProvider.getApplicationContext());
     mock.loadingText = loadingText;
     mock.databaseViewerActivity = mock(DatabaseViewerActivity.class);
     mock.loadingText.setVisibility(View.GONE);
@@ -111,7 +112,8 @@ public class DbViewerTaskTest {
     assertNotNull(sqLiteDatabase);
 
     DbViewerFragment mock = mock(DbViewerFragment.class);
-    TextView loadingText = new TextView(ApplicationProvider.getApplicationContext());
+    AppCompatTextView loadingText =
+        new AppCompatTextView(ApplicationProvider.getApplicationContext());
     mock.loadingText = loadingText;
     Cursor schemaCursor = sqLiteDatabase.rawQuery("PRAGMA table_info('users');", null);
     Cursor contentCursor = sqLiteDatabase.rawQuery("SELECT * FROM users", null);
@@ -141,7 +143,8 @@ public class DbViewerTaskTest {
     assertNotNull(sqLiteDatabase);
 
     DbViewerFragment mock = mock(DbViewerFragment.class);
-    TextView loadingText = new TextView(ApplicationProvider.getApplicationContext());
+    AppCompatTextView loadingText =
+        new AppCompatTextView(ApplicationProvider.getApplicationContext());
     mock.loadingText = loadingText;
     mock.databaseViewerActivity = mock(DatabaseViewerActivity.class);
     mock.loadingText.setVisibility(View.GONE);

--- a/app/src/test/java/com/amaze/filemanager/asynchronous/asynctasks/ssh/PemToKeyPairObservableRsaTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/asynchronous/asynctasks/ssh/PemToKeyPairObservableRsaTest.kt
@@ -25,7 +25,7 @@ import android.os.Build.VERSION_CODES
 import android.os.Build.VERSION_CODES.KITKAT
 import android.os.Build.VERSION_CODES.N
 import android.os.Build.VERSION_CODES.P
-import android.widget.EditText
+import androidx.appcompat.widget.AppCompatEditText
 import androidx.lifecycle.Lifecycle
 import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -232,7 +232,7 @@ class PemToKeyPairObservableRsaTest {
                 )
                 dialog.customView?.run {
                     lap++
-                    findViewById<EditText>(R.id.singleedittext_input)?.run {
+                    findViewById<AppCompatEditText>(R.id.singleedittext_input)?.run {
                         this.setText("test")
                     } ?: fail("Text field not found")
                 } ?: fail("No view found at dialog")

--- a/app/src/test/java/com/amaze/filemanager/ui/activities/TextEditorActivityTest.java
+++ b/app/src/test/java/com/amaze/filemanager/ui/activities/TextEditorActivityTest.java
@@ -50,8 +50,8 @@ import android.content.Intent;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Environment;
-import android.widget.TextView;
 
+import androidx.appcompat.widget.AppCompatEditText;
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
@@ -62,7 +62,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 public class TextEditorActivityTest {
 
   private final String fileContents = "fsdfsdfs";
-  private TextView text;
+  private AppCompatEditText text;
 
   @After
   public void tearDown() {

--- a/app/src/test/java/com/amaze/filemanager/ui/views/WarnableTextInputValidatorTest.java
+++ b/app/src/test/java/com/amaze/filemanager/ui/views/WarnableTextInputValidatorTest.java
@@ -37,8 +37,6 @@ import com.amaze.filemanager.R;
 
 import android.content.Context;
 import android.os.Build;
-import android.widget.Button;
-import android.widget.EditText;
 
 import androidx.appcompat.widget.AppCompatButton;
 import androidx.appcompat.widget.AppCompatEditText;
@@ -59,10 +57,10 @@ public class WarnableTextInputValidatorTest {
 
   @Test
   public void testValidate() {
-    EditText textfield = new AppCompatEditText(context);
+    AppCompatEditText textfield = new AppCompatEditText(context);
     WarnableTextInputLayout layout =
         new WarnableTextInputLayout(context, Robolectric.buildAttributeSet().build());
-    Button button = new AppCompatButton(context);
+    AppCompatButton button = new AppCompatButton(context);
     WarnableTextInputValidator.OnTextValidate validator =
         text ->
             ("Pass".equals(text))


### PR DESCRIPTION
## Description

Regressions found when launching Amaze back in Android 4.4 devices. Seems moving the widgets away from original to AppCompat ones could solve the problem.

Back to #3890 it was caused by `ImageView`, but I think it may be a good idea to move the others altogether to reduce possibility of tech debts in the future.

#### Issue tracker   
Fixes #3890

#### Manual tests
- [x] Done  

Devices:
- GPD XD Gen 1 running LegacyROM (4.4.4)
- Fairphone 3 running LineageOS 20 (13)
Everything should continue function as normal

#### Build tasks success  
Successfully running following tasks on local:
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`

#### Related PR  
Related to PR #3737
