### PR TITLE
Bug fix: #3767 `StringIndexOutOfBoundsException` on `HybridFile#getParent`

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/filesystem/HybridFile.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/HybridFile.java
@@ -555,7 +555,11 @@ public class HybridFile {
         if (thisPath.isEmpty() || pathSegments.isEmpty()) return null;
 
         String currentName = pathSegments.get(pathSegments.size() - 1);
-        String parent = thisPath.substring(0, thisPath.lastIndexOf(currentName));
+        int currentNameStartIndex = thisPath.lastIndexOf(currentName);
+        if (currentNameStartIndex < 0) {
+          return null;
+        }
+        String parent = thisPath.substring(0, currentNameStartIndex);
         if (ArraysKt.any(ANDROID_DATA_DIRS, dir -> parent.endsWith(dir + "/"))) {
           return FileProperties.unmapPathForApi30OrAbove(parent);
         } else {


### PR DESCRIPTION
<!-- 
Read this first:
To open a pull request read this file,
uncomment the corresponding lines and 
complete them.
-->

## Description

Fix `StringIndexOutOfBoundsException` by checking if the end index given to the `substring()` function is negative. This can happen if the `currentName` does not occur in `thisPath` which causes the `lastIndexOf()` function to return -1.

#### Issue tracker   
<!-- Fixes will automatically close the related issue -->
Fixes  #3767 
<!-- Addresses won't automatically close the related issue -->
<!-- Addresses # -->

#### Automatic tests
<!-- remember to do manual testing when making UI changes! -->
- [ ] Added test cases
  
#### Manual tests
- [ ] Done  
  
<!-- If yes, -->
<!-- 
- Device:
- OS:
-->

#### Build tasks success  
<!-- run these! -->
Successfully running following tasks on local:
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`

<!-- If there are related PRs please add them here -->
<!--
#### Related PR  
Related to PR #
-->