### PR TITLE
Fixes #3938

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -816,6 +816,5 @@ You only need to do this once, until the next time you select a new location for
     <string name="complete_paste_warning">Please complete paste operation first</string>
     <string name="same_dir_move_error">Destination and source folder shouldn\'t match to move.</string>
     <string name="checking_conflicts">Checking for conflicts</string>
-    <string name="same_dir_overwrite_error">Destination and source folder shouldn\'t match to overwrite.</string>
 </resources>
 


### PR DESCRIPTION
<!-- 
Read this first:
To open a pull request read this file,
uncomment the corresponding lines and 
complete them.
-->

## Description
- Fixed renaming issue while pasting conflicting files multiple times in same set of two directories.
- Disabled overwrite button if pasting in same directory. In previous implementation, we were showing users a Toast message if they try to overwrite a file in same directory. This new method seems more concise and more expressive.
- Set dialog shown during conflict resolution non-cancellable. This change ensures that users won't accidentally lose progress if they tap elsewhere on the screen.

#### Issue tracker   
<!-- Fixes will automatically close the related issue -->
Fixes #3938
<!-- Addresses won't automatically close the related issue -->
<!-- Addresses # -->

#### Automatic tests
<!-- remember to do manual testing when making UI changes! -->
- [ ] Added test cases
  
#### Manual tests
- [x] Done  
  
<!-- If yes, -->
- Device: Samsung Galaxy A13
- OS: Android 13

#### Build tasks success  
<!-- run these! -->
Successfully running following tasks on local:
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`

<!-- If there are related PRs please add them here -->
#### Related PR  
Related to PR #3898