### PR TITLE
Fixed domain, username & password extraction logic for URLs.

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/ui/dialogs/SmbConnectDialog.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/dialogs/SmbConnectDialog.java
@@ -265,15 +265,18 @@ public class SmbConnectDialog extends DialogFragment {
           int domainDelim = !inf.contains(";") ? 0 : inf.indexOf(';');
           domainp = inf.substring(0, domainDelim);
           if (domainp != null && domainp.length() > 0) inf = inf.substring(domainDelim + 1);
-          userp = inf.substring(0, inf.indexOf(":"));
-          try {
-            passp =
-                PasswordUtil.INSTANCE.decryptPassword(
-                    context, inf.substring(inf.indexOf(COLON) + 1), URL_SAFE);
-            passp = decode(passp, Charsets.UTF_8.name());
-          } catch (GeneralSecurityException | IOException e) {
-            LOG.warn("Error decrypting password", e);
-            passp = "";
+          if (!inf.contains(":")) userp = inf;
+          else {
+            userp = inf.substring(0, inf.indexOf(COLON));
+            try {
+              passp =
+                  PasswordUtil.INSTANCE.decryptPassword(
+                      context, inf.substring(inf.indexOf(COLON) + 1), URL_SAFE);
+              passp = decode(passp, Charsets.UTF_8.name());
+            } catch (GeneralSecurityException | IOException e) {
+              LOG.warn("Error decrypting password", e);
+              passp = "";
+            }
           }
           domain.setText(domainp);
           user.setText(userp);


### PR DESCRIPTION
<!-- 
Read this first:
To open a pull request read this file,
uncomment the corresponding lines and 
complete them.
-->

## Description
Fixes #3777 

Fixed domain, username & password extraction logic for URLs of the following formats:
```
https://domain;username:password@sub.example.com/resource
https://domain;username@sub.example.com/resource
https://username:password@sub.example.com/resource
```

#### Issue tracker   
<!-- Fixes will automatically close the related issue -->
<!-- Fixes # -->
<!-- Addresses won't automatically close the related issue -->
<!-- Addresses # -->

#### Automatic tests
<!-- remember to do manual testing when making UI changes! -->
- [ ] Added test cases
  
#### Manual tests
- [ ] Done  
  
<!-- If yes, -->
<!-- 
- Device:
- OS:
-->

#### Build tasks success  
<!-- run these! -->
Successfully running following tasks on local:
- [ ] `./gradlew assembledebug`
- [ ] `./gradlew spotlessCheck`

<!-- If there are related PRs please add them here -->
<!--
#### Related PR  
Related to PR #
-->