### PR TITLE
Refactor `AppTheme` enum

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/adapters/AppsRecyclerAdapter.kt
+++ b/app/src/main/java/com/amaze/filemanager/adapters/AppsRecyclerAdapter.kt
@@ -292,7 +292,7 @@ class AppsRecyclerAdapter(
             if ((
                 fragment.requireActivity()
                     as MainActivity
-                ).appTheme.getSimpleTheme(fragment.requireContext()) == AppTheme.BLACK
+                ).appTheme == AppTheme.BLACK
             ) {
                 context = ContextThemeWrapper(context, R.style.overflow_black)
             }
@@ -494,7 +494,7 @@ class AppsRecyclerAdapter(
             MaterialDialog.Builder(fragment.requireContext())
         builder1
             .theme(
-                themedActivity.appTheme.getMaterialDialogTheme(fragment.requireContext())
+                themedActivity.appTheme.getMaterialDialogTheme()
             )
             .content(fragment.getString(R.string.unin_system_apk))
             .title(fragment.getString(R.string.warning))

--- a/app/src/main/java/com/amaze/filemanager/adapters/RecyclerAdapter.java
+++ b/app/src/main/java/com/amaze/filemanager/adapters/RecyclerAdapter.java
@@ -1401,8 +1401,7 @@ public class RecyclerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
   private void showPopup(@NonNull View view, @NonNull final LayoutElementParcelable rowItem) {
     if (hasPendingPasteOperation()) return;
     Context currentContext = this.context;
-    if (mainFragment.getMainActivity().getAppTheme().getSimpleTheme(mainFragment.requireContext())
-        == AppTheme.BLACK) {
+    if (mainFragment.getMainActivity().getAppTheme() == AppTheme.BLACK) {
       currentContext = new ContextThemeWrapper(context, R.style.overflow_black);
     }
     PopupMenu popupMenu =

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/LoadFolderSpaceDataTask.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/LoadFolderSpaceDataTask.java
@@ -137,7 +137,7 @@ public class LoadFolderSpaceDataTask extends AsyncTask<Void, Long, Pair<String, 
   }
 
   private void updateChart(String totalSpace, List<PieEntry> entries) {
-    boolean isDarkTheme = appTheme.getMaterialDialogTheme(context) == Theme.DARK;
+    boolean isDarkTheme = appTheme.getMaterialDialogTheme() == Theme.DARK;
 
     PieDataSet set = new PieDataSet(entries, null);
     set.setColors(COLORS);

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/movecopy/PreparePasteTask.kt
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/movecopy/PreparePasteTask.kt
@@ -212,7 +212,7 @@ class PreparePasteTask(strongRefMain: MainActivity) {
         val checkBox: AppCompatCheckBox = copyDialogBinding.checkBox
 
         Utils.setTint(contextRef, checkBox, accentColor)
-        dialogBuilder.theme(contextRef.appTheme.getMaterialDialogTheme(contextRef))
+        dialogBuilder.theme(contextRef.appTheme.getMaterialDialogTheme())
         dialogBuilder.title(contextRef.resources.getString(R.string.paste))
         dialogBuilder.positiveText(R.string.rename)
         dialogBuilder.neutralText(R.string.skip)

--- a/app/src/main/java/com/amaze/filemanager/ui/activities/AboutActivity.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/activities/AboutActivity.java
@@ -246,7 +246,7 @@ public class AboutActivity extends ThemedActivity implements View.OnClickListene
                 .withAboutSpecial1Description(getString(R.string.amaze_license))
                 .withLicenseShown(true);
 
-        switch (getAppTheme().getSimpleTheme(this)) {
+        switch (getAppTheme()) {
           case LIGHT:
             libsBuilder.withActivityStyle(Libs.ActivityStyle.LIGHT_DARK_TOOLBAR);
             break;

--- a/app/src/main/java/com/amaze/filemanager/ui/activities/MainActivity.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/activities/MainActivity.java
@@ -1201,7 +1201,7 @@ public class MainActivity extends PermissionsActivity
             case R.id.dsort:
               String[] sort = getResources().getStringArray(R.array.directorysortmode);
               MaterialDialog.Builder builder = new MaterialDialog.Builder(mainActivity);
-              builder.theme(getAppTheme().getMaterialDialogTheme(this));
+              builder.theme(getAppTheme().getMaterialDialogTheme());
               builder.title(R.string.directorysort);
               int current =
                   Integer.parseInt(
@@ -1730,7 +1730,7 @@ public class MainActivity extends PermissionsActivity
     getSupportActionBar().setDisplayShowTitleEnabled(false);
     fabBgView = findViewById(R.id.fabs_overlay_layout);
 
-    switch (getAppTheme().getSimpleTheme(this)) {
+    switch (getAppTheme()) {
       case DARK:
         fabBgView.setBackgroundResource(R.drawable.fab_shadow_dark);
         break;
@@ -1900,7 +1900,7 @@ public class MainActivity extends PermissionsActivity
             .setLabel(fabTitle)
             .setFabBackgroundColor(iconSkin);
 
-    switch (getAppTheme().getSimpleTheme(this)) {
+    switch (getAppTheme()) {
       case LIGHT:
         fabBgView.setBackgroundResource(R.drawable.fab_shadow_light);
         break;

--- a/app/src/main/java/com/amaze/filemanager/ui/activities/superclasses/ThemedActivity.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/activities/superclasses/ThemedActivity.java
@@ -30,6 +30,7 @@ import com.amaze.filemanager.ui.colors.UserColorPreferences;
 import com.amaze.filemanager.ui.dialogs.ColorPickerDialog;
 import com.amaze.filemanager.ui.fragments.preferencefragments.PreferencesConstants;
 import com.amaze.filemanager.ui.theme.AppTheme;
+import com.amaze.filemanager.ui.theme.AppThemePreference;
 import com.amaze.filemanager.utils.PreferenceUtils;
 import com.amaze.filemanager.utils.Utils;
 import com.readystatesoftware.systembartint.SystemBarTintManager;
@@ -73,12 +74,12 @@ public class ThemedActivity extends PreferenceActivity {
           boolean followBatterySaver =
               preferences.getBoolean(PreferencesConstants.FRAGMENT_FOLLOW_BATTERY_SAVER, false);
 
-          AppTheme theme =
-              AppTheme.getTheme(
+          AppThemePreference theme =
+              AppThemePreference.getTheme(
                   Integer.parseInt(
                       preferences.getString(PreferencesConstants.FRAGMENT_THEME, "4")));
 
-          if (followBatterySaver && theme.canBeLight()) {
+          if (followBatterySaver && theme.getCanBeLight()) {
             recreate();
           }
         }
@@ -166,7 +167,7 @@ public class ThemedActivity extends PreferenceActivity {
       uiModeNight = newUiModeNight;
 
       if (getPrefs().getString(PreferencesConstants.FRAGMENT_THEME, "4").equals("4")) {
-        getUtilsProvider().getThemeManager().setAppTheme(AppTheme.getTheme(4));
+        getUtilsProvider().getThemeManager().setAppThemePreference(AppThemePreference.getTheme(4));
         // Recreate activity, handling saved state
         //
         // Not smooth, but will only be called if the user changes the system theme, not
@@ -209,7 +210,7 @@ public class ThemedActivity extends PreferenceActivity {
   }
 
   void setTheme() {
-    AppTheme theme = getAppTheme().getSimpleTheme(this);
+    AppTheme theme = getAppTheme();
     if (Build.VERSION.SDK_INT >= 21) {
 
       String stringRepresentation = String.format("#%06X", (0xFFFFFF & getAccent()));

--- a/app/src/main/java/com/amaze/filemanager/ui/base/BaseBottomSheetFragment.kt
+++ b/app/src/main/java/com/amaze/filemanager/ui/base/BaseBottomSheetFragment.kt
@@ -54,7 +54,7 @@ open class BaseBottomSheetFragment : BottomSheetDialogFragment() {
                     )
                 )
             }
-            AppTheme.LIGHT, AppTheme.TIMED, AppTheme.SYSTEM -> {
+            AppTheme.LIGHT -> {
                 rootView
                     .setBackgroundDrawable(
                         context?.resources?.getDrawable(

--- a/app/src/main/java/com/amaze/filemanager/ui/dialogs/AlertDialog.kt
+++ b/app/src/main/java/com/amaze/filemanager/ui/dialogs/AlertDialog.kt
@@ -52,7 +52,7 @@ object AlertDialog {
             .theme(
                 activity
                     .appTheme
-                    .getMaterialDialogTheme(activity.applicationContext)
+                    .getMaterialDialogTheme()
             )
             .title(title)
             .positiveText(positiveButtonText)

--- a/app/src/main/java/com/amaze/filemanager/ui/dialogs/ColorPickerDialog.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/dialogs/ColorPickerDialog.java
@@ -26,7 +26,6 @@ import com.amaze.filemanager.application.AppConfig;
 import com.amaze.filemanager.ui.colors.UserColorPreferences;
 import com.amaze.filemanager.ui.fragments.preferencefragments.PreferencesConstants;
 import com.amaze.filemanager.ui.theme.AppTheme;
-import com.amaze.filemanager.ui.theme.AppThemePreference;
 import com.amaze.filemanager.ui.views.CircularColorsView;
 import com.amaze.filemanager.utils.Utils;
 
@@ -174,8 +173,7 @@ public class ColorPickerDialog extends PreferenceDialogFragmentCompat {
       colorsView.setColors(getColor(i, 0), getColor(i, 1), getColor(i, 2), getColor(i, 3));
 
       AppTheme appTheme = AppTheme.valueOf(requireArguments().getString(ARG_APP_THEME));
-      if (appTheme.getMaterialDialogTheme() == Theme.LIGHT)
-        colorsView.setDividerColor(Color.WHITE);
+      if (appTheme.getMaterialDialogTheme() == Theme.LIGHT) colorsView.setDividerColor(Color.WHITE);
       else colorsView.setDividerColor(Color.BLACK);
       container.addView(child);
     }

--- a/app/src/main/java/com/amaze/filemanager/ui/dialogs/ColorPickerDialog.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/dialogs/ColorPickerDialog.java
@@ -26,6 +26,7 @@ import com.amaze.filemanager.application.AppConfig;
 import com.amaze.filemanager.ui.colors.UserColorPreferences;
 import com.amaze.filemanager.ui.fragments.preferencefragments.PreferencesConstants;
 import com.amaze.filemanager.ui.theme.AppTheme;
+import com.amaze.filemanager.ui.theme.AppThemePreference;
 import com.amaze.filemanager.ui.views.CircularColorsView;
 import com.amaze.filemanager.utils.Utils;
 
@@ -117,7 +118,7 @@ public class ColorPickerDialog extends PreferenceDialogFragmentCompat {
     final Bundle b = new Bundle(2);
     b.putString(ARG_KEY, key);
     b.putParcelable(ARG_COLOR_PREF, color);
-    b.putInt(ARG_APP_THEME, theme.ordinal());
+    b.putString(ARG_APP_THEME, theme.toString());
     retval.setArguments(b);
     return retval;
   }
@@ -171,8 +172,9 @@ public class ColorPickerDialog extends PreferenceDialogFragmentCompat {
       ((AppCompatTextView) child.findViewById(R.id.text)).setText(COLORS[i].first);
       CircularColorsView colorsView = child.findViewById(R.id.circularColorsView);
       colorsView.setColors(getColor(i, 0), getColor(i, 1), getColor(i, 2), getColor(i, 3));
-      AppTheme appTheme = AppTheme.getTheme(requireArguments().getInt(ARG_APP_THEME));
-      if (appTheme.getMaterialDialogTheme(requireContext()) == Theme.LIGHT)
+
+      AppTheme appTheme = AppTheme.valueOf(requireArguments().getString(ARG_APP_THEME));
+      if (appTheme.getMaterialDialogTheme() == Theme.LIGHT)
         colorsView.setDividerColor(Color.WHITE);
       else colorsView.setDividerColor(Color.BLACK);
       container.addView(child);

--- a/app/src/main/java/com/amaze/filemanager/ui/dialogs/DecryptFingerprintDialog.kt
+++ b/app/src/main/java/com/amaze/filemanager/ui/dialogs/DecryptFingerprintDialog.kt
@@ -68,7 +68,7 @@ object DecryptFingerprintDialog {
         cancelButton.setTextColor(accentColor)
         builder.customView(rootView, true)
         builder.canceledOnTouchOutside(false)
-        builder.theme(appTheme.getMaterialDialogTheme(c))
+        builder.theme(appTheme.getMaterialDialogTheme())
         val dialog = builder.show()
         cancelButton.setOnClickListener { v: View? -> dialog.cancel() }
         val manager = c.getSystemService(FingerprintManager::class.java)

--- a/app/src/main/java/com/amaze/filemanager/ui/dialogs/DragAndDropDialog.kt
+++ b/app/src/main/java/com/amaze/filemanager/ui/dialogs/DragAndDropDialog.kt
@@ -132,7 +132,7 @@ class DragAndDropDialog : DialogFragment() {
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         safeLet(
             context,
-            mainActivity?.appTheme?.getMaterialDialogTheme(mainActivity?.applicationContext),
+            mainActivity?.appTheme?.getMaterialDialogTheme(),
             mainActivity?.accent,
             pasteLocation,
             operationFiles

--- a/app/src/main/java/com/amaze/filemanager/ui/dialogs/EncryptAuthenticateDialog.kt
+++ b/app/src/main/java/com/amaze/filemanager/ui/dialogs/EncryptAuthenticateDialog.kt
@@ -123,7 +123,7 @@ object EncryptAuthenticateDialog {
                 .customView(rootView, true)
                 .positiveText(c.getString(R.string.ok))
                 .negativeText(c.getString(R.string.cancel))
-                .theme(appTheme.getMaterialDialogTheme(c))
+                .theme(appTheme.getMaterialDialogTheme())
                 .positiveColor(accentColor)
                 .negativeColor(accentColor)
                 .autoDismiss(false)

--- a/app/src/main/java/com/amaze/filemanager/ui/dialogs/EncryptWarningDialog.kt
+++ b/app/src/main/java/com/amaze/filemanager/ui/dialogs/EncryptWarningDialog.kt
@@ -47,7 +47,7 @@ object EncryptWarningDialog {
         MaterialDialog.Builder(main).run {
             title(main.getString(R.string.warning))
             content(main.getString(R.string.crypt_warning_key))
-            theme(appTheme.getMaterialDialogTheme(main))
+            theme(appTheme.getMaterialDialogTheme())
             negativeText(main.getString(R.string.warning_never_show))
             positiveText(main.getString(R.string.warning_confirm))
             positiveColor(accentColor)

--- a/app/src/main/java/com/amaze/filemanager/ui/dialogs/GeneralDialogCreation.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/dialogs/GeneralDialogCreation.java
@@ -127,10 +127,7 @@ public class GeneralDialogCreation {
         new MaterialDialog.Builder(themedActivity)
             .content(content)
             .widgetColor(accentColor)
-            .theme(
-                themedActivity
-                    .getAppTheme()
-                    .getMaterialDialogTheme(themedActivity.getApplicationContext()))
+            .theme(themedActivity.getAppTheme().getMaterialDialogTheme())
             .title(title)
             .positiveText(postiveText)
             .positiveColor(accentColor)
@@ -165,7 +162,7 @@ public class GeneralDialogCreation {
     builder
         .customView(dialogView, false)
         .widgetColor(accentColor)
-        .theme(m.getAppTheme().getMaterialDialogTheme(m.getApplicationContext()))
+        .theme(m.getAppTheme().getMaterialDialogTheme())
         .title(title)
         .positiveText(positiveButtonText)
         .onPositive(positiveButtonAction);
@@ -213,7 +210,7 @@ public class GeneralDialogCreation {
         new MaterialDialog.Builder(context)
             .title(context.getString(R.string.dialog_delete_title))
             .customView(R.layout.dialog_delete, true)
-            .theme(appTheme.getMaterialDialogTheme(context))
+            .theme(appTheme.getMaterialDialogTheme())
             .negativeText(context.getString(R.string.cancel).toUpperCase())
             .positiveText(context.getString(R.string.delete).toUpperCase())
             .positiveColor(accentColor)
@@ -445,7 +442,7 @@ public class GeneralDialogCreation {
 
     MaterialDialog.Builder builder = new MaterialDialog.Builder(themedActivity);
     builder.title(c.getString(R.string.properties));
-    builder.theme(appTheme.getMaterialDialogTheme(c));
+    builder.theme(appTheme.getMaterialDialogTheme());
 
     View v = themedActivity.getLayoutInflater().inflate(R.layout.properties_dialog, null);
     AppCompatTextView itemsText = v.findViewById(R.id.t7);
@@ -549,7 +546,7 @@ public class GeneralDialogCreation {
     {
       int layoutDirection = TextUtilsCompat.getLayoutDirectionFromLocale(Locale.getDefault());
       boolean isRightToLeft = layoutDirection == ViewCompat.LAYOUT_DIRECTION_RTL;
-      boolean isDarkTheme = appTheme.getMaterialDialogTheme(c) == Theme.DARK;
+      boolean isDarkTheme = appTheme.getMaterialDialogTheme() == Theme.DARK;
       PieChart chart = v.findViewById(R.id.chart);
 
       chart.setTouchEnabled(false);
@@ -712,7 +709,7 @@ public class GeneralDialogCreation {
         break;
     }
 
-    builder.theme(appTheme.getMaterialDialogTheme(mainActivity.getApplicationContext()));
+    builder.theme(appTheme.getMaterialDialogTheme());
     builder.content(mainActivity.getString(R.string.cloud_remove));
 
     builder.positiveText(mainActivity.getString(R.string.yes));
@@ -775,7 +772,7 @@ public class GeneralDialogCreation {
 
     builder
         .customView(dialogLayout, false)
-        .theme(appTheme.getMaterialDialogTheme(c))
+        .theme(appTheme.getMaterialDialogTheme())
         .autoDismiss(false)
         .canceledOnTouchOutside(false)
         .title(titleText)
@@ -825,7 +822,7 @@ public class GeneralDialogCreation {
         .neutralColor(accentColor)
         .onPositive((dialog, which) -> FileUtils.installApk(f, m))
         .onNegative((dialog, which) -> m.openCompressed(f.getPath()))
-        .theme(m.getAppTheme().getMaterialDialogTheme(m.getApplicationContext()))
+        .theme(m.getAppTheme().getMaterialDialogTheme())
         .build()
         .show();
   }
@@ -842,7 +839,7 @@ public class GeneralDialogCreation {
         .negativeColor(accentColor)
         .onPositive((dialog, which) -> openCallback.run())
         .onNegative((dialog, which) -> dialog.dismiss())
-        .theme(m.getAppTheme().getMaterialDialogTheme(m.getApplicationContext()))
+        .theme(m.getAppTheme().getMaterialDialogTheme())
         .build();
   }
 
@@ -900,8 +897,7 @@ public class GeneralDialogCreation {
 
     a.customView(dialogView, false)
         .widgetColor(accentColor)
-        .theme(
-            mainActivity.getAppTheme().getMaterialDialogTheme(mainActivity.getApplicationContext()))
+        .theme(mainActivity.getAppTheme().getMaterialDialogTheme())
         .title(mainActivity.getResources().getString(R.string.enterzipname))
         .positiveText(R.string.create)
         .positiveColor(accentColor)
@@ -955,7 +951,7 @@ public class GeneralDialogCreation {
     String[] sort = m.getResources().getStringArray(R.array.sortby);
     int current = SortHandler.getSortType(m.getContext(), path);
     MaterialDialog.Builder a = new MaterialDialog.Builder(m.getActivity());
-    a.theme(appTheme.getMaterialDialogTheme(m.requireContext()));
+    a.theme(appTheme.getMaterialDialogTheme());
     a.items(sort)
         .itemsCallbackSingleChoice(
             current > 3 ? current - 4 : current, (dialog, view, which, text) -> true);
@@ -1112,8 +1108,7 @@ public class GeneralDialogCreation {
 
     a.widgetColor(accentColor);
 
-    a.theme(
-        mainActivity.getAppTheme().getMaterialDialogTheme(mainActivity.getApplicationContext()));
+    a.theme(mainActivity.getAppTheme().getMaterialDialogTheme());
     a.title(R.string.enterpath);
 
     a.positiveText(R.string.go);

--- a/app/src/main/java/com/amaze/filemanager/ui/dialogs/HiddenFilesDialog.kt
+++ b/app/src/main/java/com/amaze/filemanager/ui/dialogs/HiddenFilesDialog.kt
@@ -52,7 +52,7 @@ object HiddenFilesDialog {
             builder.positiveText(R.string.close)
             builder.positiveColor(mainActivity.accent)
             builder.title(R.string.hiddenfiles)
-            builder.theme(appTheme.getMaterialDialogTheme(mainFragment.requireContext()))
+            builder.theme(appTheme.getMaterialDialogTheme())
             builder.autoDismiss(true)
             builder.adapter(adapter, null)
             builder.dividerColor(Color.GRAY)

--- a/app/src/main/java/com/amaze/filemanager/ui/dialogs/HistoryDialog.kt
+++ b/app/src/main/java/com/amaze/filemanager/ui/dialogs/HistoryDialog.kt
@@ -56,7 +56,7 @@ object HistoryDialog {
             builder.onNegative { _: MaterialDialog?, _: DialogAction? ->
                 DataUtils.getInstance().clearHistory()
             }
-            builder.theme(appTheme.getMaterialDialogTheme(mainFragment.requireContext()))
+            builder.theme(appTheme.getMaterialDialogTheme())
             builder.adapter(adapter, null)
         }.build()
         adapter.materialDialog = materialDialog

--- a/app/src/main/java/com/amaze/filemanager/ui/dialogs/RenameBookmark.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/dialogs/RenameBookmark.java
@@ -83,8 +83,7 @@ public class RenameBookmark extends DialogFragment {
       builder.positiveText(R.string.save);
       builder.neutralText(R.string.cancel);
       builder.negativeText(R.string.delete);
-      builder.theme(
-          ((BasicActivity) getActivity()).getAppTheme().getMaterialDialogTheme(getContext()));
+      builder.theme(((BasicActivity) getActivity()).getAppTheme().getMaterialDialogTheme());
       builder.autoDismiss(false);
       View v2 = getActivity().getLayoutInflater().inflate(R.layout.rename, null);
       builder.customView(v2, true);

--- a/app/src/main/java/com/amaze/filemanager/ui/dialogs/SftpConnectDialog.kt
+++ b/app/src/main/java/com/amaze/filemanager/ui/dialogs/SftpConnectDialog.kt
@@ -38,7 +38,6 @@ import android.widget.AdapterView
 import android.widget.ArrayAdapter
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.text.isDigitsOnly
-import androidx.core.widget.addTextChangedListener
 import androidx.fragment.app.DialogFragment
 import com.afollestad.materialdialogs.DialogAction
 import com.afollestad.materialdialogs.MaterialDialog
@@ -154,7 +153,7 @@ class SftpConnectDialog : DialogFragment() {
             .title(R.string.scp_connection)
             .autoDismiss(false)
             .customView(binding.root, true)
-            .theme(utilsProvider.appTheme.getMaterialDialogTheme(context))
+            .theme(utilsProvider.appTheme.getMaterialDialogTheme())
             .negativeText(R.string.cancel)
             .positiveText(if (edit) R.string.update else R.string.create)
             .positiveColor(accentColor)

--- a/app/src/main/java/com/amaze/filemanager/ui/dialogs/SmbConnectDialog.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/dialogs/SmbConnectDialog.java
@@ -310,7 +310,7 @@ public class SmbConnectDialog extends DialogFragment {
     }
 
     ba3.customView(binding.getRoot(), true);
-    ba3.theme(utilsProvider.getAppTheme().getMaterialDialogTheme(context));
+    ba3.theme(utilsProvider.getAppTheme().getMaterialDialogTheme());
     ba3.neutralText(android.R.string.cancel);
     ba3.positiveText(edit ? R.string.update : R.string.create);
     if (edit) ba3.negativeText(R.string.delete);

--- a/app/src/main/java/com/amaze/filemanager/ui/dialogs/share/ShareTask.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/dialogs/share/ShareTask.java
@@ -123,7 +123,7 @@ public class ShareTask extends AsyncTask<String, String, Void> {
     if (!targetShareIntents.isEmpty()) {
       MaterialDialog.Builder builder = new MaterialDialog.Builder(contextc);
       builder.title(R.string.share);
-      builder.theme(appTheme.getMaterialDialogTheme(contextc));
+      builder.theme(appTheme.getMaterialDialogTheme());
       ShareAdapter shareAdapter = new ShareAdapter(contextc, targetShareIntents, labels, drawables);
       builder.adapter(shareAdapter, null);
       builder.negativeText(R.string.cancel);

--- a/app/src/main/java/com/amaze/filemanager/ui/fragments/AppsListFragment.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/fragments/AppsListFragment.java
@@ -200,7 +200,7 @@ public class AppsListFragment extends Fragment
     String[] sort = getResources().getStringArray(R.array.sortbyApps);
     MaterialDialog.Builder builder =
         new MaterialDialog.Builder(mainActivity)
-            .theme(appTheme.getMaterialDialogTheme(requireContext()))
+            .theme(appTheme.getMaterialDialogTheme())
             .items(sort)
             .itemsCallbackSingleChoice(sortby, (dialog, view, which, text) -> true)
             .negativeText(R.string.ascending)

--- a/app/src/main/java/com/amaze/filemanager/ui/fragments/FtpServerFragment.kt
+++ b/app/src/main/java/com/amaze/filemanager/ui/fragments/FtpServerFragment.kt
@@ -448,7 +448,7 @@ class FtpServerFragment : Fragment(R.layout.fragment_ftp) {
                         MaterialDialog.Builder(mainActivity)
                             .content(R.string.ftp_prompt_accept_first_start_saf_access)
                             .widgetColor(accentColor)
-                            .theme(mainActivity.appTheme.getMaterialDialogTheme(c))
+                            .theme(mainActivity.appTheme.getMaterialDialogTheme())
                             .title(R.string.ftp_prompt_accept_first_start_saf_access_title)
                             .positiveText(R.string.ok)
                             .positiveColor(accentColor)
@@ -704,7 +704,7 @@ class FtpServerFragment : Fragment(R.layout.fragment_ftp) {
         val startDividerView = binding.dividerFtpStart
         val statusDividerView = binding.dividerFtpStatus
 
-        when (mainActivity.appTheme.getSimpleTheme(mainActivity.applicationContext)) {
+        when (mainActivity.appTheme) {
             AppTheme.LIGHT -> {
                 startDividerView.setBackgroundColor(Utils.getColor(context, R.color.divider))
                 statusDividerView.setBackgroundColor(Utils.getColor(context, R.color.divider))

--- a/app/src/main/java/com/amaze/filemanager/ui/fragments/preferencefragments/AppearancePrefsFragment.kt
+++ b/app/src/main/java/com/amaze/filemanager/ui/fragments/preferencefragments/AppearancePrefsFragment.kt
@@ -26,7 +26,7 @@ import com.afollestad.materialdialogs.MaterialDialog
 import com.amaze.filemanager.R
 import com.amaze.filemanager.ui.fragments.preferencefragments.PreferencesConstants.PREFERENCE_GRID_COLUMNS
 import com.amaze.filemanager.ui.fragments.preferencefragments.PreferencesConstants.PREFERENCE_GRID_COLUMNS_DEFAULT
-import com.amaze.filemanager.ui.theme.AppTheme
+import com.amaze.filemanager.ui.theme.AppThemePreference
 import java.util.*
 
 class AppearancePrefsFragment : BasePrefsFragment() {
@@ -54,7 +54,9 @@ class AppearancePrefsFragment : BasePrefsFragment() {
                 editor.putString(PreferencesConstants.FRAGMENT_THEME, which.toString())
                 editor.apply()
 
-                activity.utilsProvider.themeManager.appTheme = AppTheme.getTheme(which)
+                activity.utilsProvider.themeManager.setAppThemePreference(
+                    AppThemePreference.getTheme(which)
+                )
                 activity.recreate()
 
                 dialog.dismiss()
@@ -69,7 +71,7 @@ class AppearancePrefsFragment : BasePrefsFragment() {
 
     private val onClickGridColumn = Preference.OnPreferenceClickListener {
         val dialog = MaterialDialog.Builder(activity).also { builder ->
-            builder.theme(activity.utilsProvider.appTheme.getMaterialDialogTheme(activity))
+            builder.theme(activity.utilsProvider.appTheme.getMaterialDialogTheme())
             builder.title(R.string.gridcolumnno)
             val columnsPreference = activity
                 .prefs
@@ -127,8 +129,8 @@ class AppearancePrefsFragment : BasePrefsFragment() {
             PreferencesConstants.FRAGMENT_FOLLOW_BATTERY_SAVER
         )
 
-        val currentThemeEnum = AppTheme.getTheme(currentTheme)
-        batterySaverPref?.isVisible = currentThemeEnum.canBeLight()
+        val currentThemeEnum = AppThemePreference.getTheme(currentTheme)
+        batterySaverPref?.isVisible = currentThemeEnum.canBeLight
         batterySaverPref?.onPreferenceClickListener = onClickFollowBatterySaver
 
         findPreference<Preference>(PreferencesConstants.PREFERENCE_COLORED_NAVIGATION)

--- a/app/src/main/java/com/amaze/filemanager/ui/fragments/preferencefragments/BookmarksPrefsFragment.kt
+++ b/app/src/main/java/com/amaze/filemanager/ui/fragments/preferencefragments/BookmarksPrefsFragment.kt
@@ -98,7 +98,7 @@ class BookmarksPrefsFragment : BasePrefsFragment() {
 
         val dialog = MaterialDialog.Builder(requireActivity())
             .title(R.string.create_bookmark)
-            .theme(activity.appTheme.getMaterialDialogTheme(activity.applicationContext))
+            .theme(activity.appTheme.getMaterialDialogTheme())
             .positiveColor(fabSkin)
             .positiveText(R.string.create)
             .negativeColor(fabSkin)
@@ -147,7 +147,7 @@ class BookmarksPrefsFragment : BasePrefsFragment() {
 
         val dialog = MaterialDialog.Builder(activity)
             .title(R.string.edit_bookmark)
-            .theme(activity.appTheme.getMaterialDialogTheme(activity.applicationContext))
+            .theme(activity.appTheme.getMaterialDialogTheme())
             .positiveColor(fabSkin)
             .positiveText(getString(R.string.edit).uppercase()) // TODO: 29/4/2017 don't use toUpperCase()
             .negativeColor(fabSkin)
@@ -191,7 +191,7 @@ class BookmarksPrefsFragment : BasePrefsFragment() {
 
         val dialog = MaterialDialog.Builder(activity)
             .title(R.string.question_delete_bookmark)
-            .theme(activity.appTheme.getMaterialDialogTheme(activity.applicationContext))
+            .theme(activity.appTheme.getMaterialDialogTheme())
             .positiveColor(fabSkin)
             .positiveText(getString(R.string.delete).uppercase()) // TODO: 29/4/2017 don't use toUpperCase(), 20/9,2017 why not?
             .negativeColor(fabSkin)

--- a/app/src/main/java/com/amaze/filemanager/ui/fragments/preferencefragments/ColorPrefsFragment.kt
+++ b/app/src/main/java/com/amaze/filemanager/ui/fragments/preferencefragments/ColorPrefsFragment.kt
@@ -148,7 +148,7 @@ class ColorPrefsFragment : BasePrefsFragment() {
         dialog = MaterialDialog.Builder(activity)
             .positiveText(com.amaze.filemanager.R.string.cancel)
             .title(com.amaze.filemanager.R.string.choose_color)
-            .theme(activity.appTheme.getMaterialDialogTheme(activity.applicationContext))
+            .theme(activity.appTheme.getMaterialDialogTheme())
             .autoDismiss(true)
             .positiveColor(fabSkin)
             .neutralColor(fabSkin)

--- a/app/src/main/java/com/amaze/filemanager/ui/fragments/preferencefragments/SecurityPrefsFragment.kt
+++ b/app/src/main/java/com/amaze/filemanager/ui/fragments/preferencefragments/SecurityPrefsFragment.kt
@@ -122,7 +122,7 @@ class SecurityPrefsFragment : BasePrefsFragment() {
             true
         ) { _, _ -> }
         masterPasswordDialogBuilder.theme(
-            activity.utilsProvider.appTheme.getMaterialDialogTheme(requireContext())
+            activity.utilsProvider.appTheme.getMaterialDialogTheme()
         )
         masterPasswordDialogBuilder.positiveText(resources.getString(R.string.ok))
         masterPasswordDialogBuilder.negativeText(resources.getString(R.string.cancel))

--- a/app/src/main/java/com/amaze/filemanager/ui/fragments/preferencefragments/UiPrefsFragment.kt
+++ b/app/src/main/java/com/amaze/filemanager/ui/fragments/preferencefragments/UiPrefsFragment.kt
@@ -51,7 +51,7 @@ class UiPrefsFragment : BasePrefsFragment() {
         dragAndDropPref?.onPreferenceClickListener = Preference.OnPreferenceClickListener {
             val dragDialogBuilder = MaterialDialog.Builder(activity)
             dragDialogBuilder.theme(
-                activity.utilsProvider.appTheme.getMaterialDialogTheme(requireContext())
+                activity.utilsProvider.appTheme.getMaterialDialogTheme()
             )
             dragDialogBuilder.title(R.string.drag_and_drop_preference)
             val currentDragPreference: Int = activity.prefs.getInt(

--- a/app/src/main/java/com/amaze/filemanager/ui/selection/SelectionPopupMenu.kt
+++ b/app/src/main/java/com/amaze/filemanager/ui/selection/SelectionPopupMenu.kt
@@ -52,7 +52,7 @@ class SelectionPopupMenu(
         ) {
             mainActivity?.also {
                 var currentContext: Context = mainActivity.applicationContext
-                if (mainActivity.appTheme.getSimpleTheme(currentContext) == AppTheme.BLACK) {
+                if (mainActivity.appTheme == AppTheme.BLACK) {
                     currentContext = ContextThemeWrapper(
                         mainActivity.applicationContext,
                         R.style.overflow_black

--- a/app/src/main/java/com/amaze/filemanager/ui/theme/AppTheme.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/theme/AppTheme.java
@@ -20,143 +20,22 @@
 
 package com.amaze.filemanager.ui.theme;
 
-import java.util.Calendar;
-
 import com.afollestad.materialdialogs.Theme;
-import com.amaze.filemanager.ui.fragments.preferencefragments.PreferencesConstants;
-
-import android.content.Context;
-import android.content.SharedPreferences;
-import android.content.res.Configuration;
-import android.os.Build;
-import android.os.PowerManager;
-
-import androidx.preference.PreferenceManager;
 
 /** This enum represents the theme of the app (LIGHT or DARK) */
 public enum AppTheme {
-  LIGHT(0, true),
-  DARK(1, false),
-  TIMED(2, true),
-  BLACK(3, false),
-  SYSTEM(4, true);
+  LIGHT,
+  DARK,
+  BLACK;
 
-  public static final int LIGHT_INDEX = 0;
-  public static final int DARK_INDEX = 1;
-  public static final int TIME_INDEX = 2;
-  public static final int BLACK_INDEX = 3;
-  public static final int SYSTEM_INDEX = 4;
-
-  private int id;
-
-  /**
-   * Specifies if the theme can be light in some situations. Used for the "Follow battery saver"
-   * option.
-   */
-  private final boolean canBeLight;
-
-  AppTheme(int id, boolean canBeLight) {
-    this.id = id;
-    this.canBeLight = canBeLight;
-  }
-
-  /**
-   * Returns the correct AppTheme. If index == TIME_INDEX, TIMED is returned.
-   *
-   * @param index The theme index
-   * @return The AppTheme for the given index
-   */
-  public static AppTheme getTheme(int index) {
-    switch (index) {
+  public Theme getMaterialDialogTheme() {
+    switch (this) {
       default:
-      case LIGHT_INDEX:
-        return LIGHT;
-      case DARK_INDEX:
-        return DARK;
-      case TIME_INDEX:
-        return TIMED;
-      case BLACK_INDEX:
-        return BLACK;
-      case SYSTEM_INDEX:
-        return SYSTEM;
-    }
-  }
-
-  public Theme getMaterialDialogTheme(Context context) {
-    AppTheme simpleTheme = getSimpleTheme(context);
-    switch (simpleTheme.id) {
-      default:
-      case LIGHT_INDEX:
+      case LIGHT:
         return Theme.LIGHT;
-      case DARK_INDEX:
-      case BLACK_INDEX:
+      case DARK:
+      case BLACK:
         return Theme.DARK;
-    }
-  }
-
-  /**
-   * Returns the correct AppTheme. If index == TIME_INDEX, current time is used to select the theme.
-   *
-   * @return The AppTheme for the given index
-   */
-  public AppTheme getSimpleTheme(Context context) {
-    SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(context);
-    boolean followBatterySaver =
-        preferences.getBoolean(PreferencesConstants.FRAGMENT_FOLLOW_BATTERY_SAVER, false);
-    return getSimpleTheme(isNightMode(context), followBatterySaver && isBatterySaverMode(context));
-  }
-
-  public AppTheme getSimpleTheme(boolean isNightMode, boolean isBatterySaver) {
-    if (this.canBeLight() && isBatterySaver) {
-      return DARK;
-    }
-
-    switch (id) {
-      default:
-      case LIGHT_INDEX:
-        return LIGHT;
-      case DARK_INDEX:
-        return DARK;
-      case TIME_INDEX:
-        int hour = Calendar.getInstance().get(Calendar.HOUR_OF_DAY);
-        if (hour <= 6 || hour >= 18) {
-          return DARK;
-        } else {
-          return LIGHT;
-        }
-      case BLACK_INDEX:
-        return BLACK;
-      case SYSTEM_INDEX:
-        return isNightMode ? DARK : LIGHT;
-    }
-  }
-
-  public int getId() {
-    return id;
-  }
-
-  /** Returns if the theme can be light in some situations */
-  public boolean canBeLight() {
-    return this.canBeLight;
-  }
-
-  private static boolean isNightMode(Context context) {
-    return (context.getResources().getConfiguration().uiMode & Configuration.UI_MODE_NIGHT_MASK)
-        == Configuration.UI_MODE_NIGHT_YES;
-  }
-
-  /**
-   * Checks if battery saver mode is on
-   *
-   * @param context The context in which the battery saver mode should be checked
-   * @return Whether battery saver mode is on or off
-   */
-  private static boolean isBatterySaverMode(Context context) {
-    PowerManager powerManager = (PowerManager) context.getSystemService(Context.POWER_SERVICE);
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-      return powerManager.isPowerSaveMode();
-    } else {
-      return false;
     }
   }
 }

--- a/app/src/main/java/com/amaze/filemanager/ui/theme/AppThemeManager.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/theme/AppThemeManager.java
@@ -28,31 +28,31 @@ import android.content.SharedPreferences;
 /** Saves and restores the AppTheme */
 public class AppThemeManager {
   private SharedPreferences preferences;
-  private AppTheme appTheme;
+  private AppThemePreference appThemePreference;
   private final Context context;
 
   public AppThemeManager(SharedPreferences preferences, Context context) {
     this.preferences = preferences;
     this.context = context;
     String themeId = preferences.getString(PreferencesConstants.FRAGMENT_THEME, "4");
-    appTheme = AppTheme.getTheme(Integer.parseInt(themeId));
+    appThemePreference = AppThemePreference.getTheme(Integer.parseInt(themeId));
   }
 
   /**
    * @return The current Application theme
    */
   public AppTheme getAppTheme() {
-    return appTheme.getSimpleTheme(context);
+    return appThemePreference.getSimpleTheme(context);
   }
 
   /**
    * Change the current theme of the application. The change is saved.
    *
-   * @param appTheme The new theme
+   * @param appThemePreference The new theme
    * @return The theme manager.
    */
-  public AppThemeManager setAppTheme(AppTheme appTheme) {
-    this.appTheme = appTheme;
+  public AppThemeManager setAppThemePreference(AppThemePreference appThemePreference) {
+    this.appThemePreference = appThemePreference;
     return this;
   }
 }

--- a/app/src/main/java/com/amaze/filemanager/ui/theme/AppThemePreference.kt
+++ b/app/src/main/java/com/amaze/filemanager/ui/theme/AppThemePreference.kt
@@ -75,10 +75,10 @@ enum class AppThemePreference(val id: Int, val canBeLight: Boolean) {
         return if (canBeLight && isBatterySaver) {
             AppTheme.DARK
         } else {
-            when (id) {
-                LIGHT_INDEX -> AppTheme.LIGHT
-                DARK_INDEX -> AppTheme.DARK
-                TIME_INDEX -> {
+            when (this) {
+                LIGHT -> AppTheme.LIGHT
+                DARK -> AppTheme.DARK
+                TIMED -> {
                     val hour = Calendar.getInstance()[Calendar.HOUR_OF_DAY]
                     if (hour <= 6 || hour >= 18) {
                         AppTheme.DARK
@@ -87,9 +87,8 @@ enum class AppThemePreference(val id: Int, val canBeLight: Boolean) {
                     }
                 }
 
-                BLACK_INDEX -> AppTheme.BLACK
-                SYSTEM_INDEX -> if (isNightMode) AppTheme.DARK else AppTheme.LIGHT
-                else -> AppTheme.LIGHT
+                BLACK -> AppTheme.BLACK
+                SYSTEM -> if (isNightMode) AppTheme.DARK else AppTheme.LIGHT
             }
         }
     }

--- a/app/src/main/java/com/amaze/filemanager/ui/theme/AppThemePreference.kt
+++ b/app/src/main/java/com/amaze/filemanager/ui/theme/AppThemePreference.kt
@@ -1,0 +1,138 @@
+/*
+ * Copyright (C) 2014-2023 Arpit Khurana <arpitkh96@gmail.com>, Vishal Nehra <vishalmeham2@gmail.com>,
+ * Emmanuel Messulam<emmanuelbendavid@gmail.com>, Raymond Lai <airwave209gt at gmail.com> and Contributors.
+ *
+ * This file is part of Amaze File Manager.
+ *
+ * Amaze File Manager is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.amaze.filemanager.ui.theme
+
+import android.content.Context
+import android.content.res.Configuration
+import android.os.Build
+import android.os.PowerManager
+import androidx.preference.PreferenceManager
+import com.afollestad.materialdialogs.Theme
+import com.amaze.filemanager.ui.fragments.preferencefragments.PreferencesConstants
+import java.util.Calendar
+
+/**
+ * This enum represents the theme selected by the user in the appearance preferences.
+ *
+ * [id] corresponds to the index of the value in the selection dialog in the preferences.
+ *
+ * [canBeLight] specifies if the theme can be light in some situations. Used for the "Follow battery saver"
+ * option.
+ */
+enum class AppThemePreference(val id: Int, val canBeLight: Boolean) {
+    LIGHT(0, true),
+    DARK(1, false),
+    TIMED(2, true),
+    BLACK(3, false),
+    SYSTEM(4, true);
+
+    fun getMaterialDialogTheme(context: Context): Theme {
+        return getSimpleTheme(context).getMaterialDialogTheme()
+    }
+
+    /**
+     * Returns the correct [AppTheme]. If this is [AppThemePreference.TIME_INDEX], current time is used to select the theme.
+     *
+     * @return The [AppTheme] for the given index
+     */
+    fun getSimpleTheme(context: Context): AppTheme {
+        val preferences = PreferenceManager.getDefaultSharedPreferences(context)
+        val followBatterySaver = preferences.getBoolean(
+            PreferencesConstants.FRAGMENT_FOLLOW_BATTERY_SAVER,
+            false
+        )
+        return getSimpleTheme(
+            isNightMode(context),
+            followBatterySaver && isBatterySaverMode(context)
+        )
+    }
+
+    fun getSimpleTheme(isNightMode: Boolean, isBatterySaver: Boolean): AppTheme {
+        return if (canBeLight && isBatterySaver) {
+            AppTheme.DARK
+        } else {
+            when (id) {
+                LIGHT_INDEX -> AppTheme.LIGHT
+                DARK_INDEX -> AppTheme.DARK
+                TIME_INDEX -> {
+                    val hour = Calendar.getInstance()[Calendar.HOUR_OF_DAY]
+                    if (hour <= 6 || hour >= 18) {
+                        AppTheme.DARK
+                    } else {
+                        AppTheme.LIGHT
+                    }
+                }
+
+                BLACK_INDEX -> AppTheme.BLACK
+                SYSTEM_INDEX -> if (isNightMode) AppTheme.DARK else AppTheme.LIGHT
+                else -> AppTheme.LIGHT
+            }
+        }
+    }
+
+    /**
+     * Checks if night mode is on using [context]
+     */
+    private fun isNightMode(context: Context): Boolean {
+        return (
+            context.resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK
+                == Configuration.UI_MODE_NIGHT_YES
+            )
+    }
+
+    /**
+     * Checks if battery saver mode is on using [context]
+     */
+    private fun isBatterySaverMode(context: Context): Boolean {
+        val powerManager = context.getSystemService(Context.POWER_SERVICE) as PowerManager
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            powerManager.isPowerSaveMode
+        } else {
+            false
+        }
+    }
+
+    companion object {
+        const val LIGHT_INDEX = 0
+        const val DARK_INDEX = 1
+        const val TIME_INDEX = 2
+        const val BLACK_INDEX = 3
+        const val SYSTEM_INDEX = 4
+
+        /**
+         * Returns the correct AppTheme . If [index] == TIME_INDEX, TIMED is returned.
+         *
+         * @param index The theme index
+         * @return The AppTheme for the given index
+         */
+        @JvmStatic
+        fun getTheme(index: Int): AppThemePreference {
+            return when (index) {
+                LIGHT_INDEX -> LIGHT
+                DARK_INDEX -> DARK
+                TIME_INDEX -> TIMED
+                BLACK_INDEX -> BLACK
+                SYSTEM_INDEX -> SYSTEM
+                else -> LIGHT
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/amaze/filemanager/ui/theme/AppThemePreference.kt
+++ b/app/src/main/java/com/amaze/filemanager/ui/theme/AppThemePreference.kt
@@ -44,6 +44,9 @@ enum class AppThemePreference(val id: Int, val canBeLight: Boolean) {
     BLACK(3, false),
     SYSTEM(4, true);
 
+    /**
+     * Returns the correct [Theme] associated with this [AppThemePreference] based on [context].
+     */
     fun getMaterialDialogTheme(context: Context): Theme {
         return getSimpleTheme(context).getMaterialDialogTheme()
     }
@@ -65,6 +68,9 @@ enum class AppThemePreference(val id: Int, val canBeLight: Boolean) {
         )
     }
 
+    /**
+     * Returns the correct [AppTheme] based on [isNightMode] and [isBatterySaver].
+     */
     fun getSimpleTheme(isNightMode: Boolean, isBatterySaver: Boolean): AppTheme {
         return if (canBeLight && isBatterySaver) {
             AppTheme.DARK

--- a/app/src/main/java/com/amaze/filemanager/ui/views/appbar/SearchView.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/views/appbar/SearchView.java
@@ -430,7 +430,7 @@ public class SearchView {
   }
 
   private void initSearchViewColor(MainActivity a) {
-    AppTheme theme = a.getAppTheme().getSimpleTheme(a);
+    AppTheme theme = a.getAppTheme();
     switch (theme) {
       case LIGHT:
         searchViewLayout.setBackgroundResource(R.drawable.search_view_shape);

--- a/app/src/main/java/com/amaze/filemanager/utils/MainActivityHelper.java
+++ b/app/src/main/java/com/amaze/filemanager/utils/MainActivityHelper.java
@@ -117,7 +117,7 @@ public class MainActivityHelper {
       ArrayList<HybridFileParcelable> failedOps, Context context) {
     MaterialDialog.Builder mat = new MaterialDialog.Builder(context);
     mat.title(context.getString(R.string.operation_unsuccesful));
-    mat.theme(mainActivity.getAppTheme().getMaterialDialogTheme(context));
+    mat.theme(mainActivity.getAppTheme().getMaterialDialogTheme());
     mat.positiveColor(accentColor);
     mat.positiveText(R.string.cancel);
     String content = context.getString(R.string.operation_fail_following);
@@ -306,8 +306,7 @@ public class MainActivityHelper {
 
   public void guideDialogForLEXA(String path, int requestCode) {
     final MaterialDialog.Builder x = new MaterialDialog.Builder(mainActivity);
-    x.theme(
-        mainActivity.getAppTheme().getMaterialDialogTheme(mainActivity.getApplicationContext()));
+    x.theme(mainActivity.getAppTheme().getMaterialDialogTheme());
     x.title(R.string.needs_access);
     LayoutInflater layoutInflater =
         (LayoutInflater) mainActivity.getSystemService(Context.LAYOUT_INFLATER_SERVICE);

--- a/app/src/play/java/com/amaze/filemanager/utils/Billing.kt
+++ b/app/src/play/java/com/amaze/filemanager/utils/Billing.kt
@@ -257,7 +257,7 @@ class Billing(private val activity: BasicActivity) :
                     val builder: MaterialDialog.Builder = MaterialDialog.Builder(context)
                     builder.title(R.string.donate)
                     builder.adapter(this, null)
-                    builder.theme(context.appTheme.getMaterialDialogTheme(context))
+                    builder.theme(context.appTheme.getMaterialDialogTheme())
                     builder.cancelListener { purchaseProduct.purchaseCancel() }
                     donationDialog = builder.show()
                     null

--- a/app/src/test/java/com/amaze/filemanager/ui/dialogs/ColorPickerDialogTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/ui/dialogs/ColorPickerDialogTest.kt
@@ -53,7 +53,7 @@ class ColorPickerDialogTest {
         val dialog = ColorPickerDialog.newInstance(
             PreferencesConstants.PRESELECTED_CONFIGS,
             ColorPreferenceHelper.randomize(AppConfig.getInstance()),
-            AppTheme.SYSTEM
+            AppTheme.LIGHT
         )
         assertNotNull(dialog)
     }

--- a/app/src/test/java/com/amaze/filemanager/ui/theme/AppThemeTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/ui/theme/AppThemeTest.kt
@@ -47,19 +47,34 @@ import java.util.*
 class AppThemeTest {
 
     /**
-     * Test that the theme coincides with the index for [AppTheme.getTheme]
+     * Test that the theme coincides with the index for [AppThemePreference.getTheme]
      */
     @Test
     fun testGetTheme() {
-        Assert.assertEquals(AppTheme.LIGHT, AppTheme.getTheme(AppTheme.LIGHT_INDEX))
+        Assert.assertEquals(
+            AppThemePreference.LIGHT,
+            AppThemePreference.getTheme(AppThemePreference.LIGHT_INDEX)
+        )
 
-        Assert.assertEquals(AppTheme.DARK, AppTheme.getTheme(AppTheme.DARK_INDEX))
+        Assert.assertEquals(
+            AppThemePreference.DARK,
+            AppThemePreference.getTheme(AppThemePreference.DARK_INDEX)
+        )
 
-        Assert.assertEquals(AppTheme.TIMED, AppTheme.getTheme(AppTheme.TIME_INDEX))
+        Assert.assertEquals(
+            AppThemePreference.TIMED,
+            AppThemePreference.getTheme(AppThemePreference.TIME_INDEX)
+        )
 
-        Assert.assertEquals(AppTheme.BLACK, AppTheme.getTheme(AppTheme.BLACK_INDEX))
+        Assert.assertEquals(
+            AppThemePreference.BLACK,
+            AppThemePreference.getTheme(AppThemePreference.BLACK_INDEX)
+        )
 
-        Assert.assertEquals(AppTheme.SYSTEM, AppTheme.getTheme(AppTheme.SYSTEM_INDEX))
+        Assert.assertEquals(
+            AppThemePreference.SYSTEM,
+            AppThemePreference.getTheme(AppThemePreference.SYSTEM_INDEX)
+        )
     }
 
     /**
@@ -69,18 +84,33 @@ class AppThemeTest {
     fun testMaterialDialogTheme() {
         val context = ApplicationProvider.getApplicationContext<Context>()
 
-        Assert.assertEquals(Theme.LIGHT, getMaterialDialogTheme(AppTheme.LIGHT_INDEX, context))
+        Assert.assertEquals(
+            Theme.LIGHT,
+            getMaterialDialogTheme(AppThemePreference.LIGHT_INDEX, context)
+        )
 
-        Assert.assertEquals(Theme.DARK, getMaterialDialogTheme(AppTheme.DARK_INDEX, context))
+        Assert.assertEquals(
+            Theme.DARK,
+            getMaterialDialogTheme(AppThemePreference.DARK_INDEX, context)
+        )
 
         val hour = Calendar.getInstance()[Calendar.HOUR_OF_DAY]
         if (hour <= 6 || hour >= 18) {
-            Assert.assertEquals(Theme.DARK, getMaterialDialogTheme(AppTheme.TIME_INDEX, context))
+            Assert.assertEquals(
+                Theme.DARK,
+                getMaterialDialogTheme(AppThemePreference.TIME_INDEX, context)
+            )
         } else {
-            Assert.assertEquals(Theme.LIGHT, getMaterialDialogTheme(AppTheme.TIME_INDEX, context))
+            Assert.assertEquals(
+                Theme.LIGHT,
+                getMaterialDialogTheme(AppThemePreference.TIME_INDEX, context)
+            )
         }
 
-        Assert.assertEquals(Theme.DARK, getMaterialDialogTheme(AppTheme.BLACK_INDEX, context))
+        Assert.assertEquals(
+            Theme.DARK,
+            getMaterialDialogTheme(AppThemePreference.BLACK_INDEX, context)
+        )
     }
 
     /**
@@ -92,28 +122,28 @@ class AppThemeTest {
 
         Assert.assertEquals(
             AppTheme.LIGHT,
-            getSimpleTheme(AppTheme.LIGHT_INDEX, context)
+            getSimpleTheme(AppThemePreference.LIGHT_INDEX, context)
         )
 
         Assert.assertEquals(
             AppTheme.DARK,
-            getSimpleTheme(AppTheme.DARK_INDEX, context)
+            getSimpleTheme(AppThemePreference.DARK_INDEX, context)
         )
 
         val hour = Calendar.getInstance()[Calendar.HOUR_OF_DAY]
         if (hour <= 6 || hour >= 18) {
             Assert.assertEquals(
                 AppTheme.DARK,
-                getSimpleTheme(AppTheme.TIME_INDEX, context)
+                getSimpleTheme(AppThemePreference.TIME_INDEX, context)
             )
         } else Assert.assertEquals(
             AppTheme.LIGHT,
-            getSimpleTheme(AppTheme.TIME_INDEX, context)
+            getSimpleTheme(AppThemePreference.TIME_INDEX, context)
         )
 
         Assert.assertEquals(
             AppTheme.BLACK,
-            getSimpleTheme(AppTheme.BLACK_INDEX, context)
+            getSimpleTheme(AppThemePreference.BLACK_INDEX, context)
         )
     }
 
@@ -125,7 +155,7 @@ class AppThemeTest {
     fun testSimpleSystemThemeNightModeOn() {
         val context = ApplicationProvider.getApplicationContext<Context>()
 
-        Assert.assertEquals(AppTheme.DARK, getSimpleTheme(AppTheme.SYSTEM_INDEX, context))
+        Assert.assertEquals(AppTheme.DARK, getSimpleTheme(AppThemePreference.SYSTEM_INDEX, context))
     }
 
     /**
@@ -136,7 +166,10 @@ class AppThemeTest {
     fun testSimpleSystemThemeNightModeOff() {
         val context = ApplicationProvider.getApplicationContext<Context>()
 
-        Assert.assertEquals(AppTheme.LIGHT, getSimpleTheme(AppTheme.SYSTEM_INDEX, context))
+        Assert.assertEquals(
+            AppTheme.LIGHT,
+            getSimpleTheme(AppThemePreference.SYSTEM_INDEX, context)
+        )
     }
 
     /**
@@ -153,7 +186,7 @@ class AppThemeTest {
 
         setUpForFollowBatterySaverMode(context, true)
 
-        val canBeLightThemes = AppTheme.values().filter { it.canBeLight() }
+        val canBeLightThemes = AppThemePreference.values().filter { it.canBeLight }
 
         for (lightTheme in canBeLightThemes) {
             Assert.assertEquals(
@@ -165,12 +198,12 @@ class AppThemeTest {
 
         Assert.assertEquals(
             AppTheme.DARK,
-            getSimpleTheme(AppTheme.DARK_INDEX, context)
+            getSimpleTheme(AppThemePreference.DARK_INDEX, context)
         )
 
         Assert.assertEquals(
             AppTheme.BLACK,
-            getSimpleTheme(AppTheme.BLACK_INDEX, context)
+            getSimpleTheme(AppThemePreference.BLACK_INDEX, context)
         )
     }
 
@@ -206,7 +239,7 @@ class AppThemeTest {
 
         setUpForFollowBatterySaverMode(context, true)
 
-        val canBeLightThemes = AppTheme.values().filter { it.canBeLight() }
+        val canBeLightThemes = AppThemePreference.values().filter { it.canBeLight }
 
         for (lightTheme in canBeLightThemes) {
             Assert.assertEquals(
@@ -218,12 +251,12 @@ class AppThemeTest {
 
         Assert.assertEquals(
             Theme.DARK,
-            getMaterialDialogTheme(AppTheme.DARK_INDEX, context)
+            getMaterialDialogTheme(AppThemePreference.DARK_INDEX, context)
         )
 
         Assert.assertEquals(
             Theme.DARK,
-            getMaterialDialogTheme(AppTheme.BLACK_INDEX, context)
+            getMaterialDialogTheme(AppThemePreference.BLACK_INDEX, context)
         )
     }
 
@@ -247,11 +280,11 @@ class AppThemeTest {
 
     /** Shortcut to get the material dialog theme from the theme index */
     private fun getMaterialDialogTheme(apptheme: Int, context: Context): Theme =
-        AppTheme.getTheme(apptheme).getMaterialDialogTheme(context)
+        AppThemePreference.getTheme(apptheme).getMaterialDialogTheme(context)
 
     /** Shortcut to get the simple theme from the theme index */
     private fun getSimpleTheme(index: Int, context: Context): AppTheme =
-        AppTheme.getTheme(index).getSimpleTheme(context)
+        AppThemePreference.getTheme(index).getSimpleTheme(context)
 
     /** Sets the battery saver mode to [batterySaverOn] and the "Follow battery saver" option to true */
     private fun setUpForFollowBatterySaverMode(context: Context, batterySaverOn: Boolean) {


### PR DESCRIPTION
<!-- 
Read this first:
To open a pull request read this file,
uncomment the corresponding lines and 
complete them.
-->

## Description
This PR splits the `AppTheme` enum into two enums.`AppThemePreference` represents the theme that the user selects in the settings while `AppTheme` represents the theme/color that the app should use for the UI.

The PR is branched off of the branch for #3986 since I made some changes to `AppTheme` there, so this should only be merged after #3986.

#### Issue tracker   
<!-- Fixes will automatically close the related issue -->
Fixes #3988
<!-- Addresses won't automatically close the related issue -->
<!-- Addresses # -->

#### Automatic tests
<!-- remember to do manual testing when making UI changes! -->
- [ ] Added test cases
  
#### Manual tests
- [x] Done  
  
Device:
- Pixel 7 emulator running Android 13
- HTC U11 life running Android 10

#### Build tasks success  
<!-- run these! -->
Successfully running following tasks on local:
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`

#### Related PR  
Related to PR #3986