### PR TITLE
Feature: floating action button for selection of multiple files

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/adapters/RecyclerAdapter.java
+++ b/app/src/main/java/com/amaze/filemanager/adapters/RecyclerAdapter.java
@@ -798,7 +798,8 @@ public class RecyclerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
                 || (dragAndDropPreference == PreferencesConstants.PREFERENCE_DRAG_TO_MOVE_COPY
                     && getItemsDigested().get(holder.getAdapterPosition()).getChecked()
                         != ListItem.CHECKED)) {
-              toggleChecked(holder.getAdapterPosition(), holder.checkImageView);
+              mainFragment.registerListItemChecked(
+                  holder.getAdapterPosition(), holder.checkImageView);
             }
             initDragListener(position, p1, holder);
           }
@@ -1012,7 +1013,8 @@ public class RecyclerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
                 || (dragAndDropPreference == PreferencesConstants.PREFERENCE_DRAG_TO_MOVE_COPY
                     && getItemsDigested().get(holder.getAdapterPosition()).getChecked()
                         != ListItem.CHECKED)) {
-              toggleChecked(holder.getAdapterPosition(), holder.checkImageViewGrid);
+              mainFragment.registerListItemChecked(
+                  holder.getAdapterPosition(), holder.checkImageViewGrid);
             }
             initDragListener(position, p1, holder);
           }

--- a/app/src/main/java/com/amaze/filemanager/ui/ItemPopupMenu.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/ItemPopupMenu.java
@@ -248,7 +248,7 @@ public class ItemPopupMenu extends PopupMenu implements PopupMenu.OnMenuItemClic
             mainActivity.getCurrentMainFragment().getMainFragmentViewModel().getCurrentPath());
         return true;
       case R.id.return_select:
-        mainFragment.returnIntentResults(rowItem.generateBaseFile());
+        mainFragment.returnIntentResults(new HybridFileParcelable[] {rowItem.generateBaseFile()});
         return true;
     }
     return false;

--- a/app/src/main/java/com/amaze/filemanager/ui/activities/MainActivity.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/activities/MainActivity.java
@@ -71,6 +71,7 @@ import com.afollestad.materialdialogs.folderselector.FolderChooserDialog;
 import com.amaze.filemanager.BuildConfig;
 import com.amaze.filemanager.LogHelper;
 import com.amaze.filemanager.R;
+import com.amaze.filemanager.adapters.data.LayoutElementParcelable;
 import com.amaze.filemanager.adapters.data.StorageDirectoryParcelable;
 import com.amaze.filemanager.application.AppConfig;
 import com.amaze.filemanager.asynchronous.SaveOnDataUtilsChange;
@@ -233,6 +234,8 @@ public class MainActivity extends PermissionsActivity
 
   private SpeedDialView floatingActionButton;
 
+  private SpeedDialView fabConfirmSelection;
+
   public MainActivityHelper mainActivityHelper;
 
   public int operation = -1;
@@ -392,6 +395,8 @@ public class MainActivity extends PermissionsActivity
     }
 
     checkForExternalIntent(intent);
+
+    initialiseFabConfirmSelection();
 
     drawer.setDrawerIndicatorEnabled();
 
@@ -1904,6 +1909,52 @@ public class MainActivity extends PermissionsActivity
     }
 
     return floatingActionButton.addActionItem(builder.create());
