### PR TITLE
Fix ClassCastException at SmbSearchDialog with SMB SubnetScanner

### DIFF
--- a/app/src/main/res/layout/smb_computers_row.xml
+++ b/app/src/main/res/layout/smb_computers_row.xml
@@ -4,10 +4,11 @@
     android:minHeight="50dip"
     android:layout_height="wrap_content"
     android:clickable="true"
+    android:focusable="true"
     android:background="?selectableItemBackground"
     android:padding="@dimen/material_generic">
 
-    <androidx.appcompat.widget.AppCompatTextView
+    <androidx.appcompat.widget.AppCompatImageView
         android:id="@+id/icon"
         android:padding="10dp"
         android:layout_width="48dip"


### PR DESCRIPTION
OK, I too think it should have been fixed somewhere else, but now I got one... whatever.

## Description
Icon should be androidx.appcompat.widget.AppCompatImageView instead.

#### Issue tracker   

#### Manual tests
- [x] Done  
  
- Device: Pixel 7 emulator
- OS: Android 14
SMB search dialog should not crash with ClassCastException error when opening.

#### Build tasks success  
Successfully running following tasks on local:
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`