### PR TITLE
Feature: Option for theme to follow power save mode

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/ui/activities/superclasses/ThemedActivity.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/activities/superclasses/ThemedActivity.java
@@ -134,7 +134,7 @@ public class ThemedActivity extends PreferenceActivity {
       uiModeNight = newUiModeNight;
 
       if (getPrefs().getString(PreferencesConstants.FRAGMENT_THEME, "4").equals("4")) {
-        getUtilsProvider().getThemeManager().setAppTheme(AppTheme.getTheme(this, 4));
+        getUtilsProvider().getThemeManager().setAppTheme(AppTheme.getTheme(4));
         // Recreate activity, handling saved state
         //
         // Not smooth, but will only be called if the user changes the system theme, not

--- a/app/src/main/java/com/amaze/filemanager/ui/activities/superclasses/ThemedActivity.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/activities/superclasses/ThemedActivity.java
@@ -21,6 +21,7 @@
 package com.amaze.filemanager.ui.activities.superclasses;
 
 import static android.os.Build.VERSION.SDK_INT;
+import static android.os.Build.VERSION_CODES.LOLLIPOP;
 import static com.amaze.filemanager.ui.fragments.preferencefragments.PreferencesConstants.PREFERENCE_COLORED_NAVIGATION;
 
 import com.amaze.filemanager.R;
@@ -34,10 +35,15 @@ import com.amaze.filemanager.utils.Utils;
 import com.readystatesoftware.systembartint.SystemBarTintManager;
 
 import android.app.ActivityManager;
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
 import android.content.res.Configuration;
 import android.graphics.drawable.BitmapDrawable;
 import android.os.Build;
 import android.os.Bundle;
+import android.os.PowerManager;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.Window;
@@ -53,10 +59,19 @@ import androidx.core.content.ContextCompat;
 /** Created by arpitkh996 on 03-03-2016. */
 public class ThemedActivity extends PreferenceActivity {
   private int uiModeNight = -1;
+  private final BroadcastReceiver powerModeReceiver =
+      new BroadcastReceiver() {
+        @Override
+        public void onReceive(Context context, Intent i) {
+          recreate();
+        }
+      };
 
   @Override
   public void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
+
+    registerPowerModeReceiver();
 
     // setting window background color instead of each item, in order to reduce pixel overdraw
     if (getAppTheme().equals(AppTheme.LIGHT)) {
@@ -308,5 +323,25 @@ public class ThemedActivity extends PreferenceActivity {
 
     uiModeNight = getResources().getConfiguration().uiMode & Configuration.UI_MODE_NIGHT_MASK;
     setTheme();
+  }
+
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+
+    unregisterPowerModeReceiver();
+  }
+
+  private void registerPowerModeReceiver() {
+    if (SDK_INT >= LOLLIPOP) {
+      registerReceiver(
+          powerModeReceiver, new IntentFilter(PowerManager.ACTION_POWER_SAVE_MODE_CHANGED));
+    }
+  }
+
+  private void unregisterPowerModeReceiver() {
+    if (SDK_INT >= LOLLIPOP) {
+      unregisterReceiver(powerModeReceiver);
+    }
   }
 }

--- a/app/src/main/java/com/amaze/filemanager/ui/activities/superclasses/ThemedActivity.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/activities/superclasses/ThemedActivity.java
@@ -61,6 +61,10 @@ import androidx.preference.PreferenceManager;
 /** Created by arpitkh996 on 03-03-2016. */
 public class ThemedActivity extends PreferenceActivity {
   private int uiModeNight = -1;
+
+  /**
+   * BroadcastReceiver responsible for updating the theme if battery saver mode is turned on or off
+   */
   private final BroadcastReceiver powerModeReceiver =
       new BroadcastReceiver() {
         @Override
@@ -345,6 +349,10 @@ public class ThemedActivity extends PreferenceActivity {
     unregisterPowerModeReceiver();
   }
 
+  /**
+   * Registers the BroadcastReceiver \`powerModeReceiver\` to listen to broadcasts that the battery
+   * save mode has been changed
+   */
   private void registerPowerModeReceiver() {
     if (SDK_INT >= LOLLIPOP) {
       registerReceiver(
@@ -352,6 +360,7 @@ public class ThemedActivity extends PreferenceActivity {
     }
   }
 
+  /** Unregisters the BroadcastReceiver \`powerModeReceiver\` */
   private void unregisterPowerModeReceiver() {
     if (SDK_INT >= LOLLIPOP) {
       unregisterReceiver(powerModeReceiver);

--- a/app/src/main/java/com/amaze/filemanager/ui/activities/superclasses/ThemedActivity.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/activities/superclasses/ThemedActivity.java
@@ -39,6 +39,7 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
+import android.content.SharedPreferences;
 import android.content.res.Configuration;
 import android.graphics.drawable.BitmapDrawable;
 import android.os.Build;
@@ -55,6 +56,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.widget.Toolbar;
 import androidx.core.content.ContextCompat;
+import androidx.preference.PreferenceManager;
 
 /** Created by arpitkh996 on 03-03-2016. */
 public class ThemedActivity extends PreferenceActivity {
@@ -63,7 +65,18 @@ public class ThemedActivity extends PreferenceActivity {
       new BroadcastReceiver() {
         @Override
         public void onReceive(Context context, Intent i) {
-          recreate();
+          SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(context);
+          boolean followBatterySaver =
+              preferences.getBoolean(PreferencesConstants.FRAGMENT_FOLLOW_BATTERY_SAVER, false);
+
+          AppTheme theme =
+              AppTheme.getTheme(
+                  Integer.parseInt(
+                      preferences.getString(PreferencesConstants.FRAGMENT_THEME, "4")));
+
+          if (followBatterySaver && theme.canBeLight()) {
+            recreate();
+          }
         }
       };
 

--- a/app/src/main/java/com/amaze/filemanager/ui/dialogs/ColorPickerDialog.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/dialogs/ColorPickerDialog.java
@@ -171,8 +171,7 @@ public class ColorPickerDialog extends PreferenceDialogFragmentCompat {
       ((AppCompatTextView) child.findViewById(R.id.text)).setText(COLORS[i].first);
       CircularColorsView colorsView = child.findViewById(R.id.circularColorsView);
       colorsView.setColors(getColor(i, 0), getColor(i, 1), getColor(i, 2), getColor(i, 3));
-      AppTheme appTheme =
-          AppTheme.getTheme(requireContext(), requireArguments().getInt(ARG_APP_THEME));
+      AppTheme appTheme = AppTheme.getTheme(requireArguments().getInt(ARG_APP_THEME));
       if (appTheme.getMaterialDialogTheme(requireContext()) == Theme.LIGHT)
         colorsView.setDividerColor(Color.WHITE);
       else colorsView.setDividerColor(Color.BLACK);

--- a/app/src/main/java/com/amaze/filemanager/ui/fragments/preferencefragments/AppearancePrefsFragment.kt
+++ b/app/src/main/java/com/amaze/filemanager/ui/fragments/preferencefragments/AppearancePrefsFragment.kt
@@ -114,6 +114,15 @@ class AppearancePrefsFragment : BasePrefsFragment() {
             .prefs
             .getString(PreferencesConstants.FRAGMENT_THEME, "4")!!
             .toInt()
+
+        val batterySaverPref = findPreference<Preference>(
+            PreferencesConstants.FRAGMENT_FOLLOW_BATTERY_SAVER
+        )
+        batterySaverPref?.isVisible = (
+            currentTheme == AppTheme.LIGHT_INDEX ||
+                currentTheme == AppTheme.SYSTEM_INDEX ||
+                currentTheme == AppTheme.TIME_INDEX
+            )
         themePref?.summary = themes[currentTheme]
         themePref?.onPreferenceClickListener = onClickTheme
 

--- a/app/src/main/java/com/amaze/filemanager/ui/fragments/preferencefragments/AppearancePrefsFragment.kt
+++ b/app/src/main/java/com/amaze/filemanager/ui/fragments/preferencefragments/AppearancePrefsFragment.kt
@@ -54,8 +54,7 @@ class AppearancePrefsFragment : BasePrefsFragment() {
                 editor.putString(PreferencesConstants.FRAGMENT_THEME, which.toString())
                 editor.apply()
 
-                activity.utilsProvider.themeManager.appTheme =
-                    AppTheme.getTheme(activity, which)
+                activity.utilsProvider.themeManager.appTheme = AppTheme.getTheme(which)
                 activity.recreate()
 
                 dialog.dismiss()
@@ -115,16 +114,15 @@ class AppearancePrefsFragment : BasePrefsFragment() {
             .getString(PreferencesConstants.FRAGMENT_THEME, "4")!!
             .toInt()
 
-        val batterySaverPref = findPreference<Preference>(
-            PreferencesConstants.FRAGMENT_FOLLOW_BATTERY_SAVER
-        )
-        batterySaverPref?.isVisible = (
-            currentTheme == AppTheme.LIGHT_INDEX ||
-                currentTheme == AppTheme.SYSTEM_INDEX ||
-                currentTheme == AppTheme.TIME_INDEX
-            )
         themePref?.summary = themes[currentTheme]
         themePref?.onPreferenceClickListener = onClickTheme
+
+        val batterySaverPref = findPreference<Preference>(
+                PreferencesConstants.FRAGMENT_FOLLOW_BATTERY_SAVER
+        )
+
+        val currentThemeEnum = AppTheme.getTheme(currentTheme)
+        batterySaverPref?.isVisible = currentThemeEnum.canBeLight()
 
         findPreference<Preference>(PreferencesConstants.PREFERENCE_COLORED_NAVIGATION)
             ?.let {

--- a/app/src/main/java/com/amaze/filemanager/ui/fragments/preferencefragments/AppearancePrefsFragment.kt
+++ b/app/src/main/java/com/amaze/filemanager/ui/fragments/preferencefragments/AppearancePrefsFragment.kt
@@ -104,6 +104,11 @@ class AppearancePrefsFragment : BasePrefsFragment() {
         true
     }
 
+    private val onClickFollowBatterySaver = Preference.OnPreferenceClickListener {
+        activity.recreate()
+        true
+    }
+
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
         setPreferencesFromResource(R.xml.appearance_prefs, rootKey)
 
@@ -118,11 +123,12 @@ class AppearancePrefsFragment : BasePrefsFragment() {
         themePref?.onPreferenceClickListener = onClickTheme
 
         val batterySaverPref = findPreference<Preference>(
-                PreferencesConstants.FRAGMENT_FOLLOW_BATTERY_SAVER
+            PreferencesConstants.FRAGMENT_FOLLOW_BATTERY_SAVER
         )
 
         val currentThemeEnum = AppTheme.getTheme(currentTheme)
         batterySaverPref?.isVisible = currentThemeEnum.canBeLight()
+        batterySaverPref?.onPreferenceClickListener = onClickFollowBatterySaver
 
         findPreference<Preference>(PreferencesConstants.PREFERENCE_COLORED_NAVIGATION)
             ?.let {

--- a/app/src/main/java/com/amaze/filemanager/ui/fragments/preferencefragments/AppearancePrefsFragment.kt
+++ b/app/src/main/java/com/amaze/filemanager/ui/fragments/preferencefragments/AppearancePrefsFragment.kt
@@ -104,8 +104,8 @@ class AppearancePrefsFragment : BasePrefsFragment() {
         true
     }
 
-    /** OnPreferenceClickListener for "FollowBatterySaver" option to update the activity */
     private val onClickFollowBatterySaver = Preference.OnPreferenceClickListener {
+        // recreate the activity since the theme could have changed with this preference change
         activity.recreate()
         true
     }

--- a/app/src/main/java/com/amaze/filemanager/ui/fragments/preferencefragments/AppearancePrefsFragment.kt
+++ b/app/src/main/java/com/amaze/filemanager/ui/fragments/preferencefragments/AppearancePrefsFragment.kt
@@ -104,6 +104,7 @@ class AppearancePrefsFragment : BasePrefsFragment() {
         true
     }
 
+    /** OnPreferenceClickListener for "FollowBatterySaver" option to update the activity */
     private val onClickFollowBatterySaver = Preference.OnPreferenceClickListener {
         activity.recreate()
         true

--- a/app/src/main/java/com/amaze/filemanager/ui/fragments/preferencefragments/PreferencesConstants.kt
+++ b/app/src/main/java/com/amaze/filemanager/ui/fragments/preferencefragments/PreferencesConstants.kt
@@ -23,6 +23,7 @@ package com.amaze.filemanager.ui.fragments.preferencefragments
 object PreferencesConstants {
     // appearance_prefs.xml
     const val FRAGMENT_THEME = "theme"
+    const val FRAGMENT_FOLLOW_BATTERY_SAVER = "follow_battery_saver"
     const val PREFERENCE_USE_CIRCULAR_IMAGES = "circularimages"
     const val PREFERENCE_SHOW_DIVIDERS = "showDividers"
     const val PREFERENCE_SHOW_HEADERS = "showHeaders"

--- a/app/src/main/java/com/amaze/filemanager/ui/provider/UtilitiesProvider.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/provider/UtilitiesProvider.java
@@ -26,7 +26,6 @@ import com.amaze.filemanager.ui.theme.AppThemeManager;
 
 import android.content.Context;
 import android.content.SharedPreferences;
-import android.content.res.Configuration;
 
 import androidx.preference.PreferenceManager;
 
@@ -40,11 +39,7 @@ public class UtilitiesProvider {
 
     colorPreference = new ColorPreferenceHelper();
     colorPreference.getCurrentUserColorPreferences(context, sharedPreferences);
-    appThemeManager =
-        new AppThemeManager(
-            sharedPreferences,
-            (context.getResources().getConfiguration().uiMode & Configuration.UI_MODE_NIGHT_MASK)
-                == Configuration.UI_MODE_NIGHT_YES);
+    appThemeManager = new AppThemeManager(sharedPreferences, context);
   }
 
   public ColorPreferenceHelper getColorPreference() {

--- a/app/src/main/java/com/amaze/filemanager/ui/theme/AppTheme.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/theme/AppTheme.java
@@ -26,6 +26,8 @@ import com.afollestad.materialdialogs.Theme;
 
 import android.content.Context;
 import android.content.res.Configuration;
+import android.os.Build;
+import android.os.PowerManager;
 
 /** This enum represents the theme of the app (LIGHT or DARK) */
 public enum AppTheme {
@@ -130,5 +132,14 @@ public enum AppTheme {
   private static boolean isNightMode(Context context) {
     return (context.getResources().getConfiguration().uiMode & Configuration.UI_MODE_NIGHT_MASK)
         == Configuration.UI_MODE_NIGHT_YES;
+  }
+
+  private static boolean isBatterySaverMode(Context context) {
+    PowerManager powerManager = (PowerManager) context.getSystemService(Context.POWER_SERVICE);
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+      return powerManager.isPowerSaveMode();
+    } else {
+      return false;
+    }
   }
 }

--- a/app/src/main/java/com/amaze/filemanager/ui/theme/AppTheme.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/theme/AppTheme.java
@@ -48,6 +48,11 @@ public enum AppTheme {
   public static final int SYSTEM_INDEX = 4;
 
   private int id;
+
+  /**
+   * Specifies if the theme can be light in some situations. Used for the "Follow battery saver"
+   * option.
+   */
   private final boolean canBeLight;
 
   AppTheme(int id, boolean canBeLight) {
@@ -138,6 +143,7 @@ public enum AppTheme {
     return id;
   }
 
+  /** Returns if the theme can be light in some situations */
   public boolean canBeLight() {
     return this.canBeLight;
   }
@@ -147,6 +153,12 @@ public enum AppTheme {
         == Configuration.UI_MODE_NIGHT_YES;
   }
 
+  /**
+   * Checks if battery saver mode is on
+   *
+   * @param context The context in which the battery saver mode should be checked
+   * @return Whether battery saver mode is on or off
+   */
   private static boolean isBatterySaverMode(Context context) {
     PowerManager powerManager = (PowerManager) context.getSystemService(Context.POWER_SERVICE);
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {

--- a/app/src/main/java/com/amaze/filemanager/ui/theme/AppTheme.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/theme/AppTheme.java
@@ -78,22 +78,14 @@ public enum AppTheme {
   }
 
   public Theme getMaterialDialogTheme(Context context) {
-    switch (id) {
+    AppTheme simpleTheme = getSimpleTheme(context);
+    switch (simpleTheme.id) {
       default:
       case LIGHT_INDEX:
         return Theme.LIGHT;
       case DARK_INDEX:
       case BLACK_INDEX:
         return Theme.DARK;
-      case TIME_INDEX:
-        int hour = Calendar.getInstance().get(Calendar.HOUR_OF_DAY);
-        if (hour <= 6 || hour >= 18) {
-          return Theme.DARK;
-        } else {
-          return Theme.LIGHT;
-        }
-      case SYSTEM_INDEX:
-        return isNightMode(context) ? Theme.DARK : Theme.LIGHT;
     }
   }
 

--- a/app/src/main/java/com/amaze/filemanager/ui/theme/AppTheme.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/theme/AppTheme.java
@@ -107,35 +107,27 @@ public enum AppTheme {
   }
 
   public AppTheme getSimpleTheme(boolean isNightMode, boolean isBatterySaver) {
-    AppTheme theme;
+    if (this.canBeLight() && isBatterySaver) {
+      return DARK;
+    }
+
     switch (id) {
       default:
       case LIGHT_INDEX:
-        theme = LIGHT;
-        break;
+        return LIGHT;
       case DARK_INDEX:
-        theme = DARK;
-        break;
+        return DARK;
       case TIME_INDEX:
         int hour = Calendar.getInstance().get(Calendar.HOUR_OF_DAY);
         if (hour <= 6 || hour >= 18) {
-          theme = DARK;
+          return DARK;
         } else {
-          theme = LIGHT;
+          return LIGHT;
         }
-        break;
       case BLACK_INDEX:
-        theme = BLACK;
-        break;
+        return BLACK;
       case SYSTEM_INDEX:
-        theme = isNightMode ? DARK : LIGHT;
-        break;
-    }
-
-    if (this.canBeLight && isBatterySaver) {
-      return DARK;
-    } else {
-      return theme;
+        return isNightMode ? DARK : LIGHT;
     }
   }
 

--- a/app/src/main/java/com/amaze/filemanager/ui/theme/AppTheme.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/theme/AppTheme.java
@@ -35,11 +35,11 @@ import androidx.preference.PreferenceManager;
 
 /** This enum represents the theme of the app (LIGHT or DARK) */
 public enum AppTheme {
-  LIGHT(0),
-  DARK(1),
-  TIMED(2),
-  BLACK(3),
-  SYSTEM(4);
+  LIGHT(0, true),
+  DARK(1, false),
+  TIMED(2, true),
+  BLACK(3, false),
+  SYSTEM(4, true);
 
   public static final int LIGHT_INDEX = 0;
   public static final int DARK_INDEX = 1;
@@ -48,9 +48,11 @@ public enum AppTheme {
   public static final int SYSTEM_INDEX = 4;
 
   private int id;
+  private final boolean canBeLight;
 
-  AppTheme(int id) {
+  AppTheme(int id, boolean canBeLight) {
     this.id = id;
+    this.canBeLight = canBeLight;
   }
 
   /**
@@ -137,16 +139,19 @@ public enum AppTheme {
         break;
     }
 
-    if (theme == LIGHT && isBatterySaver) {
+    if (this.canBeLight && isBatterySaver) {
       return DARK;
-    }
-    else {
+    } else {
       return theme;
     }
   }
 
   public int getId() {
     return id;
+  }
+
+  public boolean canBeLight() {
+    return this.canBeLight;
   }
 
   private static boolean isNightMode(Context context) {

--- a/app/src/main/java/com/amaze/filemanager/ui/theme/AppTheme.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/theme/AppTheme.java
@@ -61,11 +61,7 @@ public enum AppTheme {
    * @param index The theme index
    * @return The AppTheme for the given index
    */
-  public static AppTheme getTheme(Context context, int index) {
-    return getTheme(isNightMode(context), index);
-  }
-
-  public static AppTheme getTheme(boolean isNightMode, int index) {
+  public static AppTheme getTheme(int index) {
     switch (index) {
       default:
       case LIGHT_INDEX:
@@ -77,7 +73,7 @@ public enum AppTheme {
       case BLACK_INDEX:
         return BLACK;
       case SYSTEM_INDEX:
-        return isNightMode ? DARK : LIGHT;
+        return SYSTEM;
     }
   }
 

--- a/app/src/main/java/com/amaze/filemanager/ui/theme/AppTheme.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/theme/AppTheme.java
@@ -23,11 +23,15 @@ package com.amaze.filemanager.ui.theme;
 import java.util.Calendar;
 
 import com.afollestad.materialdialogs.Theme;
+import com.amaze.filemanager.ui.fragments.preferencefragments.PreferencesConstants;
 
 import android.content.Context;
+import android.content.SharedPreferences;
 import android.content.res.Configuration;
 import android.os.Build;
 import android.os.PowerManager;
+
+import androidx.preference.PreferenceManager;
 
 /** This enum represents the theme of the app (LIGHT or DARK) */
 public enum AppTheme {
@@ -101,27 +105,43 @@ public enum AppTheme {
    * @return The AppTheme for the given index
    */
   public AppTheme getSimpleTheme(Context context) {
-    return getSimpleTheme(isNightMode(context));
+    SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(context);
+    boolean followBatterySaver =
+        preferences.getBoolean(PreferencesConstants.FRAGMENT_FOLLOW_BATTERY_SAVER, false);
+    return getSimpleTheme(isNightMode(context), followBatterySaver && isBatterySaverMode(context));
   }
 
-  public AppTheme getSimpleTheme(boolean isNightMode) {
+  public AppTheme getSimpleTheme(boolean isNightMode, boolean isBatterySaver) {
+    AppTheme theme;
     switch (id) {
       default:
       case LIGHT_INDEX:
-        return LIGHT;
+        theme = LIGHT;
+        break;
       case DARK_INDEX:
-        return DARK;
+        theme = DARK;
+        break;
       case TIME_INDEX:
         int hour = Calendar.getInstance().get(Calendar.HOUR_OF_DAY);
         if (hour <= 6 || hour >= 18) {
-          return DARK;
+          theme = DARK;
         } else {
-          return LIGHT;
+          theme = LIGHT;
         }
+        break;
       case BLACK_INDEX:
-        return BLACK;
+        theme = BLACK;
+        break;
       case SYSTEM_INDEX:
-        return isNightMode ? DARK : LIGHT;
+        theme = isNightMode ? DARK : LIGHT;
+        break;
+    }
+
+    if (theme == LIGHT && isBatterySaver) {
+      return DARK;
+    }
+    else {
+      return theme;
     }
   }
 

--- a/app/src/main/java/com/amaze/filemanager/ui/theme/AppThemeManager.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/theme/AppThemeManager.java
@@ -39,7 +39,7 @@ public class AppThemeManager {
     String themeId = preferences.getString(PreferencesConstants.FRAGMENT_THEME, "4");
     this.followBatterySaver =
         preferences.getBoolean(PreferencesConstants.FRAGMENT_FOLLOW_BATTERY_SAVER, false);
-    appTheme = AppTheme.getTheme(context, Integer.parseInt(themeId)).getSimpleTheme(context);
+    appTheme = AppTheme.getTheme(Integer.parseInt(themeId)).getSimpleTheme(context);
   }
 
   /**

--- a/app/src/main/java/com/amaze/filemanager/ui/theme/AppThemeManager.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/theme/AppThemeManager.java
@@ -35,7 +35,7 @@ public class AppThemeManager {
     this.preferences = preferences;
     this.context = context;
     String themeId = preferences.getString(PreferencesConstants.FRAGMENT_THEME, "4");
-    appTheme = AppTheme.getTheme(Integer.parseInt(themeId)).getSimpleTheme(context);
+    appTheme = AppTheme.getTheme(Integer.parseInt(themeId));
   }
 
   /**

--- a/app/src/main/java/com/amaze/filemanager/ui/theme/AppThemeManager.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/theme/AppThemeManager.java
@@ -31,14 +31,10 @@ public class AppThemeManager {
   private AppTheme appTheme;
   private final Context context;
 
-  private final boolean followBatterySaver;
-
   public AppThemeManager(SharedPreferences preferences, Context context) {
     this.preferences = preferences;
     this.context = context;
     String themeId = preferences.getString(PreferencesConstants.FRAGMENT_THEME, "4");
-    this.followBatterySaver =
-        preferences.getBoolean(PreferencesConstants.FRAGMENT_FOLLOW_BATTERY_SAVER, false);
     appTheme = AppTheme.getTheme(Integer.parseInt(themeId)).getSimpleTheme(context);
   }
 

--- a/app/src/main/java/com/amaze/filemanager/ui/theme/AppThemeManager.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/theme/AppThemeManager.java
@@ -22,27 +22,31 @@ package com.amaze.filemanager.ui.theme;
 
 import com.amaze.filemanager.ui.fragments.preferencefragments.PreferencesConstants;
 
+import android.content.Context;
 import android.content.SharedPreferences;
 
 /** Saves and restores the AppTheme */
 public class AppThemeManager {
   private SharedPreferences preferences;
   private AppTheme appTheme;
-  private final boolean isNightMode;
+  private final Context context;
 
-  public AppThemeManager(SharedPreferences preferences, boolean isNightMode) {
+  private final boolean followBatterySaver;
+
+  public AppThemeManager(SharedPreferences preferences, Context context) {
     this.preferences = preferences;
-    this.isNightMode = isNightMode;
+    this.context = context;
     String themeId = preferences.getString(PreferencesConstants.FRAGMENT_THEME, "4");
-    appTheme =
-        AppTheme.getTheme(isNightMode, Integer.parseInt(themeId)).getSimpleTheme(isNightMode);
+    this.followBatterySaver =
+        preferences.getBoolean(PreferencesConstants.FRAGMENT_FOLLOW_BATTERY_SAVER, false);
+    appTheme = AppTheme.getTheme(context, Integer.parseInt(themeId)).getSimpleTheme(context);
   }
 
   /**
    * @return The current Application theme
    */
   public AppTheme getAppTheme() {
-    return appTheme.getSimpleTheme(isNightMode);
+    return appTheme.getSimpleTheme(context);
   }
 
   /**

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -183,6 +183,8 @@
     <string name="xda_summary">Q&amp;A, Help &amp; Troubleshooting</string>
     <string name="circular_images">Use circular icons for images and videos</string>
     <string name="circular_icons">Use circular icons</string>
+    <string name="follow_battery_saver_title">Follow battery saver</string>
+    <string name="follow_battery_saver_desc">If selected and the battery saver mode is turned on, the theme changes to dark theme</string>
     <string name="back_title">Back navigation</string>
     <string name="back_summary">Enables custom back navigation at top of the list</string>
     <string name="details">Details</string>

--- a/app/src/main/res/xml/appearance_prefs.xml
+++ b/app/src/main/res/xml/appearance_prefs.xml
@@ -4,7 +4,12 @@
     <Preference
         app:key="theme"
         app:title="@string/theme" />
-
+    <com.amaze.filemanager.ui.views.preference.CheckBox
+        app:defaultValue="false"
+        app:key="follow_battery_saver"
+        app:summary="@string/follow_battery_saver_desc"
+        app:title="@string/follow_battery_saver_title"
+        app:isPreferenceVisible="false" />
     <com.amaze.filemanager.ui.views.preference.CheckBox
         app:defaultValue="true"
         app:key="circularimages"

--- a/app/src/test/java/com/amaze/filemanager/ui/theme/AppThemeTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/ui/theme/AppThemeTest.kt
@@ -69,22 +69,18 @@ class AppThemeTest {
     fun testMaterialDialogTheme() {
         val context = ApplicationProvider.getApplicationContext<Context>()
 
-        val getMaterialDialogTheme = { apptheme: Int ->
-            AppTheme.getTheme(apptheme).getMaterialDialogTheme(context)
-        }
+        Assert.assertEquals(Theme.LIGHT, getMaterialDialogTheme(AppTheme.LIGHT_INDEX, context))
 
-        Assert.assertEquals(Theme.LIGHT, getMaterialDialogTheme(AppTheme.LIGHT_INDEX))
-
-        Assert.assertEquals(Theme.DARK, getMaterialDialogTheme(AppTheme.DARK_INDEX))
+        Assert.assertEquals(Theme.DARK, getMaterialDialogTheme(AppTheme.DARK_INDEX, context))
 
         val hour = Calendar.getInstance()[Calendar.HOUR_OF_DAY]
         if (hour <= 6 || hour >= 18) {
-            Assert.assertEquals(Theme.DARK, getMaterialDialogTheme(AppTheme.TIME_INDEX))
+            Assert.assertEquals(Theme.DARK, getMaterialDialogTheme(AppTheme.TIME_INDEX, context))
         } else {
-            Assert.assertEquals(Theme.LIGHT, getMaterialDialogTheme(AppTheme.TIME_INDEX))
+            Assert.assertEquals(Theme.LIGHT, getMaterialDialogTheme(AppTheme.TIME_INDEX, context))
         }
 
-        Assert.assertEquals(Theme.DARK, getMaterialDialogTheme(AppTheme.BLACK_INDEX))
+        Assert.assertEquals(Theme.DARK, getMaterialDialogTheme(AppTheme.BLACK_INDEX, context))
     }
 
     /**
@@ -196,7 +192,57 @@ class AppThemeTest {
         testSimpleTheme()
     }
 
-    private fun getSimpleTheme(index: Int, context: Context) =
+    @Test
+    @Config(
+            shadows = [ShadowPowerManager::class, ShadowMultiDex::class],
+            qualifiers = "notnight",
+            minSdk = Build.VERSION_CODES.LOLLIPOP
+    )
+    fun testMaterialDialogThemeWithFollowBatterySaverAndBatterySaverOn() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+
+        setUpForFollowBatterySaverMode(context, true)
+
+        val canBeLightThemes = AppTheme.values().filter { it.canBeLight() }
+
+        for (lightTheme in canBeLightThemes) {
+            Assert.assertEquals(
+                "For $lightTheme: ",
+                Theme.DARK,
+                getMaterialDialogTheme(lightTheme.id, context)
+            )
+        }
+
+        Assert.assertEquals(
+                Theme.DARK,
+                getMaterialDialogTheme(AppTheme.DARK_INDEX, context)
+        )
+
+        Assert.assertEquals(
+                Theme.DARK,
+                getMaterialDialogTheme(AppTheme.BLACK_INDEX, context)
+        )
+    }
+
+    @Test
+    @Config(
+            shadows = [ShadowPowerManager::class, ShadowMultiDex::class],
+            qualifiers = "notnight",
+            minSdk = Build.VERSION_CODES.LOLLIPOP
+    )
+    fun testMaterialDialogThemeWithFollowBatterySaverAndBatterySaverOff() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+
+        setUpForFollowBatterySaverMode(context, false)
+
+        // Should have the same behavior
+        testMaterialDialogTheme()
+    }
+
+    private fun getMaterialDialogTheme(apptheme: Int, context: Context) : Theme =
+        AppTheme.getTheme(apptheme).getMaterialDialogTheme(context)
+
+    private fun getSimpleTheme(index: Int, context: Context) : AppTheme =
         AppTheme.getTheme(index).getSimpleTheme(context)
 
     private fun setUpForFollowBatterySaverMode(context: Context, batterySaverOn: Boolean) {

--- a/app/src/test/java/com/amaze/filemanager/ui/theme/AppThemeTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/ui/theme/AppThemeTest.kt
@@ -48,13 +48,15 @@ class AppThemeTest {
     @Test
     fun testGetTheme() {
         val context = ApplicationProvider.getApplicationContext<Context>()
-        Assert.assertEquals(AppTheme.LIGHT, AppTheme.getTheme(context, AppTheme.LIGHT_INDEX))
+        Assert.assertEquals(AppTheme.LIGHT, AppTheme.getTheme(AppTheme.LIGHT_INDEX))
 
-        Assert.assertEquals(AppTheme.DARK, AppTheme.getTheme(context, AppTheme.DARK_INDEX))
+        Assert.assertEquals(AppTheme.DARK, AppTheme.getTheme(AppTheme.DARK_INDEX))
 
-        Assert.assertEquals(AppTheme.TIMED, AppTheme.getTheme(context, AppTheme.TIME_INDEX))
+        Assert.assertEquals(AppTheme.TIMED, AppTheme.getTheme(AppTheme.TIME_INDEX))
 
-        Assert.assertEquals(AppTheme.BLACK, AppTheme.getTheme(context, AppTheme.BLACK_INDEX))
+        Assert.assertEquals(AppTheme.BLACK, AppTheme.getTheme(AppTheme.BLACK_INDEX))
+
+        Assert.assertEquals(AppTheme.SYSTEM, AppTheme.getTheme(AppTheme.SYSTEM_INDEX))
     }
 
     /**
@@ -65,7 +67,7 @@ class AppThemeTest {
         val context = ApplicationProvider.getApplicationContext<Context>()
 
         val getMaterialDialogTheme = { apptheme: Int ->
-            AppTheme.getTheme(context, apptheme).getMaterialDialogTheme(context)
+            AppTheme.getTheme(apptheme).getMaterialDialogTheme(context)
         }
 
         Assert.assertEquals(Theme.LIGHT, getMaterialDialogTheme(AppTheme.LIGHT_INDEX))
@@ -88,33 +90,31 @@ class AppThemeTest {
     @Test
     fun testSimpleTheme() {
         val context = ApplicationProvider.getApplicationContext<Context>()
-        val mask = context.resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK
-        val isNightMode = mask == Configuration.UI_MODE_NIGHT_YES
 
         Assert.assertEquals(
             AppTheme.LIGHT,
-            AppTheme.getTheme(context, AppTheme.LIGHT_INDEX).getSimpleTheme(isNightMode)
+            AppTheme.getTheme(AppTheme.LIGHT_INDEX).getSimpleTheme(context)
         )
 
         Assert.assertEquals(
             AppTheme.DARK,
-            AppTheme.getTheme(context, AppTheme.DARK_INDEX).getSimpleTheme(isNightMode)
+            AppTheme.getTheme(AppTheme.DARK_INDEX).getSimpleTheme(context)
         )
 
         val hour = Calendar.getInstance()[Calendar.HOUR_OF_DAY]
         if (hour <= 6 || hour >= 18) {
             Assert.assertEquals(
                 AppTheme.DARK,
-                AppTheme.getTheme(context, AppTheme.TIME_INDEX).getSimpleTheme(isNightMode)
+                AppTheme.getTheme(AppTheme.TIME_INDEX).getSimpleTheme(context)
             )
         } else Assert.assertEquals(
             AppTheme.LIGHT,
-            AppTheme.getTheme(context, AppTheme.TIME_INDEX).getSimpleTheme(isNightMode)
+            AppTheme.getTheme(AppTheme.TIME_INDEX).getSimpleTheme(context)
         )
 
         Assert.assertEquals(
             AppTheme.BLACK,
-            AppTheme.getTheme(context, AppTheme.BLACK_INDEX).getSimpleTheme(isNightMode)
+            AppTheme.getTheme(AppTheme.BLACK_INDEX).getSimpleTheme(context)
         )
     }
 }

--- a/app/src/test/java/com/amaze/filemanager/ui/theme/AppThemeTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/ui/theme/AppThemeTest.kt
@@ -96,7 +96,7 @@ class AppThemeTest {
 
         Assert.assertEquals(
             AppTheme.LIGHT,
-                getSimpleTheme(AppTheme.LIGHT_INDEX, context)
+            getSimpleTheme(AppTheme.LIGHT_INDEX, context)
         )
 
         Assert.assertEquals(
@@ -160,13 +160,13 @@ class AppThemeTest {
         }
 
         Assert.assertEquals(
-                AppTheme.DARK,
-                getSimpleTheme(AppTheme.DARK_INDEX, context)
+            AppTheme.DARK,
+            getSimpleTheme(AppTheme.DARK_INDEX, context)
         )
 
         Assert.assertEquals(
-                AppTheme.BLACK,
-                getSimpleTheme(AppTheme.BLACK_INDEX, context)
+            AppTheme.BLACK,
+            getSimpleTheme(AppTheme.BLACK_INDEX, context)
         )
     }
 
@@ -184,7 +184,8 @@ class AppThemeTest {
         testSimpleTheme()
     }
 
-    private fun getSimpleTheme(index: Int, context: Context) = AppTheme.getTheme(index).getSimpleTheme(context)
+    private fun getSimpleTheme(index: Int, context: Context) =
+        AppTheme.getTheme(index).getSimpleTheme(context)
 
     private fun setUpForFollowBatterySaverMode(context: Context, batterySaverOn: Boolean) {
         // Set Battery saver mode to given state `batterySaverOn`
@@ -194,6 +195,9 @@ class AppThemeTest {
 
         // Set follow battery saver preference to true
         val preferences = PreferenceManager.getDefaultSharedPreferences(context)
-        preferences.edit().putBoolean(PreferencesConstants.FRAGMENT_FOLLOW_BATTERY_SAVER, true).apply()
+        preferences
+            .edit()
+            .putBoolean(PreferencesConstants.FRAGMENT_FOLLOW_BATTERY_SAVER, true)
+            .apply()
     }
 }

--- a/app/src/test/java/com/amaze/filemanager/ui/theme/AppThemeTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/ui/theme/AppThemeTest.kt
@@ -192,6 +192,9 @@ class AppThemeTest {
         testSimpleTheme()
     }
 
+    /**
+     * Tests the material dialog theme with "Follow Battery Saver" option selected when battery saver is on
+     */
     @Test
     @Config(
         shadows = [ShadowPowerManager::class, ShadowMultiDex::class],
@@ -224,6 +227,9 @@ class AppThemeTest {
         )
     }
 
+    /**
+     * Tests the material dialog theme with "Follow Battery Saver" option selected when battery saver is off
+     */
     @Test
     @Config(
         shadows = [ShadowPowerManager::class, ShadowMultiDex::class],
@@ -239,12 +245,15 @@ class AppThemeTest {
         testMaterialDialogTheme()
     }
 
+    /** Shortcut to get the material dialog theme from the theme index */
     private fun getMaterialDialogTheme(apptheme: Int, context: Context): Theme =
         AppTheme.getTheme(apptheme).getMaterialDialogTheme(context)
 
+    /** Shortcut to get the simple theme from the theme index */
     private fun getSimpleTheme(index: Int, context: Context): AppTheme =
         AppTheme.getTheme(index).getSimpleTheme(context)
 
+    /** Sets the battery saver mode to [batterySaverOn] and the "Follow battery saver" option to true */
     private fun setUpForFollowBatterySaverMode(context: Context, batterySaverOn: Boolean) {
         // Set Battery saver mode to given state `batterySaverOn`
         val powerManager = context.getSystemService(Context.POWER_SERVICE) as PowerManager

--- a/app/src/test/java/com/amaze/filemanager/ui/theme/AppThemeTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/ui/theme/AppThemeTest.kt
@@ -194,9 +194,9 @@ class AppThemeTest {
 
     @Test
     @Config(
-            shadows = [ShadowPowerManager::class, ShadowMultiDex::class],
-            qualifiers = "notnight",
-            minSdk = Build.VERSION_CODES.LOLLIPOP
+        shadows = [ShadowPowerManager::class, ShadowMultiDex::class],
+        qualifiers = "notnight",
+        minSdk = Build.VERSION_CODES.LOLLIPOP
     )
     fun testMaterialDialogThemeWithFollowBatterySaverAndBatterySaverOn() {
         val context = ApplicationProvider.getApplicationContext<Context>()
@@ -214,21 +214,21 @@ class AppThemeTest {
         }
 
         Assert.assertEquals(
-                Theme.DARK,
-                getMaterialDialogTheme(AppTheme.DARK_INDEX, context)
+            Theme.DARK,
+            getMaterialDialogTheme(AppTheme.DARK_INDEX, context)
         )
 
         Assert.assertEquals(
-                Theme.DARK,
-                getMaterialDialogTheme(AppTheme.BLACK_INDEX, context)
+            Theme.DARK,
+            getMaterialDialogTheme(AppTheme.BLACK_INDEX, context)
         )
     }
 
     @Test
     @Config(
-            shadows = [ShadowPowerManager::class, ShadowMultiDex::class],
-            qualifiers = "notnight",
-            minSdk = Build.VERSION_CODES.LOLLIPOP
+        shadows = [ShadowPowerManager::class, ShadowMultiDex::class],
+        qualifiers = "notnight",
+        minSdk = Build.VERSION_CODES.LOLLIPOP
     )
     fun testMaterialDialogThemeWithFollowBatterySaverAndBatterySaverOff() {
         val context = ApplicationProvider.getApplicationContext<Context>()
@@ -239,10 +239,10 @@ class AppThemeTest {
         testMaterialDialogTheme()
     }
 
-    private fun getMaterialDialogTheme(apptheme: Int, context: Context) : Theme =
+    private fun getMaterialDialogTheme(apptheme: Int, context: Context): Theme =
         AppTheme.getTheme(apptheme).getMaterialDialogTheme(context)
 
-    private fun getSimpleTheme(index: Int, context: Context) : AppTheme =
+    private fun getSimpleTheme(index: Int, context: Context): AppTheme =
         AppTheme.getTheme(index).getSimpleTheme(context)
 
     private fun setUpForFollowBatterySaverMode(context: Context, batterySaverOn: Boolean) {

--- a/app/src/test/java/com/amaze/filemanager/ui/theme/AppThemeTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/ui/theme/AppThemeTest.kt
@@ -21,7 +21,6 @@
 package com.amaze.filemanager.ui.theme
 
 import android.content.Context
-import android.content.res.Configuration
 import android.os.Build
 import android.os.Build.VERSION_CODES.KITKAT
 import android.os.Build.VERSION_CODES.P

--- a/app/src/test/java/com/amaze/filemanager/ui/theme/AppThemeTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/ui/theme/AppThemeTest.kt
@@ -122,7 +122,7 @@ class AppThemeTest {
     }
 
     /**
-     * Tests the System theme when night mode is on
+     * Tests the "System" theme when night mode is on
      */
     @Test
     @Config(qualifiers = "night")
@@ -133,7 +133,7 @@ class AppThemeTest {
     }
 
     /**
-     * Tests the System theme when night mode is off
+     * Tests the "System" theme when night mode is off
      */
     @Test
     @Config(qualifiers = "notnight")
@@ -144,11 +144,15 @@ class AppThemeTest {
     }
 
     /**
-     * Tests the the themes with "Follow Battery Saver" option selected when battery saver is on
+     * Tests the themes with "Follow Battery Saver" option selected when battery saver is on
      */
     @Test
-    @Config(shadows = [ShadowPowerManager::class], qualifiers = "notnight")
-    fun testSimpleSystemThemeFollowBatterySaverAndBatterySaverOn() {
+    @Config(
+        shadows = [ShadowPowerManager::class, ShadowMultiDex::class],
+        qualifiers = "notnight",
+        minSdk = Build.VERSION_CODES.LOLLIPOP
+    )
+    fun testSimpleAppThemeWithFollowBatterySaverAndBatterySaverOn() {
         val context = ApplicationProvider.getApplicationContext<Context>()
 
         setUpForFollowBatterySaverMode(context, true)
@@ -156,7 +160,11 @@ class AppThemeTest {
         val canBeLightThemes = AppTheme.values().filter { it.canBeLight() }
 
         for (lightTheme in canBeLightThemes) {
-            Assert.assertEquals(AppTheme.DARK, getSimpleTheme(lightTheme.id, context))
+            Assert.assertEquals(
+                "For $lightTheme: ",
+                AppTheme.DARK,
+                getSimpleTheme(lightTheme.id, context)
+            )
         }
 
         Assert.assertEquals(
@@ -171,11 +179,15 @@ class AppThemeTest {
     }
 
     /**
-     * Tests the the themes with "Follow Battery Saver" option selected when battery saver is off
+     * Tests the themes with "Follow Battery Saver" option selected when battery saver is off
      */
     @Test
-    @Config(shadows = [ShadowPowerManager::class], qualifiers = "notnight")
-    fun testSimpleSystemThemeFollowBatterySaverAndBatterySaverOff() {
+    @Config(
+        shadows = [ShadowPowerManager::class, ShadowMultiDex::class],
+        qualifiers = "notnight",
+        minSdk = Build.VERSION_CODES.LOLLIPOP
+    )
+    fun testSimpleAppThemeWithFollowBatterySaverAndBatterySaverOff() {
         val context = ApplicationProvider.getApplicationContext<Context>()
 
         setUpForFollowBatterySaverMode(context, false)


### PR DESCRIPTION
<!-- 
Read this first:
To open a pull request read this file,
uncomment the corresponding lines and 
complete them.
-->

## Description
This PR adds a new appearance configuration whether the theme should follow the battery saver mode of the device. The option only appears for themes that can be light.

A `BroadcastListener` is added to `ThemedActivity` to be able to respond when the battery saver mode is turned on or off.

https://github.com/TeamAmaze/AmazeFileManager/assets/74261221/db230675-d39f-440e-be07-d67a0d7b919d

https://github.com/TeamAmaze/AmazeFileManager/assets/74261221/0041a94f-957a-4701-bf88-5f5d3508dc8f


#### Issue tracker   
<!-- Fixes will automatically close the related issue -->
Fixes #2748
<!-- Addresses won't automatically close the related issue -->
<!-- Addresses # -->

#### Automatic tests
<!-- remember to do manual testing when making UI changes! -->
- [x] Added test cases
  
#### Manual tests
- [x] Done  
  
Device: 
- Pixel 7 emulator running Android 13
- HTC U11 life running Android 10

#### Build tasks success  
<!-- run these! -->
Successfully running following tasks on local:
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`

<!-- If there are related PRs please add them here -->
<!--
#### Related PR  
Related to PR #
-->