+  }
+
+  private void initialiseFabConfirmSelection() {
+    fabConfirmSelection = findViewById(R.id.fabs_confirm_selection);
+    fabConfirmSelection.hide();
+    if (mReturnIntent) {
+      int colorAccent = getAccent();
+      fabConfirmSelection.setMainFabClosedBackgroundColor(colorAccent);
+      fabConfirmSelection.setMainFabOpenedBackgroundColor(colorAccent);
+
+      fabConfirmSelection.setOnChangeListener(
+          new SpeedDialView.OnChangeListener() {
+            @Override
+            public boolean onMainActionSelected() {
+              if (getCurrentMainFragment() != null
+                  && getCurrentMainFragment().getMainFragmentViewModel() != null) {
+                ArrayList<LayoutElementParcelable> checkedItems =
+                    getCurrentMainFragment().getMainFragmentViewModel().getCheckedItems();
+                ArrayList<HybridFileParcelable> baseFiles = new ArrayList<>();
+                for (LayoutElementParcelable item : checkedItems) {
+                  baseFiles.add(item.generateBaseFile());
+                }
+                getCurrentMainFragment()
+                    .returnIntentResults(baseFiles.toArray(new HybridFileParcelable[0]));
+              }
+              return false;
+            }
+
+            @Override
+            public void onToggleChanged(boolean isOpen) {}
+          });
+    }
+  }
+
+  /**
+   * If a intent should be returned, shows the floating action button which confirms the selection
+   */
+  public void showFabConfirmSelection() {
+    if (mReturnIntent) {
+      fabConfirmSelection.show();
+    }
+  }
+
+  /** Hides the floating action button which confirms the selection */
+  public void hideFabConfirmSelection() {
+    fabConfirmSelection.hide();
   }
 
   public boolean copyToClipboard(Context context, String text) {

--- a/app/src/main/java/com/amaze/filemanager/ui/activities/MainActivity.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/activities/MainActivity.java
@@ -586,7 +586,11 @@ public class MainActivity extends PermissionsActivity
     if (actionIntent.equals(Intent.ACTION_GET_CONTENT)) {
       // file picker intent
       mReturnIntent = true;
-      Toast.makeText(this, getString(R.string.pick_a_file), Toast.LENGTH_LONG).show();
+      String text =
+          intent.getBooleanExtra(Intent.EXTRA_ALLOW_MULTIPLE, false)
+              ? getString(R.string.pick_files)
+              : getString(R.string.pick_a_file);
+      Toast.makeText(this, text, Toast.LENGTH_LONG).show();
 
       // disable screen rotation just for convenience purpose
       // TODO: Support screen rotation when picking file

--- a/app/src/main/java/com/amaze/filemanager/ui/fragments/MainFragment.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/fragments/MainFragment.java
@@ -473,7 +473,23 @@ public class MainFragment extends Fragment
         requireMainActivity().getActionModeHelper().setActionMode(null);
       } else {
         // the first {goback} item if back navigation is enabled
-        adapter.toggleChecked(position, imageView);
+        MainActivity mainActivity = requireMainActivity();
+        if (mainActivity.mReturnIntent
+            && !mainActivity.getIntent().getBooleanExtra(Intent.EXTRA_ALLOW_MULTIPLE, false)) {
+          // Only one item should be checked
+          ArrayList<Integer> checkedItemsIndex = adapter.getCheckedItemsIndex();
+          if (checkedItemsIndex.contains(position)) {
+            // The clicked item was the only item checked so it can be unchecked
+            adapter.toggleChecked(position, imageView);
+          } else {
+            // The clicked item was not checked so we have to uncheck all currently checked items
+            for (Integer index : checkedItemsIndex) {
+              adapter.toggleChecked(index, imageView);
+            }
+            // Now we check the clicked item
+            adapter.toggleChecked(position, imageView);
+          }
+        } else adapter.toggleChecked(position, imageView);
       }
     } else {
       if (isBackButton) {

--- a/app/src/main/java/com/amaze/filemanager/ui/fragments/MainFragment.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/fragments/MainFragment.java
@@ -473,23 +473,7 @@ public class MainFragment extends Fragment
         requireMainActivity().getActionModeHelper().setActionMode(null);
       } else {
         // the first {goback} item if back navigation is enabled
-        MainActivity mainActivity = requireMainActivity();
-        if (mainActivity.mReturnIntent
-            && !mainActivity.getIntent().getBooleanExtra(Intent.EXTRA_ALLOW_MULTIPLE, false)) {
-          // Only one item should be checked
-          ArrayList<Integer> checkedItemsIndex = adapter.getCheckedItemsIndex();
-          if (checkedItemsIndex.contains(position)) {
-            // The clicked item was the only item checked so it can be unchecked
-            adapter.toggleChecked(position, imageView);
-          } else {
-            // The clicked item was not checked so we have to uncheck all currently checked items
-            for (Integer index : checkedItemsIndex) {
-              adapter.toggleChecked(index, imageView);
-            }
-            // Now we check the clicked item
-            adapter.toggleChecked(position, imageView);
-          }
-        } else adapter.toggleChecked(position, imageView);
+        registerListItemChecked(position, imageView);
       }
     } else {
       if (isBackButton) {
@@ -542,6 +526,26 @@ public class MainFragment extends Fragment
         }
       }
     }
