### PR TITLE
Correct class cast at color selection dialog

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/ui/dialogs/ColorPickerDialog.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/dialogs/ColorPickerDialog.java
@@ -46,6 +46,7 @@ import android.widget.RadioButton;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.StringRes;
+import androidx.appcompat.widget.AppCompatButton;
 import androidx.appcompat.widget.AppCompatTextView;
 import androidx.core.util.Pair;
 import androidx.preference.Preference.BaseSavedState;
@@ -249,9 +250,9 @@ public class ColorPickerDialog extends PreferenceDialogFragmentCompat {
         ((UserColorPreferences) requireArguments().getParcelable(ARG_COLOR_PREF)).getAccent();
 
     // Button views
-    ((AppCompatTextView) dialog.findViewById(res.getIdentifier("button1", "id", "android")))
+    ((AppCompatButton) dialog.findViewById(res.getIdentifier("button1", "id", "android")))
         .setTextColor(accentColor);
-    ((AppCompatTextView) dialog.findViewById(res.getIdentifier("button2", "id", "android")))
+    ((AppCompatButton) dialog.findViewById(res.getIdentifier("button2", "id", "android")))
         .setTextColor(accentColor);
 
     return dialog;

--- a/app/src/test/java/com/amaze/filemanager/ui/dialogs/ColorPickerDialogTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/ui/dialogs/ColorPickerDialogTest.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2014-2023 Arpit Khurana <arpitkh96@gmail.com>, Vishal Nehra <vishalmeham2@gmail.com>,
+ * Emmanuel Messulam<emmanuelbendavid@gmail.com>, Raymond Lai <airwave209gt at gmail.com> and Contributors.
+ *
+ * This file is part of Amaze File Manager.
+ *
+ * Amaze File Manager is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.amaze.filemanager.ui.dialogs
+
+import android.os.Build.VERSION_CODES
+import android.os.Build.VERSION_CODES.KITKAT
+import android.os.Build.VERSION_CODES.P
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.amaze.filemanager.application.AppConfig
+import com.amaze.filemanager.shadows.ShadowMultiDex
+import com.amaze.filemanager.test.ShadowTabHandler
+import com.amaze.filemanager.ui.colors.ColorPreferenceHelper
+import com.amaze.filemanager.ui.fragments.preferencefragments.PreferencesConstants
+import com.amaze.filemanager.ui.theme.AppTheme
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+/**
+ * Tests for [ColorPickerDialog].
+ */
+@RunWith(AndroidJUnit4::class)
+@Config(
+    shadows = [ShadowMultiDex::class, ShadowTabHandler::class],
+    sdk = [KITKAT, P, VERSION_CODES.R]
+)
+class ColorPickerDialogTest {
+
+    /**
+     * Tests [ColorPickerDialog.onCreateDialog] as sanity check.
+     */
+    @Test
+    fun testCreateDialog() {
+        val dialog = ColorPickerDialog.newInstance(
+            PreferencesConstants.PRESELECTED_CONFIGS,
+            ColorPreferenceHelper.randomize(AppConfig.getInstance()),
+            AppTheme.SYSTEM
+        )
+        assertNotNull(dialog)
+    }
+}


### PR DESCRIPTION
## Description
To fix the incorrect class cast at color selection dialog.

#### Issue tracker   
Fixes #3900

#### Automatic tests
<!-- remember to do manual testing when making UI changes! -->
- [x] Added test cases
  
#### Manual tests
- [x] Done  
  
Device:
- Galaxy Nexus emulator running Android 4.4
- Pixel 6 emulator running Android 13

There should be no crash when choosing UI colors, either preset, custom or random colors.

#### Build tasks success  
Successfully running following tasks on local:
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`
