### PR TITLE
Fix NetworkOnMainThreadException on HybridFile.getUsableSpace() and HybridFileParcelable.isDirectory()

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/LoadFilesListTask.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/LoadFilesListTask.java
@@ -74,9 +74,11 @@ import android.os.AsyncTask;
 import android.os.Bundle;
 import android.provider.MediaStore;
 import android.text.format.Formatter;
+import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.appcompat.app.AlertDialog;
 import androidx.core.util.Pair;
 
 import jcifs.smb.SmbAuthException;
@@ -85,7 +87,7 @@ import jcifs.smb.SmbFile;
 import kotlin.collections.CollectionsKt;
 
 public class LoadFilesListTask
-    extends AsyncTask<Void, Void, Pair<OpenMode, List<LayoutElementParcelable>>> {
+    extends AsyncTask<Void, Throwable, Pair<OpenMode, List<LayoutElementParcelable>>> {
 
   private static final Logger LOG = LoggerFactory.getLogger(LoadFilesListTask.class);
 
@@ -201,6 +203,41 @@ public class LoadFilesListTask
   @Override
   protected void onCancelled() {
     listener.onAsyncTaskFinished(null);
+  }
+
+  @Override
+  protected void onProgressUpdate(Throwable... values) {
+    for (Throwable exception : values) {
+      if (exception instanceof SmbException) {
+        if ("/".equals(Uri.parse(path).getPath())) {
+          new AlertDialog.Builder(context.get())
+              .setTitle(R.string.error_listfile_smb_title)
+              .setMessage(
+                  context
+                      .get()
+                      .getString(
+                          R.string.error_listfile_smb_noipcshare,
+                          HybridFile.parseAndFormatUriForDisplay(path)))
+              .setPositiveButton(
+                  android.R.string.ok,
+                  (dialog, which) -> {
+                    dialog.dismiss();
+                  })
+              .show();
+        } else {
+          Toast.makeText(
+                  context.get(),
+                  context
+                      .get()
+                      .getString(
+                          R.string.error_listfile_smb,
+                          HybridFile.parseAndFormatUriForDisplay(path),
+                          exception.getMessage()),
+                  Toast.LENGTH_LONG)
+              .show();
+        }
+      }
+    }
   }
 
   @Override
@@ -615,7 +652,8 @@ public class LoadFilesListTask
         if (!e.getMessage().toLowerCase().contains("denied")) {
           mainFragment.reauthenticateSmb();
         }
-        LOG.warn("failed to load smb list, authentication issue", e);
+        LOG.warn("failed to load smb list, authentication issue: ", e);
+        publishProgress(e);
         return null;
       } catch (SmbException | NullPointerException e) {
         LOG.warn("Failed to load smb files for path: " + path, e);

--- a/app/src/main/java/com/amaze/filemanager/filesystem/HybridFile.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/HybridFile.java
@@ -592,16 +592,8 @@ public class HybridFile {
     switch (mode) {
       case SFTP:
       case FTP:
-        return isDirectory(AppConfig.getInstance());
       case SMB:
-        SmbFile smbFile = getSmbFile();
-        try {
-          isDirectory = smbFile != null && smbFile.isDirectory();
-        } catch (SmbException e) {
-          LOG.warn("failed to get isDirectory for smb file", e);
-          isDirectory = false;
-        }
-        break;
+        return isDirectory(AppConfig.getInstance());
       case ROOT:
         isDirectory = NativeOperations.isDirectory(path);
         break;

--- a/app/src/main/java/com/amaze/filemanager/filesystem/HybridFile.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/HybridFile.java
@@ -104,7 +104,6 @@ import androidx.arch.core.util.Function;
 import androidx.documentfile.provider.DocumentFile;
 import androidx.preference.PreferenceManager;
 
-import io.reactivex.Completable;
 import io.reactivex.Single;
 import io.reactivex.SingleObserver;
 import io.reactivex.android.schedulers.AndroidSchedulers;
@@ -781,15 +780,20 @@ public class HybridFile {
     long size = 0L;
     switch (mode) {
       case SMB:
-        size = Single.fromCallable((Callable<Long>) () -> {
-          try {
-            SmbFile smbFile = getSmbFile();
-            return smbFile != null ? smbFile.getDiskFreeSpace() : 0L;
-          } catch (SmbException e) {
-            LOG.warn("failed to get usage space for smb file", e);
-            return 0L;
-          }
-        }).subscribeOn(Schedulers.io()).blockingGet();
+        size =
+            Single.fromCallable(
+                    (Callable<Long>)
+                        () -> {
+                          try {
+                            SmbFile smbFile = getSmbFile();
+                            return smbFile != null ? smbFile.getDiskFreeSpace() : 0L;
+                          } catch (SmbException e) {
+                            LOG.warn("failed to get usage space for smb file", e);
+                            return 0L;
+                          }
+                        })
+                .subscribeOn(Schedulers.io())
+                .blockingGet();
         break;
       case FILE:
       case ROOT:

--- a/app/src/main/java/com/amaze/filemanager/filesystem/HybridFileParcelable.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/HybridFileParcelable.java
@@ -147,6 +147,11 @@ public class HybridFileParcelable extends HybridFile implements Parcelable {
     return isDirectory;
   }
 
+  @Override
+  public boolean isDirectory(Context context) {
+    return isDirectory;
+  }
+
   public boolean isHidden() {
     return name.startsWith(".");
   }

--- a/app/src/main/java/com/amaze/filemanager/filesystem/HybridFileParcelable.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/HybridFileParcelable.java
@@ -149,7 +149,8 @@ public class HybridFileParcelable extends HybridFile implements Parcelable {
 
   @Override
   public boolean isDirectory(Context context) {
-    return isDirectory;
+    if (isSmb() || isSftp()) return isDirectory;
+    else return super.isDirectory(context);
   }
 
   public boolean isHidden() {

--- a/app/src/main/java/com/amaze/filemanager/ui/dialogs/SmbConnectDialog.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/dialogs/SmbConnectDialog.java
@@ -346,7 +346,8 @@ public class SmbConnectDialog extends DialogFragment {
           }
           SmbFile smbFile;
           String domaind = domain.getText().toString();
-          if (chkSmbAnonymous.isChecked())
+          if (chkSmbAnonymous.isChecked()
+              || (TextUtils.isEmpty(user.getText()) && TextUtils.isEmpty(pass.getText())))
             smbFile = createSMBPath(new String[] {ipa, "", "", domaind, sShare}, true, false);
           else {
             String useraw = user.getText().toString();

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -825,5 +825,8 @@ You only need to do this once, until the next time you select a new location for
     <string name="preference_language_title">App Language</string>
     <string name="preference_language_dialog_title">Select Language</string>
     <string name="preference_language_system_default">System Default</string>
+    <string name="error.listfile.smb.title">Unable to load SMB file list</string>
+    <string name="error.listfile.smb">Error listing files at %s: %s</string>
+    <string name="error.listfile.smb.noipcshare">Error listing files at %s - probably the SMB server does not allow anonymous access to the IPC$ share. You may try specifying the share name directly in connection settings.</string>
 </resources>
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         robolectricVersion = '4.9'
         glideVersion = '4.11.0'
         sshjVersion = '0.35.0'
-        jcifsVersion = '2.1.6'
+        jcifsVersion = '2.1.9'
         fabSpeedDialVersion = '3.1.1'
         roomVersion = '2.5.0'
         bouncyCastleVersion = '1.70'


### PR DESCRIPTION
## Description

- Fix `SmbFile.getDiskSpace()` was not wrapped with RxJava in `HybridFile.getUsableSpace()` for network calls
- Added `HybridFileParcelable.isDirectory(Context)` that made copy and paste remote folders unnecessary long, especially when remote is SSH server

#### Issue tracker   
Fixes #3982

#### Manual tests
- [x] Done  
  
Device:
- Pixel 5 emulator running Android 11
- Fairphone 3 running LineageOS 20 (13)

#### Build tasks success  
Successfully running following tasks on local:
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`