+  }
+
+  public void registerListItemChecked(int position, AppCompatImageView imageView) {
+    MainActivity mainActivity = requireMainActivity();
+    if (mainActivity.mReturnIntent
+        && !mainActivity.getIntent().getBooleanExtra(Intent.EXTRA_ALLOW_MULTIPLE, false)) {
+      // Only one item should be checked
+      ArrayList<Integer> checkedItemsIndex = adapter.getCheckedItemsIndex();
+      if (checkedItemsIndex.contains(position)) {
+        // The clicked item was the only item checked so it can be unchecked
+        adapter.toggleChecked(position, imageView);
+      } else {
+        // The clicked item was not checked so we have to uncheck all currently checked items
+        for (Integer index : checkedItemsIndex) {
+          adapter.toggleChecked(index, imageView);
+        }
+        // Now we check the clicked item
+        adapter.toggleChecked(position, imageView);
+      }
+    } else adapter.toggleChecked(position, imageView);
   }
 
   public void updateTabWithDb(Tab tab) {

--- a/app/src/main/java/com/amaze/filemanager/ui/fragments/MainFragment.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/fragments/MainFragment.java
@@ -34,7 +34,9 @@ import static com.amaze.filemanager.ui.fragments.preferencefragments.Preferences
 import java.io.File;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -88,6 +90,8 @@ import com.amaze.filemanager.utils.Utils;
 import com.google.android.material.appbar.AppBarLayout;
 
 import android.content.BroadcastReceiver;
+import android.content.ClipData;
+import android.content.ClipDescription;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
@@ -513,7 +517,8 @@ public class MainFragment extends Fragment
         } else {
           if (getMainActivity().mReturnIntent) {
             // are we here to return an intent to another app
-            returnIntentResults(layoutElementParcelable.generateBaseFile());
+            returnIntentResults(
+                new HybridFileParcelable[] {layoutElementParcelable.generateBaseFile()});
           } else {
             layoutElementParcelable.generateBaseFile().openFile(getMainActivity(), false);
             DataUtils.getInstance().addHistoryFile(layoutElementParcelable.desc);
@@ -533,29 +538,71 @@ public class MainFragment extends Fragment
    * Returns the intent with uri corresponding to specific {@link HybridFileParcelable} back to
    * external app
    */
-  public void returnIntentResults(HybridFileParcelable baseFile) {
-
+  public void returnIntentResults(HybridFileParcelable[] baseFiles) {
     requireMainActivity().mReturnIntent = false;
+    HashMap<HybridFileParcelable, Uri> resultUris = new HashMap<>();
+    ArrayList<String> failedPaths = new ArrayList<>();
 
-    @Nullable Uri mediaStoreUri = Utils.getUriForBaseFile(requireActivity(), baseFile);
-    if (mediaStoreUri != null) {
-      LOG.debug(
-          mediaStoreUri + "\t" + MimeTypes.getMimeType(baseFile.getPath(), baseFile.isDirectory()));
+    for (HybridFileParcelable baseFile : baseFiles) {
+      @Nullable Uri resultUri = Utils.getUriForBaseFile(requireActivity(), baseFile);
+      if (resultUri != null) {
+        resultUris.put(baseFile, resultUri);
+        LOG.debug(
+            resultUri + "\t" + MimeTypes.getMimeType(baseFile.getPath(), baseFile.isDirectory()));
+      } else {
+        failedPaths.add(baseFile.getPath());
+      }
+    }
+
+    if (!resultUris.isEmpty()) {
       Intent intent = new Intent();
       intent.setFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
-      intent.setAction(Intent.ACTION_SEND);
+      if (resultUris.size() == 1) {
+        intent.setAction(Intent.ACTION_SEND);
+        Map.Entry<HybridFileParcelable, Uri> result = resultUris.entrySet().iterator().next();
+        Uri resultUri = result.getValue();
+        HybridFileParcelable resultBaseFile = result.getKey();
 
-      if (requireMainActivity().mRingtonePickerIntent) {
-        intent.setDataAndType(
-            mediaStoreUri, MimeTypes.getMimeType(baseFile.getPath(), baseFile.isDirectory()));
-        intent.putExtra(RingtoneManager.EXTRA_RINGTONE_PICKED_URI, mediaStoreUri);
+        if (requireMainActivity().mRingtonePickerIntent) {
+          intent.setDataAndType(
+              resultUri,
+              MimeTypes.getMimeType(resultBaseFile.getPath(), resultBaseFile.isDirectory()));
+          intent.putExtra(RingtoneManager.EXTRA_RINGTONE_PICKED_URI, resultUri);
+        } else {
+          LOG.debug("pickup file");
+          intent.setDataAndType(resultUri, MimeTypes.getExtension(resultBaseFile.getPath()));
+        }
+
       } else {
-        LOG.debug("pickup file");
-        intent.setDataAndType(mediaStoreUri, MimeTypes.getExtension(baseFile.getPath()));
+        LOG.debug("pickup multiple files");
+        // Build ClipData
+        ArrayList<ClipData.Item> uriDataClipItems = new ArrayList<>();
+        HashSet<String> mimeTypes = new HashSet<>();
+        for (Map.Entry<HybridFileParcelable, Uri> result : resultUris.entrySet()) {
+          HybridFileParcelable baseFile = result.getKey();
+          Uri uri = result.getValue();
+          mimeTypes.add(MimeTypes.getMimeType(baseFile.getPath(), baseFile.isDirectory()));
+          uriDataClipItems.add(new ClipData.Item(uri));
+        }
+        ClipData clipData =
+            new ClipData(
+                ClipDescription.MIMETYPE_TEXT_URILIST,
+                mimeTypes.toArray(new String[0]),
+                uriDataClipItems.remove(0));
+        for (ClipData.Item item : uriDataClipItems) {
+          clipData.addItem(item);
+        }
+
+        intent.setClipData(clipData);
+        intent.setAction(Intent.ACTION_SEND_MULTIPLE);
+        intent.putParcelableArrayListExtra(
+            Intent.EXTRA_STREAM, new ArrayList<>(resultUris.values()));
       }
+
       requireActivity().setResult(FragmentActivity.RESULT_OK, intent);
-    } else {
-      LOG.warn("Unable to get URI from baseFile [{}]", baseFile.getPath());
+    }
+    if (!failedPaths.isEmpty()) {
+      LOG.warn("Unable to get URIs from baseFiles {}", failedPaths);
     }
     requireActivity().finish();
   }

--- a/app/src/main/java/com/amaze/filemanager/utils/MainActivityActionMode.kt
+++ b/app/src/main/java/com/amaze/filemanager/utils/MainActivityActionMode.kt
@@ -68,6 +68,11 @@ class MainActivityActionMode(private val mainActivityReference: WeakReference<Ma
             mode.customView = actionModeView
             mainActivity.setPagingEnabled(false)
             mainActivity.hideFab()
+            if (mainActivity.mReturnIntent &&
+                Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN
+            ) {
+                mainActivity.showFabConfirmSelection()
+            }
 
             // translates the drawable content down
             // if (mainActivity.isDrawerLocked) mainActivity.translateDrawerList(true);
@@ -375,6 +380,7 @@ class MainActivityActionMode(private val mainActivityReference: WeakReference<Ma
             // translates the drawer content up
             // if (mainActivity.isDrawerLocked) mainActivity.translateDrawerList(false);
             mainActivity.showFab()
+            mainActivity.hideFabConfirmSelection()
 
             mainActivity.setPagingEnabled(true)
             safeLet(
@@ -405,7 +411,10 @@ class MainActivityActionMode(private val mainActivityReference: WeakReference<Ma
      * Finishes the action mode
      */
     fun disableActionMode() {
-        mainActivityReference.get()?.listItemSelected = false
+        mainActivityReference.get()?.let {
+            it.listItemSelected = false
+            it.hideFabConfirmSelection()
+        }
         actionMode?.finish()
         actionMode = null
     }

--- a/app/src/main/java/com/amaze/filemanager/utils/MainActivityActionMode.kt
+++ b/app/src/main/java/com/amaze/filemanager/utils/MainActivityActionMode.kt
@@ -20,6 +20,7 @@
 
 package com.amaze.filemanager.utils
 
+import android.content.Intent
 import android.graphics.drawable.ColorDrawable
 import android.os.Build
 import android.view.Menu
@@ -123,13 +124,24 @@ class MainActivityActionMode(private val mainActivityReference: WeakReference<Ma
             }
             val textView: AppCompatTextView = actionModeView!!.findViewById(R.id.item_count)
             textView.text = checkedItems.size.toString()
-            menu.findItem(R.id.all)
-                .setTitle(
-                    if (checkedItems.size
-                        == mainFragmentViewModel.folderCount +
-                        mainFragmentViewModel.fileCount
-                    ) R.string.deselect_all else R.string.select_all
+
+            if (mainActivity.mReturnIntent && !mainActivity.intent.getBooleanExtra(
+                    Intent.EXTRA_ALLOW_MULTIPLE,
+                    false
                 )
+            ) {
+                // Only one item can be returned, so there should not be a "Select all" button
+                hideOption(R.id.all, menu)
+            } else {
+                menu.findItem(R.id.all)
+                    .setTitle(
+                        if (checkedItems.size
+                            == mainFragmentViewModel.folderCount +
+                            mainFragmentViewModel.fileCount
+                        ) R.string.deselect_all else R.string.select_all
+                    )
+            }
+
             if (mainFragmentViewModel.openMode != OpenMode.FILE && !mainFragmentViewModel
                 .getIsCloudOpenMode()
             ) {

--- a/app/src/main/java/com/amaze/filemanager/utils/MainActivityActionMode.kt
+++ b/app/src/main/java/com/amaze/filemanager/utils/MainActivityActionMode.kt
@@ -20,9 +20,7 @@
 
 package com.amaze.filemanager.utils
 
-import android.content.Intent
 import android.graphics.drawable.ColorDrawable
-import android.net.Uri
 import android.os.Build
 import android.view.Menu
 import android.view.MenuItem
@@ -31,7 +29,6 @@ import android.widget.Toast
 import androidx.appcompat.view.ActionMode
 import androidx.appcompat.widget.AppCompatTextView
 import androidx.drawerlayout.widget.DrawerLayout
-import androidx.fragment.app.FragmentActivity
 import com.amaze.filemanager.R
 import com.amaze.filemanager.adapters.data.LayoutElementParcelable
 import com.amaze.filemanager.fileoperations.filesystem.OpenMode
@@ -80,7 +77,6 @@ class MainActivityActionMode(private val mainActivityReference: WeakReference<Ma
             hideOption(R.id.addshortcut, menu)
             hideOption(R.id.share, menu)
             hideOption(R.id.openwith, menu)
-            if (mainActivity.mReturnIntent) showOption(R.id.openmulti, menu)
             // hideOption(R.id.setringtone,menu);
             mode.title = mainActivity.resources.getString(R.string.select)
             mainActivity
@@ -122,7 +118,6 @@ class MainActivityActionMode(private val mainActivityReference: WeakReference<Ma
             }
             val textView: AppCompatTextView = actionModeView!!.findViewById(R.id.item_count)
             textView.text = checkedItems.size.toString()
-            hideOption(R.id.openmulti, menu)
             menu.findItem(R.id.all)
                 .setTitle(
                     if (checkedItems.size
@@ -137,11 +132,6 @@ class MainActivityActionMode(private val mainActivityReference: WeakReference<Ma
                 hideOption(R.id.compress, menu)
                 return true
             }
-            if (mainActivity.mReturnIntent &&
-                Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN
-            ) {
-                showOption(R.id.openmulti, menu)
-            }
             // tv.setText(checkedItems.size());
             if (!mainFragmentViewModel.results) {
                 hideOption(R.id.openparent, menu)
@@ -152,26 +142,12 @@ class MainActivityActionMode(private val mainActivityReference: WeakReference<Ma
                     if (mainFragmentViewModel.getCheckedItems()[0].isDirectory) {
                         hideOption(R.id.openwith, menu)
                         hideOption(R.id.share, menu)
-                        hideOption(R.id.openmulti, menu)
-                    }
-                    if (mainActivity.mReturnIntent) {
-                        if (Build.VERSION.SDK_INT >= 16) showOption(
-                            R.id.openmulti,
-                            menu
-                        )
                     }
                 } else {
                     showOption(R.id.share, menu)
-                    if (mainActivity.mReturnIntent && Build.VERSION.SDK_INT >= 16) {
-                        showOption(
-                            R.id.openmulti,
-                            menu
-                        )
-                    }
                     for (e in mainFragmentViewModel.getCheckedItems()) {
                         if (e.isDirectory) {
                             hideOption(R.id.share, menu)
-                            hideOption(R.id.openmulti, menu)
                             break
                         }
                     }
@@ -187,26 +163,13 @@ class MainActivityActionMode(private val mainActivityReference: WeakReference<Ma
                     if (mainFragmentViewModel.getCheckedItems()[0].isDirectory) {
                         hideOption(R.id.openwith, menu)
                         hideOption(R.id.share, menu)
-                        hideOption(R.id.openmulti, menu)
-                    }
-                    if (mainActivity.mReturnIntent &&
-                        Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN
-                    ) {
-                        showOption(R.id.openmulti, menu)
                     }
                 } else {
                     hideOption(R.id.openparent, menu)
                     hideOption(R.id.addshortcut, menu)
-                    if (mainActivity.mReturnIntent && Build.VERSION.SDK_INT >= 16) {
-                        showOption(
-                            R.id.openmulti,
-                            menu
-                        )
-                    }
                     for (e in mainFragmentViewModel.getCheckedItems()) {
                         if (e.isDirectory) {
                             hideOption(R.id.share, menu)
-                            hideOption(R.id.openmulti, menu)
                             break
                         }
                     }
@@ -233,26 +196,6 @@ class MainActivityActionMode(private val mainActivityReference: WeakReference<Ma
         ) {
                 mainActivity, checkedItems ->
             return when (item.itemId) {
-                R.id.openmulti -> {
-                    val intent_result = Intent(Intent.ACTION_SEND_MULTIPLE)
-                    val resulturis = ArrayList<Uri>()
-                    for (element in checkedItems) {
-                        val baseFile = element.generateBaseFile()
-                        val resultUri = Utils.getUriForBaseFile(mainActivity, baseFile)
-                        if (resultUri != null) {
-                            resulturis.add(resultUri)
-                        }
-                    }
-                    intent_result.flags = Intent.FLAG_GRANT_READ_URI_PERMISSION
-                    mainActivity.setResult(FragmentActivity.RESULT_OK, intent_result)
-                    intent_result.putParcelableArrayListExtra(
-                        Intent.EXTRA_STREAM,
-                        resulturis
-                    )
-                    mainActivity.finish()
-                    // mode.finish();
-                    true
-                }
                 R.id.about -> {
                     val x = checkedItems[0]
                     mainActivity.currentMainFragment?.also {

--- a/app/src/main/res/layout-v21/main_toolbar.xml
+++ b/app/src/main/res/layout-v21/main_toolbar.xml
@@ -82,6 +82,16 @@
                 app:sdMainFabOpenedSrc="@drawable/ic_close_white_24dp"
                 app:sdOverlayLayout="@id/fabs_overlay_layout"
                 app:layout_behavior="@string/speeddial_scrolling_view_snackbar_behavior" />
+        <com.leinardi.android.speeddial.SpeedDialView
+            android:id="@+id/fabs_confirm_selection"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="bottom|end"
+            android:layout_margin="2dp"
+            android:focusable="true"
+            app:sdMainFabClosedSrc="@drawable/ic_check_white_24dp"
+            app:sdMainFabOpenedSrc="@drawable/ic_check_white_24dp"
+            app:layout_behavior="@string/speeddial_scrolling_view_snackbar_behavior"/>
 
         <com.amaze.filemanager.ui.views.drawer.GestureExclusionView
             android:id="@+id/placeholder_drag_start"

--- a/app/src/main/res/layout-w720dp/main_toolbar.xml
+++ b/app/src/main/res/layout-w720dp/main_toolbar.xml
@@ -87,6 +87,16 @@
                 app:sdMainFabOpenedSrc="@drawable/ic_close_white_24dp"
                 app:sdOverlayLayout="@id/fabs_overlay_layout"
                 app:layout_behavior="@string/speeddial_scrolling_view_snackbar_behavior" />
+        <com.leinardi.android.speeddial.SpeedDialView
+            android:id="@+id/fabs_confirm_selection"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="bottom|end"
+            android:layout_margin="2dp"
+            android:focusable="true"
+            app:sdMainFabClosedSrc="@drawable/ic_check_white_24dp"
+            app:sdMainFabOpenedSrc="@drawable/ic_check_white_24dp"
+            app:layout_behavior="@string/speeddial_scrolling_view_snackbar_behavior"/>
         <View
             android:id="@+id/placeholder_drag_bottom"
             android:layout_width="match_parent"

--- a/app/src/main/res/layout/main_toolbar.xml
+++ b/app/src/main/res/layout/main_toolbar.xml
@@ -84,6 +84,16 @@
                 app:sdMainFabOpenedSrc="@drawable/ic_close_white_24dp"
                 app:sdOverlayLayout="@id/fabs_overlay_layout"
                 app:layout_behavior="@string/speeddial_scrolling_view_snackbar_behavior" />
+        <com.leinardi.android.speeddial.SpeedDialView
+                android:id="@+id/fabs_confirm_selection"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="bottom|end"
+                android:layout_margin="2dp"
+                android:focusable="true"
+                app:sdMainFabClosedSrc="@drawable/ic_check_white_24dp"
+                app:sdMainFabOpenedSrc="@drawable/ic_check_white_24dp"
+                app:layout_behavior="@string/speeddial_scrolling_view_snackbar_behavior"/>
         <View
             android:id="@+id/placeholder_drag_bottom"
             android:layout_width="match_parent"

--- a/app/src/main/res/menu/contextual.xml
+++ b/app/src/main/res/menu/contextual.xml
@@ -20,11 +20,6 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
     <item
-        android:id="@+id/openmulti"
-        android:title="@string/select_intent"
-        android:visible="false"
-        app:showAsAction="ifRoom|withText" />
-    <item
         android:id="@+id/cpy"
         android:title="@string/copy"
         android:icon="@drawable/ic_content_copy_white_24dp"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -122,6 +122,7 @@
     <!--ListMode-->
     <!--Folder-->
     <string name="pick_a_file">Pick a file</string>
+    <string name="pick_files">Pick one or more files</string>
     <string name="process_viewer">Process Viewer</string>
     <string name="in_safe">Insufficient space</string>
     <string name="no_file_overwrite">No File Overwritten</string>


### PR DESCRIPTION
<!-- 
Read this first:
To open a pull request read this file,
uncomment the corresponding lines and 
complete them.
-->

## Description
This PR adds a floating action button to confirm your selection when Amaze is opened as a file picker by another app.

https://github.com/TeamAmaze/AmazeFileManager/assets/74261221/5d81bd9a-74f7-46a3-9ed9-29797f2b7237

When only one file can be selected, the selection switches between the clicked files.

https://github.com/TeamAmaze/AmazeFileManager/assets/74261221/64242b3c-39e2-47d7-a357-c7e0876b9fe0

#### Issue tracker   
<!-- Fixes will automatically close the related issue -->
Fixes #3747
<!-- Addresses won't automatically close the related issue -->
<!-- Addresses # -->

#### Automatic tests
<!-- remember to do manual testing when making UI changes! -->
- [ ] Added test cases
  
#### Manual tests
- [x] Done 

Device: 
- Pixel 7 emulator running Android 13
- HTC U11 life running Android 10
  
<!-- If yes, -->
<!-- 
- Device:
- OS:
-->

#### Build tasks success  
<!-- run these! -->
Successfully running following tasks on local:
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`

<!-- If there are related PRs please add them here -->
<!--
#### Related PR  
Related to PR #
-->