### PR TITLE
Sorting of search results

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/adapters/RecyclerAdapter.java
+++ b/app/src/main/java/com/amaze/filemanager/adapters/RecyclerAdapter.java
@@ -21,7 +21,6 @@
 package com.amaze.filemanager.adapters;
 
 import static com.amaze.filemanager.filesystem.compressed.CompressedHelper.*;
-import static com.amaze.filemanager.filesystem.files.FileListSorter.SORT_NONE_ON_TOP;
 import static com.amaze.filemanager.ui.fragments.preferencefragments.PreferencesConstants.PREFERENCE_COLORIZE_ICONS;
 import static com.amaze.filemanager.ui.fragments.preferencefragments.PreferencesConstants.PREFERENCE_SHOW_FILE_SIZE;
 import static com.amaze.filemanager.ui.fragments.preferencefragments.PreferencesConstants.PREFERENCE_SHOW_GOBACK_BUTTON;
@@ -52,6 +51,7 @@ import com.amaze.filemanager.application.AppConfig;
 import com.amaze.filemanager.fileoperations.filesystem.OpenMode;
 import com.amaze.filemanager.filesystem.PasteHelper;
 import com.amaze.filemanager.filesystem.files.CryptUtil;
+import com.amaze.filemanager.filesystem.files.sort.DirSortBy;
 import com.amaze.filemanager.ui.ItemPopupMenu;
 import com.amaze.filemanager.ui.activities.MainActivity;
 import com.amaze.filemanager.ui.activities.superclasses.PreferenceActivity;
@@ -626,7 +626,7 @@ public class RecyclerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
 
   public void createHeaders(boolean invalidate, List<IconDataParcelable> uris) {
     if ((mainFragment.getMainFragmentViewModel() != null
-            && mainFragment.getMainFragmentViewModel().getDsort() == SORT_NONE_ON_TOP)
+            && mainFragment.getMainFragmentViewModel().getDsort() == DirSortBy.NONE_ON_TOP)
         || getItemsDigested() == null
         || getItemsDigested().isEmpty()) {
       return;

--- a/app/src/main/java/com/amaze/filemanager/adapters/data/LayoutElementParcelable.java
+++ b/app/src/main/java/com/amaze/filemanager/adapters/data/LayoutElementParcelable.java
@@ -25,6 +25,7 @@ import java.util.Calendar;
 
 import com.amaze.filemanager.fileoperations.filesystem.OpenMode;
 import com.amaze.filemanager.filesystem.HybridFileParcelable;
+import com.amaze.filemanager.filesystem.files.sort.ComparableParcelable;
 import com.amaze.filemanager.ui.icons.Icons;
 import com.amaze.filemanager.utils.Utils;
 
@@ -35,7 +36,7 @@ import android.os.Parcelable;
 import androidx.annotation.DrawableRes;
 import androidx.annotation.NonNull;
 
-public class LayoutElementParcelable implements Parcelable {
+public class LayoutElementParcelable implements Parcelable, ComparableParcelable {
 
   private static final String CURRENT_YEAR =
       String.valueOf(Calendar.getInstance().get(Calendar.YEAR));
@@ -275,4 +276,25 @@ public class LayoutElementParcelable implements Parcelable {
           return new LayoutElementParcelable[size];
         }
       };
+
+  @Override
+  public boolean isDirectory() {
+    return isDirectory;
+  }
+
+  @NonNull
+  @Override
+  public String getParcelableName() {
+    return title;
+  }
+
+  @Override
+  public long getDate() {
+    return date;
+  }
+
+  @Override
+  public long getSize() {
+    return longSize;
+  }
 }

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/LoadFilesListTask.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/LoadFilesListTask.java
@@ -22,8 +22,6 @@ package com.amaze.filemanager.asynchronous.asynctasks;
 
 import static android.os.Build.VERSION.SDK_INT;
 import static android.os.Build.VERSION_CODES.Q;
-import static com.amaze.filemanager.filesystem.files.FileListSorter.SORT_ASC;
-import static com.amaze.filemanager.filesystem.files.FileListSorter.SORT_DSC;
 
 import java.io.File;
 import java.lang.ref.WeakReference;
@@ -51,6 +49,7 @@ import com.amaze.filemanager.filesystem.RootHelper;
 import com.amaze.filemanager.filesystem.SafRootHolder;
 import com.amaze.filemanager.filesystem.cloud.CloudUtil;
 import com.amaze.filemanager.filesystem.files.FileListSorter;
+import com.amaze.filemanager.filesystem.files.sort.SortType;
 import com.amaze.filemanager.filesystem.root.ListFilesCommand;
 import com.amaze.filemanager.ui.activities.MainActivityViewModel;
 import com.amaze.filemanager.ui.fragments.CloudSheetFragment;
@@ -254,17 +253,7 @@ public class LoadFilesListTask
   private void postListCustomPathProcess(
       @NonNull List<LayoutElementParcelable> list, @NonNull MainFragment mainFragment) {
 
-    int sortType = SortHandler.getSortType(context.get(), path);
-    int sortBy;
-    int isAscending;
-
-    if (sortType <= 3) {
-      sortBy = sortType;
-      isAscending = SORT_ASC;
-    } else {
-      isAscending = SORT_DSC;
-      sortBy = sortType - 4;
-    }
+    SortType sortType = SortHandler.getSortType(context.get(), path);
 
     MainFragmentViewModel viewModel = mainFragment.getMainFragmentViewModel();
 
@@ -289,7 +278,7 @@ public class LoadFilesListTask
       }
     }
 
-    Collections.sort(list, new FileListSorter(viewModel.getDsort(), sortBy, isAscending));
+    Collections.sort(list, new FileListSorter(viewModel.getDsort(), sortType));
   }
 
   private @Nullable LayoutElementParcelable createListParcelables(HybridFileParcelable baseFile) {

--- a/app/src/main/java/com/amaze/filemanager/filesystem/HybridFileParcelable.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/HybridFileParcelable.java
@@ -27,6 +27,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.amaze.filemanager.fileoperations.filesystem.OpenMode;
+import com.amaze.filemanager.filesystem.files.sort.ComparableParcelable;
 import com.amaze.filemanager.filesystem.ftp.ExtensionsKt;
 import com.amaze.filemanager.utils.Utils;
 
@@ -44,7 +45,7 @@ import jcifs.smb.SmbFile;
 import net.schmizz.sshj.sftp.RemoteResourceInfo;
 import net.schmizz.sshj.xfer.FilePermission;
 
-public class HybridFileParcelable extends HybridFile implements Parcelable {
+public class HybridFileParcelable extends HybridFile implements Parcelable, ComparableParcelable {
   private final Logger LOG = LoggerFactory.getLogger(HybridFileParcelable.class);
 
   private long date, size;
@@ -254,5 +255,11 @@ public class HybridFileParcelable extends HybridFile implements Parcelable {
     result = 37 * result + (int) (size ^ size >>> 32);
     result = 37 * result + (int) (date ^ date >>> 32);
     return result;
+  }
+
+  @NonNull
+  @Override
+  public String getParcelableName() {
+    return getName();
   }
 }

--- a/app/src/main/java/com/amaze/filemanager/filesystem/files/FileListSorter.kt
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/files/FileListSorter.kt
@@ -47,24 +47,29 @@ class FileListSorter(
                 0
             }
         } else {
-            compareBy<ComparableParcelable> {
-                // first we compare by the match percentage of the name
-                searchTerm.length.toDouble() / it.getParcelableName().length.toDouble()
-            }.thenBy {
-                // if match percentage is the same, we compare if the name starts with the match
-                it.getParcelableName().startsWith(searchTerm, ignoreCase = true)
-            }.thenBy { file ->
-                // if the match in the name could a word because it is surrounded by separators, it could be more relevant
-                // e.g. "my-cat" more relevant than "mysterious"
-                file.getParcelableName().split('-', '_', '.', ' ').any {
-                    it.contentEquals(
-                        searchTerm,
-                        ignoreCase = true
-                    )
+            Comparator { o1, o2 ->
+                // Sorts in a way that least relevant is first
+                val comparator = compareBy<ComparableParcelable> {
+                    // first we compare by the match percentage of the name
+                    searchTerm.length.toDouble() / it.getParcelableName().length.toDouble()
+                }.thenBy {
+                    // if match percentage is the same, we compare if the name starts with the match
+                    it.getParcelableName().startsWith(searchTerm, ignoreCase = true)
+                }.thenBy { file ->
+                    // if the match in the name could a word because it is surrounded by separators, it could be more relevant
+                    // e.g. "my-cat" more relevant than "mysterious"
+                    file.getParcelableName().split('-', '_', '.', ' ').any {
+                        it.contentEquals(
+                            searchTerm,
+                            ignoreCase = true
+                        )
+                    }
+                }.thenBy { file ->
+                    // sort by modification date as last resort
+                    file.getDate()
                 }
-            }.thenBy { file ->
-                // sort by modification date as last resort
-                file.getDate()
+                // Reverts the sorting to make most relevant first
+                comparator.compare(o1, o2) * -1
             }
         }
     }

--- a/app/src/main/java/com/amaze/filemanager/filesystem/files/FileListSorter.kt
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/files/FileListSorter.kt
@@ -22,6 +22,7 @@ package com.amaze.filemanager.filesystem.files
 
 import androidx.annotation.IntDef
 import com.amaze.filemanager.adapters.data.LayoutElementParcelable
+import com.amaze.filemanager.filesystem.files.sort.ComparableParcelable
 import java.util.Locale
 
 /**
@@ -31,20 +32,24 @@ class FileListSorter(
     @DirSortMode dirArg: Int,
     @SortBy sortArg: Int,
     @SortOrder ascArg: Int
-) : Comparator<LayoutElementParcelable> {
+) : Comparator<ComparableParcelable> {
     private var dirsOnTop = dirArg
     private val asc = ascArg
     private val sort = sortArg
 
-    private fun isDirectory(path: LayoutElementParcelable): Boolean {
-        return path.isDirectory
+    private fun isDirectory(path: ComparableParcelable): Boolean {
+        return path.isDirectory()
+    }
+
+    private fun compareName(file1: ComparableParcelable, file2: ComparableParcelable): Int {
+        return file1.getParcelableName().compareTo(file2.getParcelableName(), ignoreCase = true)
     }
 
     /**
      * Compares two elements and return negative, zero and positive integer if first argument is less
      * than, equal to or greater than second
      */
-    override fun compare(file1: LayoutElementParcelable, file2: LayoutElementParcelable): Int {
+    override fun compare(file1: ComparableParcelable, file2: ComparableParcelable): Int {
         /*File f1;
 
     if(!file1.hasSymlink()) {
@@ -79,33 +84,33 @@ class FileListSorter(
         when (sort) {
             SORT_BY_NAME -> {
                 // sort by name
-                return asc * file1.title.compareTo(file2.title, ignoreCase = true)
+                return asc * compareName(file1, file2)
             }
             SORT_BY_LAST_MODIFIED -> {
                 // sort by last modified
-                return asc * java.lang.Long.valueOf(file1.date).compareTo(file2.date)
+                return asc * java.lang.Long.valueOf(file1.getDate()).compareTo(file2.getDate())
             }
             SORT_BY_SIZE -> {
                 // sort by size
-                return if (!file1.isDirectory && !file2.isDirectory) {
-                    asc * java.lang.Long.valueOf(file1.longSize).compareTo(file2.longSize)
+                return if (!isDirectory(file1) && !isDirectory(file2)) {
+                    asc * java.lang.Long.valueOf(file1.getSize()).compareTo(file2.getSize())
                 } else {
-                    file1.title.compareTo(file2.title, ignoreCase = true)
+                    compareName(file1, file2)
                 }
             }
             SORT_BY_TYPE -> {
                 // sort by type
-                return if (!file1.isDirectory && !file2.isDirectory) {
-                    val ext_a = getExtension(file1.title)
-                    val ext_b = getExtension(file2.title)
+                return if (!isDirectory(file1) && !isDirectory(file2)) {
+                    val ext_a = getExtension(file1.getParcelableName())
+                    val ext_b = getExtension(file2.getParcelableName())
                     val res = asc * ext_a.compareTo(ext_b)
                     if (res == 0) {
-                        asc * file1.title.compareTo(file2.title, ignoreCase = true)
+                        asc * compareName(file1, file2)
                     } else {
                         res
                     }
                 } else {
-                    file1.title.compareTo(file2.title, ignoreCase = true)
+                    compareName(file1, file2)
                 }
             }
             else -> return 0

--- a/app/src/main/java/com/amaze/filemanager/filesystem/files/FileListSorter.kt
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/files/FileListSorter.kt
@@ -20,22 +20,24 @@
 
 package com.amaze.filemanager.filesystem.files
 
-import androidx.annotation.IntDef
 import com.amaze.filemanager.adapters.data.LayoutElementParcelable
 import com.amaze.filemanager.filesystem.files.sort.ComparableParcelable
+import com.amaze.filemanager.filesystem.files.sort.DirSortBy
+import com.amaze.filemanager.filesystem.files.sort.SortBy
+import com.amaze.filemanager.filesystem.files.sort.SortType
+import java.lang.Long
 import java.util.Locale
 
 /**
  * [Comparator] implementation to sort [LayoutElementParcelable]s.
  */
 class FileListSorter(
-    @DirSortMode dirArg: Int,
-    @SortBy sortArg: Int,
-    @SortOrder ascArg: Int
+    dirArg: DirSortBy,
+    sortType: SortType
 ) : Comparator<ComparableParcelable> {
     private var dirsOnTop = dirArg
-    private val asc = ascArg
-    private val sort = sortArg
+    private val asc: Int = sortType.sortOrder.sortFactor
+    private val sort: SortBy = sortType.sortBy
 
     private fun isDirectory(path: ComparableParcelable): Boolean {
         return path.isDirectory()
@@ -67,13 +69,13 @@ class FileListSorter(
     } else {
         f2=new File(file1.getSymlink());
     }*/
-        if (dirsOnTop == SORT_DIR_ON_TOP) {
+        if (dirsOnTop == DirSortBy.DIR_ON_TOP) {
             if (isDirectory(file1) && !isDirectory(file2)) {
                 return -1
             } else if (isDirectory(file2) && !isDirectory(file1)) {
                 return 1
             }
-        } else if (dirsOnTop == SORT_FILE_ON_TOP) {
+        } else if (dirsOnTop == DirSortBy.FILE_ON_TOP) {
             if (isDirectory(file1) && !isDirectory(file2)) {
                 return 1
             } else if (isDirectory(file2) && !isDirectory(file1)) {
@@ -82,23 +84,23 @@ class FileListSorter(
         }
 
         when (sort) {
-            SORT_BY_NAME -> {
+            SortBy.NAME -> {
                 // sort by name
                 return asc * compareName(file1, file2)
             }
-            SORT_BY_LAST_MODIFIED -> {
+            SortBy.LAST_MODIFIED -> {
                 // sort by last modified
-                return asc * java.lang.Long.valueOf(file1.getDate()).compareTo(file2.getDate())
+                return asc * Long.valueOf(file1.getDate()).compareTo(file2.getDate())
             }
-            SORT_BY_SIZE -> {
+            SortBy.SIZE -> {
                 // sort by size
                 return if (!isDirectory(file1) && !isDirectory(file2)) {
-                    asc * java.lang.Long.valueOf(file1.getSize()).compareTo(file2.getSize())
+                    asc * Long.valueOf(file1.getSize()).compareTo(file2.getSize())
                 } else {
                     compareName(file1, file2)
                 }
             }
-            SORT_BY_TYPE -> {
+            SortBy.TYPE -> {
                 // sort by type
                 return if (!isDirectory(file1) && !isDirectory(file2)) {
                     val ext_a = getExtension(file1.getParcelableName())
@@ -113,35 +115,11 @@ class FileListSorter(
                     compareName(file1, file2)
                 }
             }
-            else -> return 0
+            SortBy.RELEVANCE -> TODO()
         }
     }
 
     companion object {
-
-        const val SORT_BY_NAME = 0
-        const val SORT_BY_LAST_MODIFIED = 1
-        const val SORT_BY_SIZE = 2
-        const val SORT_BY_TYPE = 3
-
-        const val SORT_DIR_ON_TOP = 0
-        const val SORT_FILE_ON_TOP = 1
-        const val SORT_NONE_ON_TOP = 2
-
-        const val SORT_ASC = 1
-        const val SORT_DSC = -1
-
-        @Retention(AnnotationRetention.SOURCE)
-        @IntDef(SORT_BY_NAME, SORT_BY_LAST_MODIFIED, SORT_BY_SIZE, SORT_BY_TYPE)
-        annotation class SortBy
-
-        @Retention(AnnotationRetention.SOURCE)
-        @IntDef(SORT_DIR_ON_TOP, SORT_FILE_ON_TOP, SORT_NONE_ON_TOP)
-        annotation class DirSortMode
-
-        @Retention(AnnotationRetention.SOURCE)
-        @IntDef(SORT_ASC, SORT_DSC)
-        annotation class SortOrder
 
         /**
          * Convenience method to get the file extension in given path.

--- a/app/src/main/java/com/amaze/filemanager/filesystem/files/sort/ComparableParcelable.kt
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/files/sort/ComparableParcelable.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2014-2023 Arpit Khurana <arpitkh96@gmail.com>, Vishal Nehra <vishalmeham2@gmail.com>,
+ * Emmanuel Messulam<emmanuelbendavid@gmail.com>, Raymond Lai <airwave209gt at gmail.com> and Contributors.
+ *
+ * This file is part of Amaze File Manager.
+ *
+ * Amaze File Manager is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.amaze.filemanager.filesystem.files.sort
+
+interface ComparableParcelable {
+
+    /** Returns if the parcelable represents a directory */
+    fun isDirectory(): Boolean
+
+    /** Returns the name of the item represented by the parcelable */
+    fun getParcelableName(): String
+
+    /** Returns the date of the item represented by the parcelable as a Long */
+    fun getDate(): Long
+
+    /** Returns the size of the item represented by the parcelable */
+    fun getSize(): Long
+}

--- a/app/src/main/java/com/amaze/filemanager/filesystem/files/sort/DirSortBy.kt
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/files/sort/DirSortBy.kt
@@ -20,18 +20,22 @@
 
 package com.amaze.filemanager.filesystem.files.sort
 
-/** Used by [FileListSorter] to get the needed information from a `Parcelable` */
-interface ComparableParcelable {
+/** Represents the way in which directories and files should be sorted */
+enum class DirSortBy {
+    DIR_ON_TOP,
+    FILE_ON_TOP,
+    NONE_ON_TOP;
 
-    /** Returns if the parcelable represents a directory */
-    fun isDirectory(): Boolean
-
-    /** Returns the name of the item represented by the parcelable */
-    fun getParcelableName(): String
-
-    /** Returns the date of the item represented by the parcelable as a Long */
-    fun getDate(): Long
-
-    /** Returns the size of the item represented by the parcelable */
-    fun getSize(): Long
+    companion object {
+        /** Returns the corresponding [DirSortBy] to [index] */
+        @JvmStatic
+        fun getDirSortBy(index: Int): DirSortBy {
+            return when (index) {
+                0 -> DIR_ON_TOP
+                1 -> FILE_ON_TOP
+                2 -> NONE_ON_TOP
+                else -> NONE_ON_TOP
+            }
+        }
+    }
 }

--- a/app/src/main/java/com/amaze/filemanager/filesystem/files/sort/SortBy.kt
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/files/sort/SortBy.kt
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2014-2023 Arpit Khurana <arpitkh96@gmail.com>, Vishal Nehra <vishalmeham2@gmail.com>,
+ * Emmanuel Messulam<emmanuelbendavid@gmail.com>, Raymond Lai <airwave209gt at gmail.com> and Contributors.
+ *
+ * This file is part of Amaze File Manager.
+ *
+ * Amaze File Manager is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.amaze.filemanager.filesystem.files.sort
+
+import android.content.Context
+import com.amaze.filemanager.R
+
+/**
+ * Represents the sort by types.
+ * [index] is the index of the sort in the xml string array resource
+ * [sortDirectory] indicates if the sort can be used to sort an directory.
+ */
+enum class SortBy(val index: Int, val sortDirectory: Boolean) {
+    NAME(0, true),
+    LAST_MODIFIED(1, true),
+    SIZE(2, true),
+    TYPE(3, true),
+    RELEVANCE(4, false);
+
+    /** Returns the corresponding string resource of the enum */
+    fun toResourceString(context: Context): String {
+        return when (this) {
+            NAME -> context.resources.getString(R.string.sort_name)
+            LAST_MODIFIED -> context.resources.getString(R.string.lastModified)
+            SIZE -> context.resources.getString(R.string.sort_size)
+            TYPE -> context.resources.getString(R.string.type)
+            RELEVANCE -> context.resources.getString(R.string.sort_relevance)
+        }
+    }
+
+    companion object {
+        const val NAME_INDEX = 0
+        const val LAST_MODIFIED_INDEX = 1
+        const val SIZE_INDEX = 2
+        const val TYPE_INDEX = 3
+        const val RELEVANCE_INDEX = 4
+
+        /** Returns the SortBy corresponding to [index] which can be used to sort directories */
+        @JvmStatic
+        fun getDirectorySortBy(index: Int): SortBy {
+            return when (index) {
+                NAME_INDEX -> NAME
+                LAST_MODIFIED_INDEX -> LAST_MODIFIED
+                SIZE_INDEX -> SIZE
+                TYPE_INDEX -> TYPE
+                else -> NAME
+            }
+        }
+
+        /** Returns the SortBy corresponding to [index] */
+        @JvmStatic
+        fun getSortBy(index: Int): SortBy {
+            return when (index) {
+                NAME_INDEX -> NAME
+                LAST_MODIFIED_INDEX -> LAST_MODIFIED
+                SIZE_INDEX -> SIZE
+                TYPE_INDEX -> TYPE
+                RELEVANCE_INDEX -> RELEVANCE
+                else -> NAME
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/amaze/filemanager/filesystem/files/sort/SortOrder.kt
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/files/sort/SortOrder.kt
@@ -20,18 +20,12 @@
 
 package com.amaze.filemanager.filesystem.files.sort
 
-/** Used by [FileListSorter] to get the needed information from a `Parcelable` */
-interface ComparableParcelable {
-
-    /** Returns if the parcelable represents a directory */
-    fun isDirectory(): Boolean
-
-    /** Returns the name of the item represented by the parcelable */
-    fun getParcelableName(): String
-
-    /** Returns the date of the item represented by the parcelable as a Long */
-    fun getDate(): Long
-
-    /** Returns the size of the item represented by the parcelable */
-    fun getSize(): Long
+/**
+ * Represents the direction the sort should be ordered
+ *
+ * [sortFactor] is the factor that should be multiplied to the result of `compareTo()` to achieve the correct sort direction
+ */
+enum class SortOrder(val sortFactor: Int) {
+    ASC(1),
+    DESC(-1)
 }

--- a/app/src/main/java/com/amaze/filemanager/filesystem/files/sort/SortType.kt
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/files/sort/SortType.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2014-2023 Arpit Khurana <arpitkh96@gmail.com>, Vishal Nehra <vishalmeham2@gmail.com>,
+ * Emmanuel Messulam<emmanuelbendavid@gmail.com>, Raymond Lai <airwave209gt at gmail.com> and Contributors.
+ *
+ * This file is part of Amaze File Manager.
+ *
+ * Amaze File Manager is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.amaze.filemanager.filesystem.files.sort
+
+/** Describes how to sort with [sortBy] and which direction to use for the sort with [sortOrder] */
+data class SortType(val sortBy: SortBy, val sortOrder: SortOrder) {
+
+    /**
+     * Returns the Int corresponding to the combination of [sortBy] and [sortOrder]
+     */
+    fun toDirectorySortInt(): Int {
+        val sortIndex = if (sortBy.sortDirectory) sortBy.index else 0
+        return when (sortOrder) {
+            SortOrder.ASC -> sortIndex
+            SortOrder.DESC -> sortIndex + 4
+        }
+    }
+
+    companion object {
+        /**
+         * Returns the [SortType] with the [SortBy] and [SortOrder] corresponding to [index]
+         */
+        @JvmStatic
+        fun getDirectorySortType(index: Int): SortType {
+            val sortOrder = if (index <= 3) SortOrder.ASC else SortOrder.DESC
+            val normalizedIndex = if (index <= 3) index else index - 4
+            val sortBy = SortBy.getDirectorySortBy(normalizedIndex)
+            return SortType(sortBy, sortOrder)
+        }
+    }
+}

--- a/app/src/main/java/com/amaze/filemanager/ui/dialogs/GeneralDialogCreation.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/dialogs/GeneralDialogCreation.java
@@ -60,6 +60,9 @@ import com.amaze.filemanager.filesystem.RootHelper;
 import com.amaze.filemanager.filesystem.compressed.CompressedHelper;
 import com.amaze.filemanager.filesystem.files.EncryptDecryptUtils;
 import com.amaze.filemanager.filesystem.files.FileUtils;
+import com.amaze.filemanager.filesystem.files.sort.SortBy;
+import com.amaze.filemanager.filesystem.files.sort.SortOrder;
+import com.amaze.filemanager.filesystem.files.sort.SortType;
 import com.amaze.filemanager.filesystem.root.ChangeFilePermissionsCommand;
 import com.amaze.filemanager.ui.ExtensionsKt;
 import com.amaze.filemanager.ui.activities.MainActivity;
@@ -953,12 +956,12 @@ public class GeneralDialogCreation {
     final String path = m.getCurrentPath();
     int accentColor = m.getMainActivity().getAccent();
     String[] sort = m.getResources().getStringArray(R.array.sortby);
-    int current = SortHandler.getSortType(m.getContext(), path);
+    SortType current = SortHandler.getSortType(m.getContext(), path);
     MaterialDialog.Builder a = new MaterialDialog.Builder(m.getActivity());
     a.theme(appTheme.getMaterialDialogTheme(m.requireContext()));
     a.items(sort)
         .itemsCallbackSingleChoice(
-            current > 3 ? current - 4 : current, (dialog, view, which, text) -> true);
+            current.getSortBy().getIndex(), (dialog, view, which, text) -> true);
     final Set<String> sortbyOnlyThis =
         sharedPref.getStringSet(PREFERENCE_SORTBY_ONLY_THIS, Collections.emptySet());
     final Set<String> onlyThisFloders = new HashSet<>(sortbyOnlyThis);
@@ -981,11 +984,11 @@ public class GeneralDialogCreation {
     a.positiveText(R.string.descending).negativeColor(accentColor);
     a.onNegative(
         (dialog, which) -> {
-          onSortTypeSelected(m, sharedPref, onlyThisFloders, dialog, false);
+          onSortTypeSelected(m, sharedPref, onlyThisFloders, dialog, SortOrder.ASC);
         });
     a.onPositive(
         (dialog, which) -> {
-          onSortTypeSelected(m, sharedPref, onlyThisFloders, dialog, true);
+          onSortTypeSelected(m, sharedPref, onlyThisFloders, dialog, SortOrder.DESC);
         });
     a.title(R.string.sort_by);
     a.build().show();
@@ -996,20 +999,20 @@ public class GeneralDialogCreation {
       SharedPreferences sharedPref,
       Set<String> onlyThisFloders,
       MaterialDialog dialog,
-      boolean desc) {
-    final int sortType = desc ? dialog.getSelectedIndex() + 4 : dialog.getSelectedIndex();
+      SortOrder sortOrder) {
+    final SortType sortType =
+        new SortType(SortBy.getDirectorySortBy(dialog.getSelectedIndex()), sortOrder);
     SortHandler sortHandler = SortHandler.getInstance();
     if (onlyThisFloders.contains(m.getCurrentPath())) {
       Sort oldSort = sortHandler.findEntry(m.getCurrentPath());
-      Sort newSort = new Sort(m.getCurrentPath(), sortType);
       if (oldSort == null) {
-        sortHandler.addEntry(newSort);
+        sortHandler.addEntry(m.getCurrentPath(), sortType);
       } else {
-        sortHandler.updateEntry(oldSort, newSort);
+        sortHandler.updateEntry(oldSort, m.getCurrentPath(), sortType);
       }
     } else {
       sortHandler.clear(m.getCurrentPath());
-      sharedPref.edit().putString("sortby", String.valueOf(sortType)).apply();
+      sharedPref.edit().putString("sortby", String.valueOf(sortType.toDirectorySortInt())).apply();
     }
     sharedPref.edit().putStringSet(PREFERENCE_SORTBY_ONLY_THIS, onlyThisFloders).apply();
     m.updateList(false);

--- a/app/src/main/java/com/amaze/filemanager/ui/fragments/MainFragment.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/fragments/MainFragment.java
@@ -1564,9 +1564,7 @@ public class MainFragment extends Fragment
         new SortSearchResultTask(
             elements,
             new FileListSorter(
-                mainFragmentViewModel.getDsort(),
-                mainFragmentViewModel.getSortby(),
-                mainFragmentViewModel.getAsc()),
+                mainFragmentViewModel.getDsort(), mainFragmentViewModel.getSortType()),
             this,
             query));
   }

--- a/app/src/main/java/com/amaze/filemanager/ui/fragments/data/MainFragmentViewModel.kt
+++ b/app/src/main/java/com/amaze/filemanager/ui/fragments/data/MainFragmentViewModel.kt
@@ -31,9 +31,10 @@ import com.amaze.filemanager.adapters.data.LayoutElementParcelable
 import com.amaze.filemanager.database.CloudHandler
 import com.amaze.filemanager.fileoperations.filesystem.OpenMode
 import com.amaze.filemanager.filesystem.HybridFileParcelable
-import com.amaze.filemanager.filesystem.files.FileListSorter.Companion.DirSortMode
-import com.amaze.filemanager.filesystem.files.FileListSorter.Companion.SortBy
-import com.amaze.filemanager.filesystem.files.FileListSorter.Companion.SortOrder
+import com.amaze.filemanager.filesystem.files.sort.DirSortBy
+import com.amaze.filemanager.filesystem.files.sort.SortBy
+import com.amaze.filemanager.filesystem.files.sort.SortOrder
+import com.amaze.filemanager.filesystem.files.sort.SortType
 import com.amaze.filemanager.ui.fragments.preferencefragments.PreferencesConstants
 import com.amaze.filemanager.ui.fragments.preferencefragments.PreferencesConstants.PREFERENCE_GRID_COLUMNS
 import com.amaze.filemanager.ui.fragments.preferencefragments.PreferencesConstants.PREFERENCE_GRID_COLUMNS_DEFAULT
@@ -59,14 +60,9 @@ class MainFragmentViewModel : ViewModel() {
     var searchHelper = ArrayList<HybridFileParcelable>()
     var no = 0
 
-    @SortBy
-    var sortby = 0
+    var sortType: SortType = SortType(SortBy.NAME, SortOrder.ASC)
 
-    @DirSortMode
-    var dsort = 0
-
-    @SortOrder
-    var asc = 0
+    var dsort: DirSortBy = DirSortBy.DIR_ON_TOP
 
     var home: String? = null
 
@@ -174,19 +170,13 @@ class MainFragmentViewModel : ViewModel() {
      *
      * Final value of [.sortby] varies from 0 to 3
      */
-    fun initSortModes(sortType: Int, sharedPref: SharedPreferences) {
-        if (sortType <= 3) {
-            sortby = sortType
-            asc = 1
-        } else {
-            asc = -1
-            sortby = sortType - 4
-        }
+    fun initSortModes(sortType: SortType, sharedPref: SharedPreferences) {
+        this.sortType = sortType
         sharedPref.getString(
             PreferencesConstants.PREFERENCE_DIRECTORY_SORT_MODE,
             "0"
         )?.run {
-            dsort = Integer.parseInt(this)
+            dsort = DirSortBy.getDirSortBy(Integer.parseInt(this))
         }
     }
 

--- a/app/src/main/java/com/amaze/filemanager/ui/views/appbar/SearchView.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/views/appbar/SearchView.java
@@ -120,7 +120,7 @@ public class SearchView {
 
   private boolean enabled = false;
 
-  private final SortType defaultSortType = new SortType(SortBy.RELEVANCE, SortOrder.DESC);
+  private final SortType defaultSortType = new SortType(SortBy.RELEVANCE, SortOrder.ASC);
 
   /** The selected sort type for the search results */
   private SortType sortType = defaultSortType;

--- a/app/src/main/java/com/amaze/filemanager/ui/views/appbar/SearchView.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/views/appbar/SearchView.java
@@ -55,6 +55,7 @@ import android.view.animation.AccelerateDecelerateInterpolator;
 import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputMethodManager;
 
+import androidx.appcompat.widget.AppCompatButton;
 import androidx.appcompat.widget.AppCompatEditText;
 import androidx.appcompat.widget.AppCompatImageView;
 import androidx.appcompat.widget.AppCompatTextView;
@@ -88,6 +89,12 @@ public class SearchView {
 
   private final SearchRecyclerViewAdapter searchRecyclerViewAdapter;
 
+  /** Text to describe {@link SearchView#searchResultsSortButton} */
+  private final AppCompatTextView searchResultsSortHintTV;
+
+  /** The button to select how the results should be sorted */
+  private final AppCompatButton searchResultsSortButton;
+
   // 0 -> Basic Search
   // 1 -> Indexed Search
   // 2 -> Deep Search
@@ -111,6 +118,8 @@ public class SearchView {
     searchResultsHintTV = mainActivity.findViewById(R.id.searchResultsHintTV);
     deepSearchTV = mainActivity.findViewById(R.id.searchDeepSearchTV);
     recyclerView = mainActivity.findViewById(R.id.searchRecyclerView);
+    searchResultsSortHintTV = mainActivity.findViewById(R.id.searchResultsSortHintTV);
+    searchResultsSortButton = mainActivity.findViewById(R.id.searchResultsSortButton);
 
     initRecentSearches(mainActivity);
 
@@ -215,6 +224,8 @@ public class SearchView {
     clearRecyclerView();
 
     searchResultsHintTV.setVisibility(View.VISIBLE);
+    searchResultsSortButton.setVisibility(View.VISIBLE);
+    searchResultsSortHintTV.setVisibility(View.VISIBLE);
     deepSearchTV.setVisibility(View.VISIBLE);
     searchMode = 1;
     deepSearchTV.setText(
@@ -464,6 +475,8 @@ public class SearchView {
     searchRecyclerViewAdapter.notifyDataSetChanged();
 
     searchResultsHintTV.setVisibility(View.GONE);
+    searchResultsSortHintTV.setVisibility(View.GONE);
+    searchResultsSortButton.setVisibility(View.GONE);
   }
 
   private SpannableString getSpannableText(String s1, String s2) {

--- a/app/src/main/res/drawable/baseline_sort_24_asc_white.xml
+++ b/app/src/main/res/drawable/baseline_sort_24_asc_white.xml
@@ -1,0 +1,11 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:autoMirrored="true"
+    android:viewportHeight="24" android:height="24dp"
+    android:viewportWidth="24" android:width="24dp" >
+    <group
+        android:name="rotationGroup"
+        android:pivotY="12"
+        android:scaleY="-1" >
+        <path android:fillColor="@android:color/white" android:pathData="M3,18h6v-2L3,16v2zM3,6v2h18L21,6L3,6zM3,13h12v-2L3,11v2z"/>
+    </group>
+</vector>

--- a/app/src/main/res/drawable/baseline_sort_24_desc_white.xml
+++ b/app/src/main/res/drawable/baseline_sort_24_desc_white.xml
@@ -1,0 +1,6 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:autoMirrored="true"
+    android:viewportHeight="24" android:height="24dp"
+    android:viewportWidth="24" android:width="24dp" >
+    <path android:fillColor="@android:color/white" android:pathData="M3,18h6v-2L3,16v2zM3,6v2h18L21,6L3,6zM3,13h12v-2L3,11v2z"/>
+</vector>

--- a/app/src/main/res/layout-v21/layout_search.xml
+++ b/app/src/main/res/layout-v21/layout_search.xml
@@ -24,11 +24,11 @@
             android:layout_marginLeft="@dimen/search_view_back_margin_left_right"
             android:layout_marginRight="@dimen/search_view_back_margin_left_right"
             android:background="@drawable/ripple"
-            app:srcCompat="@drawable/ic_arrow_back_black_24dp"
             app:layout_constraintBottom_toBottomOf="@id/search_edit_text"
             app:layout_constraintEnd_toStartOf="@id/search_edit_text"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="@id/search_edit_text" />
+            app:layout_constraintTop_toTopOf="@id/search_edit_text"
+            app:srcCompat="@drawable/ic_arrow_back_black_24dp" />
 
         <androidx.appcompat.widget.AppCompatEditText
             android:id="@+id/search_edit_text"
@@ -53,11 +53,11 @@
             android:layout_marginLeft="@dimen/search_view_info_margin_left_right"
             android:layout_marginRight="@dimen/search_view_info_margin_left_right"
             android:background="@drawable/ripple"
-            app:srcCompat="@drawable/ic_close_black_24dp"
             app:layout_constraintBottom_toBottomOf="@id/search_edit_text"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toEndOf="@id/search_edit_text"
-            app:layout_constraintTop_toTopOf="@id/search_edit_text" />
+            app:layout_constraintTop_toTopOf="@id/search_edit_text"
+            app:srcCompat="@drawable/ic_close_black_24dp" />
 
         <TextView
             android:id="@+id/searchRecentHintTV"
@@ -121,21 +121,54 @@
 
         <TextView
             android:id="@+id/searchResultsHintTV"
-            android:layout_width="wrap_content"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginStart="8dp"
             android:layout_marginTop="4dp"
-            android:layout_marginEnd="8dp"
             android:layout_marginBottom="4dp"
             android:text="@string/results"
             android:textColor="@color/accent_material_light"
             android:textSize="12sp"
             android:visibility="gone"
             app:layout_constraintBottom_toTopOf="@id/searchRecyclerView"
-            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintEnd_toStartOf="@+id/searchResultsSortHintTV"
             app:layout_constraintHorizontal_bias="0"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/searchDeepSearchTV" />
+
+        <TextView
+            android:id="@+id/searchResultsSortHintTV"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:layout_marginEnd="4dp"
+            android:text="@string/sort_by_colon"
+            android:textColor="@color/accent_material_light"
+            android:textSize="12sp"
+            android:visibility="gone"
+            app:layout_constraintBottom_toTopOf="@id/searchRecyclerView"
+            app:layout_constraintEnd_toStartOf="@+id/searchResultsSortButton"
+            app:layout_constraintStart_toEndOf="@+id/searchResultsHintTV"
+            app:layout_constraintTop_toBottomOf="@id/searchDeepSearchTV"
+            app:layout_constraintHorizontal_bias="1" />
+
+        <Button
+            android:id="@+id/searchResultsSortButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="4dp"
+            android:layout_marginEnd="4dp"
+            android:textColor="@color/accent_material_light"
+            android:textSize="12sp"
+            android:visibility="gone"
+            android:minHeight="0dp"
+            android:minWidth="0dp"
+            app:layout_constraintBottom_toTopOf="@+id/searchRecyclerView"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@+id/searchResultsSortHintTV"
+            app:layout_constraintTop_toBottomOf="@id/searchDeepSearchTV"
+            app:layout_constraintHorizontal_bias="1"
+            style="@style/SearchSortButton" />
 
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/searchRecyclerView"

--- a/app/src/main/res/layout-w720dp/layout_search.xml
+++ b/app/src/main/res/layout-w720dp/layout_search.xml
@@ -22,11 +22,11 @@
             android:layout_height="wrap_content"
             android:layout_marginLeft="@dimen/search_view_back_margin_left_right"
             android:layout_marginRight="@dimen/search_view_back_margin_left_right"
-            app:srcCompat="@drawable/ic_arrow_back_black_24dp"
             app:layout_constraintBottom_toBottomOf="@id/search_edit_text"
             app:layout_constraintEnd_toStartOf="@id/search_edit_text"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="@id/search_edit_text" />
+            app:layout_constraintTop_toTopOf="@id/search_edit_text"
+            app:srcCompat="@drawable/ic_arrow_back_black_24dp" />
 
         <androidx.appcompat.widget.AppCompatEditText
             android:id="@+id/search_edit_text"
@@ -50,11 +50,11 @@
             android:layout_height="wrap_content"
             android:layout_marginLeft="@dimen/search_view_info_margin_left_right"
             android:layout_marginRight="@dimen/search_view_info_margin_left_right"
-            app:srcCompat="@drawable/ic_close_black_24dp"
             app:layout_constraintBottom_toBottomOf="@id/search_edit_text"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toEndOf="@id/search_edit_text"
-            app:layout_constraintTop_toTopOf="@id/search_edit_text" />
+            app:layout_constraintTop_toTopOf="@id/search_edit_text"
+            app:srcCompat="@drawable/ic_close_black_24dp" />
 
         <TextView
             android:id="@+id/searchRecentHintTV"
@@ -118,21 +118,55 @@
 
         <TextView
             android:id="@+id/searchResultsHintTV"
-            android:layout_width="wrap_content"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginStart="8dp"
             android:layout_marginTop="4dp"
-            android:layout_marginEnd="8dp"
             android:layout_marginBottom="4dp"
             android:text="@string/results"
             android:textColor="@color/accent_material_light"
             android:textSize="12sp"
             android:visibility="gone"
             app:layout_constraintBottom_toTopOf="@id/searchRecyclerView"
-            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintEnd_toStartOf="@+id/searchResultsSortHintTV"
             app:layout_constraintHorizontal_bias="0"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/searchDeepSearchTV" />
+
+        <TextView
+            android:id="@+id/searchResultsSortHintTV"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:layout_marginEnd="4dp"
+            android:text="@string/sort_by_colon"
+            android:textColor="@color/accent_material_light"
+            android:textSize="12sp"
+            android:visibility="gone"
+            app:layout_constraintBottom_toTopOf="@id/searchRecyclerView"
+            app:layout_constraintEnd_toStartOf="@+id/searchResultsSortButton"
+            app:layout_constraintStart_toEndOf="@+id/searchResultsHintTV"
+            app:layout_constraintTop_toBottomOf="@id/searchDeepSearchTV"
+            app:layout_constraintHorizontal_bias="1" />
+
+        <Button
+            android:id="@+id/searchResultsSortButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="4dp"
+            android:layout_marginEnd="4dp"
+            android:textColor="@color/accent_material_light"
+            android:textSize="12sp"
+            android:visibility="gone"
+            android:minHeight="0dp"
+            android:minWidth="0dp"
+            app:layout_constraintBottom_toTopOf="@+id/searchRecyclerView"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@+id/searchResultsSortHintTV"
+            app:layout_constraintTop_toBottomOf="@id/searchDeepSearchTV"
+            app:layout_constraintHorizontal_bias="1"
+            style="@style/SearchSortButton" />
+
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/searchRecyclerView"
             android:layout_width="@dimen/zero_dp"

--- a/app/src/main/res/layout/layout_search.xml
+++ b/app/src/main/res/layout/layout_search.xml
@@ -118,21 +118,54 @@
 
         <androidx.appcompat.widget.AppCompatTextView
             android:id="@+id/searchResultsHintTV"
-            android:layout_width="wrap_content"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginStart="8dp"
             android:layout_marginTop="4dp"
-            android:layout_marginEnd="8dp"
             android:layout_marginBottom="4dp"
             android:text="@string/results"
             android:textColor="@color/accent_material_light"
             android:textSize="12sp"
             android:visibility="gone"
             app:layout_constraintBottom_toTopOf="@id/searchRecyclerView"
-            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintEnd_toStartOf="@+id/searchResultsSortHintTV"
             app:layout_constraintHorizontal_bias="0"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/searchDeepSearchTV" />
+
+        <androidx.appcompat.widget.AppCompatTextView
+            android:id="@+id/searchResultsSortHintTV"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:layout_marginEnd="4dp"
+            android:text="@string/sort_by_colon"
+            android:textColor="@color/accent_material_light"
+            android:textSize="12sp"
+            android:visibility="gone"
+            app:layout_constraintBottom_toTopOf="@id/searchRecyclerView"
+            app:layout_constraintEnd_toStartOf="@+id/searchResultsSortButton"
+            app:layout_constraintStart_toEndOf="@+id/searchResultsHintTV"
+            app:layout_constraintTop_toBottomOf="@id/searchDeepSearchTV"
+            app:layout_constraintHorizontal_bias="1" />
+
+        <androidx.appcompat.widget.AppCompatButton
+            android:id="@+id/searchResultsSortButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="4dp"
+            android:layout_marginEnd="4dp"
+            android:textColor="@color/accent_material_light"
+            android:textSize="12sp"
+            android:visibility="gone"
+            android:minHeight="0dp"
+            android:minWidth="0dp"
+            app:layout_constraintBottom_toTopOf="@+id/searchRecyclerView"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@+id/searchResultsSortHintTV"
+            app:layout_constraintTop_toBottomOf="@id/searchDeepSearchTV"
+            app:layout_constraintHorizontal_bias="1"
+            style="@style/SearchSortButton" />
 
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/searchRecyclerView"

--- a/app/src/main/res/values-v19/styles.xml
+++ b/app/src/main/res/values-v19/styles.xml
@@ -67,4 +67,9 @@
         <item name="spinBars">true</item>
         <item name="color">@android:color/white</item>
     </style>
+
+    <style name="SearchSortButton" parent="Widget.AppCompat.Spinner">
+        <item name="android:gravity">right|end|center_vertical</item>
+        <item name="android:paddingEnd">35dp</item>
+    </style>
 </resources>

--- a/app/src/main/res/values-v21/styles.xml
+++ b/app/src/main/res/values-v21/styles.xml
@@ -97,4 +97,8 @@
     <style name="DrawerItemDriveSizeTextStyle">
         <item name="android:letterSpacing">0.05</item>
     </style>
+    <style name="SearchSortButton" parent="Widget.AppCompat.Spinner">
+        <item name="android:gravity">right|end|center_vertical</item>
+        <item name="android:paddingEnd">35dp</item>
+    </style>
 </resources>

--- a/app/src/main/res/values-v23/styles.xml
+++ b/app/src/main/res/values-v23/styles.xml
@@ -245,4 +245,8 @@
     <style name="pref_accent_black_super_su" parent="appCompatBlack">
         <item name="colorAccent">@color/accent_super_su</item>
     </style>
+    <style name="SearchSortButton" parent="Widget.AppCompat.Spinner">
+        <item name="android:gravity">right|end|center_vertical</item>
+        <item name="android:paddingEnd">35dp</item>
+    </style>
 </resources>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -52,6 +52,14 @@
         <item>@string/type</item>
     </string-array>
 
+    <string-array name="sortbySearch">
+        <item>@string/sort_name</item>
+        <item>@string/lastModified</item>
+        <item>@string/sort_size</item>
+        <item>@string/type</item>
+        <item>@string/sort_relevance</item>
+    </string-array>
+
     <string-array name="sortbyApps">
         <item>@string/sort_name</item>
         <item>@string/lastModified</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -82,6 +82,7 @@
     <string name="question_set_path_as_home">Do you want to set current path as home for this tab?</string>
     <string name="directorysort">Directory Sort Mode</string>
     <string name="sort_by">Sort By</string>
+    <string name="sort_by_colon">Sort By:</string>
     <string name="sort_only_this">Only this folder</string>
     <string name="theme">Theme</string>
     <string name="random">Random Skin</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -120,6 +120,7 @@
     <string name="sort_name">Name</string>
     <string name="lastModified">Last Modified</string>
     <string name="sort_size">Size</string>
+    <string name="sort_relevance">Relevance</string>
     <!--ListMode-->
     <!--Folder-->
     <string name="pick_a_file">Pick a file</string>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -325,4 +325,9 @@
 
     </style>
 
+    <style name="SearchSortButton" parent="Widget.AppCompat.Spinner">
+        <item name="android:gravity">right|end|center_vertical</item>
+        <item name="android:paddingEnd">35dp</item>
+    </style>
+
 </resources>

--- a/app/src/test/java/com/amaze/filemanager/asynchronous/services/DecryptServiceTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/asynchronous/services/DecryptServiceTest.kt
@@ -125,7 +125,7 @@ class DecryptServiceTest {
             putExtra(
                 TAG_SOURCE,
                 HybridFileParcelable(targetFile.absolutePath).also {
-                    it.size = targetFile.length()
+                    it.setSize(targetFile.length())
                 }
             )
             putExtra(TAG_DECRYPT_PATH, Environment.getExternalStorageDirectory().absolutePath)
@@ -183,7 +183,7 @@ class DecryptServiceTest {
                 putExtra(
                     TAG_SOURCE,
                     HybridFileParcelable(sourceFile.absolutePath).also {
-                        it.size = sourceFile.length()
+                        it.setSize(sourceFile.length())
                     }
                 )
                 putExtra(TAG_DECRYPT_PATH, Environment.getExternalStorageDirectory().absolutePath)

--- a/app/src/test/java/com/amaze/filemanager/filesystem/files/FileListSorterTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/filesystem/files/FileListSorterTest.kt
@@ -1011,4 +1011,533 @@ class FileListSorterTest {
         )
         Assert.assertEquals(fileListSorter.compare(file1, file2).toLong(), 0)
     }
+
+    /**
+     * Purpose: when sort is [SortBy.RELEVANCE], if file1 matches the search term more than file2, result is positive
+     *
+     * Input: FileListSorter with [DirSortBy.NONE_ON_TOP], [SortBy.RELEVANCE], [SortOrder.ASC] and search term "abc"
+     * compare(file1,file2) file1 title matches "abc" more than file2 title
+     *
+     * Expected: return positive integer
+     */
+    @Test
+    fun testSortByRelevanceWithFile1MoreMatchThanFile2() {
+        val fileListSorter = FileListSorter(
+            DirSortBy.NONE_ON_TOP,
+            SortType(SortBy.RELEVANCE, SortOrder.ASC),
+            "abc"
+        )
+        val file1 = LayoutElementParcelable(
+            ApplicationProvider.getApplicationContext(),
+            "abc.txt",
+            "C:\\AmazeFileManager\\abc",
+            "user",
+            "symlink",
+            "100",
+            123L,
+            true,
+            "1234",
+            false,
+            false,
+            OpenMode.UNKNOWN
+        )
+        val file2 = LayoutElementParcelable(
+            ApplicationProvider.getApplicationContext(),
+            "ABCDE.txt",
+            "C:\\AmazeFileManager\\ABCDE",
+            "user",
+            "symlink",
+            "101",
+            124L,
+            true,
+            "1234",
+            false,
+            false,
+            OpenMode.UNKNOWN
+        )
+        Assert.assertEquals(1, fileListSorter.compare(file1, file2).toLong())
+    }
+
+    /**
+     * Purpose: when sort is [SortBy.RELEVANCE], if file1 matches the search term less than file2, result is negative
+     *
+     * Input: FileListSorter with [DirSortBy.NONE_ON_TOP], [SortBy.RELEVANCE], [SortOrder.ASC] and search term "abc"
+     * compare(file1,file2) file1 title matches "abc" less than file2 title
+     *
+     * Expected: return negative integer
+     */
+    @Test
+    fun testSortByRelevanceWithFile1LessMatchThanFile2() {
+        val fileListSorter = FileListSorter(
+            DirSortBy.NONE_ON_TOP,
+            SortType(SortBy.RELEVANCE, SortOrder.ASC),
+            "abc"
+        )
+        val file1 = LayoutElementParcelable(
+            ApplicationProvider.getApplicationContext(),
+            "abcdefg.txt",
+            "C:\\AmazeFileManager\\abcdefg",
+            "user",
+            "symlink",
+            "100",
+            123L,
+            true,
+            "1234",
+            false,
+            false,
+            OpenMode.UNKNOWN
+        )
+        val file2 = LayoutElementParcelable(
+            ApplicationProvider.getApplicationContext(),
+            "ABC.txt",
+            "C:\\AmazeFileManager\\ABC",
+            "user",
+            "symlink",
+            "101",
+            124L,
+            true,
+            "1234",
+            false,
+            false,
+            OpenMode.UNKNOWN
+        )
+        Assert.assertEquals(-1, fileListSorter.compare(file1, file2).toLong())
+    }
+
+    /**
+     * Purpose: when sort is [SortBy.RELEVANCE], if file1 matches the search term as much as file2
+     * and file1 starts with search term, result is positive
+     *
+     * Input: FileListSorter with [DirSortBy.NONE_ON_TOP], [SortBy.RELEVANCE], [SortOrder.ASC] and search term "abc"
+     * compare(file1,file2) file1 title matches "abc" as much as file2 title and file1 starts with "abc"
+     *
+     * Expected: return positive integer
+     */
+    @Test
+    fun testSortByRelevanceWithFile1StartsWithSearchTerm() {
+        val fileListSorter = FileListSorter(
+            DirSortBy.NONE_ON_TOP,
+            SortType(SortBy.RELEVANCE, SortOrder.ASC),
+            "abc"
+        )
+        val file1 = LayoutElementParcelable(
+            ApplicationProvider.getApplicationContext(),
+            "abc.txt",
+            "C:\\AmazeFileManager\\abc",
+            "user",
+            "symlink",
+            "100",
+            123L,
+            true,
+            "1234",
+            false,
+            false,
+            OpenMode.UNKNOWN
+        )
+        val file2 = LayoutElementParcelable(
+            ApplicationProvider.getApplicationContext(),
+            "XYZ_ABC",
+            "C:\\AmazeFileManager\\XYZ_ABC",
+            "user",
+            "symlink",
+            "101",
+            124L,
+            true,
+            "1234",
+            false,
+            false,
+            OpenMode.UNKNOWN
+        )
+        Assert.assertEquals(1, fileListSorter.compare(file1, file2).toLong())
+    }
+
+    /**
+     * Purpose: when sort is [SortBy.RELEVANCE], if file1 matches the search term as much as file2
+     * and file2 starts with search term, result is negative
+     *
+     * Input: FileListSorter with [DirSortBy.NONE_ON_TOP], [SortBy.RELEVANCE], [SortOrder.ASC] and search term "abc"
+     * compare(file1,file2) file1 title matches "abc" as much as file2 title and file2 starts with "abc"
+     *
+     * Expected: return negative integer
+     */
+    @Test
+    fun testSortByRelevanceWithFile2StartWithSearchTerm() {
+        val fileListSorter = FileListSorter(
+            DirSortBy.NONE_ON_TOP,
+            SortType(SortBy.RELEVANCE, SortOrder.ASC),
+            "abc"
+        )
+        val file1 = LayoutElementParcelable(
+            ApplicationProvider.getApplicationContext(),
+            "txt-abc",
+            "C:\\AmazeFileManager\\txt-abc",
+            "user",
+            "symlink",
+            "100",
+            123L,
+            true,
+            "1234",
+            false,
+            false,
+            OpenMode.UNKNOWN
+        )
+        val file2 = LayoutElementParcelable(
+            ApplicationProvider.getApplicationContext(),
+            "ABC.txt",
+            "C:\\AmazeFileManager\\ABC",
+            "user",
+            "symlink",
+            "101",
+            124L,
+            true,
+            "1234",
+            false,
+            false,
+            OpenMode.UNKNOWN
+        )
+        Assert.assertEquals(-1, fileListSorter.compare(file1, file2).toLong())
+    }
+
+    /**
+     * Purpose: when sort is [SortBy.RELEVANCE], if file1 matches the search term as much as file2,
+     * both start with search term and file1 contains the search term as a word (surrounded by
+     * separators), result is positive
+     *
+     * Input: FileListSorter with [DirSortBy.NONE_ON_TOP], [SortBy.RELEVANCE], [SortOrder.ASC] and search term "abc"
+     * compare(file1,file2) file1 title matches "abc" as much as file2 title, both start with "abc"
+     * and file1 contains "abc" as word (separated by "-")
+     *
+     * Expected: return positive integer
+     */
+    @Test
+    fun testSortByRelevanceWithFile1HasSearchTermAsWord() {
+        val fileListSorter = FileListSorter(
+            DirSortBy.NONE_ON_TOP,
+            SortType(SortBy.RELEVANCE, SortOrder.ASC),
+            "abc"
+        )
+        val file1 = LayoutElementParcelable(
+            ApplicationProvider.getApplicationContext(),
+            "abc-efg.txt",
+            "C:\\AmazeFileManager\\abc-efg",
+            "user",
+            "symlink",
+            "100",
+            123L,
+            true,
+            "1234",
+            false,
+            false,
+            OpenMode.UNKNOWN
+        )
+        val file2 = LayoutElementParcelable(
+            ApplicationProvider.getApplicationContext(),
+            "ABCD-FG.txt",
+            "C:\\AmazeFileManager\\ABCD-FG",
+            "user",
+            "symlink",
+            "101",
+            124L,
+            true,
+            "1234",
+            false,
+            false,
+            OpenMode.UNKNOWN
+        )
+        Assert.assertEquals(1, fileListSorter.compare(file1, file2).toLong())
+    }
+
+    /**
+     * Purpose: when sort is [SortBy.RELEVANCE], if file1 matches the search term as much as file2,
+     * both start with search term and file2 contains the search term as a word (surrounded by
+     * separators), result is negative
+     *
+     * Input: FileListSorter with [DirSortBy.NONE_ON_TOP], [SortBy.RELEVANCE], [SortOrder.ASC] and search term "abc"
+     * compare(file1,file2) file1 title matches "abc" as much as file2 title, both start with "abc"
+     * and file2 contains "abc" as word (separated by "_")
+     *
+     * Expected: return negative integer
+     */
+    @Test
+    fun testSortByRelevanceWithFile2HasSearchTermAsWord() {
+        val fileListSorter = FileListSorter(
+            DirSortBy.NONE_ON_TOP,
+            SortType(SortBy.RELEVANCE, SortOrder.ASC),
+            "abc"
+        )
+        val file1 = LayoutElementParcelable(
+            ApplicationProvider.getApplicationContext(),
+            "abcdefg",
+            "C:\\AmazeFileManager\\abcdefg",
+            "user",
+            "symlink",
+            "100",
+            123L,
+            true,
+            "1234",
+            false,
+            false,
+            OpenMode.UNKNOWN
+        )
+        val file2 = LayoutElementParcelable(
+            ApplicationProvider.getApplicationContext(),
+            "ABC_EFG",
+            "C:\\AmazeFileManager\\ABC_EFG",
+            "user",
+            "symlink",
+            "101",
+            124L,
+            true,
+            "1234",
+            false,
+            false,
+            OpenMode.UNKNOWN
+        )
+        Assert.assertEquals(-1, fileListSorter.compare(file1, file2).toLong())
+    }
+
+    /**
+     * Purpose: when sort is [SortBy.RELEVANCE], if file1 matches the search term as much as file2,
+     * both start with search term and file2 contains the search term as a word (surrounded by
+     * separators), result is negative
+     *
+     * Input: FileListSorter with [DirSortBy.NONE_ON_TOP], [SortBy.RELEVANCE], [SortOrder.ASC] and search term "abc"
+     * compare(file1,file2) file1 title matches "abc" as much as file2 title, both start with "abc"
+     * and file2 contains "abc" as word (separated by " ")
+     *
+     * Expected: return negative integer
+     */
+    @Test
+    fun testSortByRelevanceWithSpaceWordSeparator() {
+        val fileListSorter = FileListSorter(
+            DirSortBy.NONE_ON_TOP,
+            SortType(SortBy.RELEVANCE, SortOrder.ASC),
+            "abc"
+        )
+        val file1 = LayoutElementParcelable(
+            ApplicationProvider.getApplicationContext(),
+            "abcdefg",
+            "C:\\AmazeFileManager\\abcdefg",
+            "user",
+            "symlink",
+            "100",
+            123L,
+            true,
+            "1234",
+            false,
+            false,
+            OpenMode.UNKNOWN
+        )
+        val file2 = LayoutElementParcelable(
+            ApplicationProvider.getApplicationContext(),
+            "ABC EFG",
+            "C:\\AmazeFileManager\\ABC EFG",
+            "user",
+            "symlink",
+            "101",
+            124L,
+            true,
+            "1234",
+            false,
+            false,
+            OpenMode.UNKNOWN
+        )
+        Assert.assertEquals(-1, fileListSorter.compare(file1, file2).toLong())
+    }
+
+    /**
+     * Purpose: when sort is [SortBy.RELEVANCE], if file1 matches the search term as much as file2,
+     * both start with search term and file2 contains the search term as a word (surrounded by
+     * separators), result is negative
+     *
+     * Input: FileListSorter with [DirSortBy.NONE_ON_TOP], [SortBy.RELEVANCE], [SortOrder.ASC] and search term "abc"
+     * compare(file1,file2) file1 title matches "abc" as much as file2 title, both start with "abc"
+     * and file2 contains "abc" as word (separated by ".")
+     *
+     * Expected: return negative integer
+     */
+    @Test
+    fun testSortByRelevanceWithDotWordSeparator() {
+        val fileListSorter = FileListSorter(
+            DirSortBy.NONE_ON_TOP,
+            SortType(SortBy.RELEVANCE, SortOrder.ASC),
+            "abc"
+        )
+        val file1 = LayoutElementParcelable(
+            ApplicationProvider.getApplicationContext(),
+            "abcdefg",
+            "C:\\AmazeFileManager\\abcdefg",
+            "user",
+            "symlink",
+            "100",
+            123L,
+            true,
+            "1234",
+            false,
+            false,
+            OpenMode.UNKNOWN
+        )
+        val file2 = LayoutElementParcelable(
+            ApplicationProvider.getApplicationContext(),
+            "ABC.EFG",
+            "C:\\AmazeFileManager\\ABC.EFG",
+            "user",
+            "symlink",
+            "101",
+            124L,
+            true,
+            "1234",
+            false,
+            false,
+            OpenMode.UNKNOWN
+        )
+        Assert.assertEquals(-1, fileListSorter.compare(file1, file2).toLong())
+    }
+
+    /**
+     * Purpose: when sort is [SortBy.RELEVANCE], if file1 matches the search term as much as file2,
+     * both start with search term, both contain the search term as a word and file1 date is more recent,
+     * result is positive
+     *
+     * Input: FileListSorter with [DirSortBy.NONE_ON_TOP], [SortBy.RELEVANCE], [SortOrder.ASC] and search term "abc"
+     * compare(file1,file2) file1 title matches "abc" as much as file2 title, both start with "abc",
+     * both contain "abc" as word and file1 date is more recent
+     *
+     * Expected: return negative integer
+     */
+    @Test
+    fun testSortByRelevanceWithFile1MoreRecent() {
+        val fileListSorter = FileListSorter(
+            DirSortBy.NONE_ON_TOP,
+            SortType(SortBy.RELEVANCE, SortOrder.ASC),
+            "abc"
+        )
+        val file1 = LayoutElementParcelable(
+            ApplicationProvider.getApplicationContext(),
+            "abc.efg",
+            "C:\\AmazeFileManager\\abc.efg",
+            "user",
+            "symlink",
+            "100",
+            123L,
+            true,
+            "1234",
+            false,
+            false,
+            OpenMode.UNKNOWN
+        )
+        val file2 = LayoutElementParcelable(
+            ApplicationProvider.getApplicationContext(),
+            "ABC_EFG",
+            "C:\\AmazeFileManager\\ABC_EFG",
+            "user",
+            "symlink",
+            "101",
+            124L,
+            true,
+            "1235",
+            false,
+            false,
+            OpenMode.UNKNOWN
+        )
+        Assert.assertEquals(-1, fileListSorter.compare(file1, file2).toLong())
+    }
+
+    /**
+     * Purpose: when sort is [SortBy.RELEVANCE], if file1 matches the search term as much as file2,
+     * both start with search term, both contain the search term as a word and file2 date is more recent,
+     * result is positive
+     *
+     * Input: FileListSorter with [DirSortBy.NONE_ON_TOP], [SortBy.RELEVANCE], [SortOrder.ASC] and search term "abc"
+     * compare(file1,file2) file1 title matches "abc" as much as file2 title, both start with "abc",
+     * both contain "abc" as word and file2 date is more recent
+     *
+     * Expected: return positive integer
+     */
+    @Test
+    fun testSortByRelevanceWithFile2MoreRecent() {
+        val fileListSorter = FileListSorter(
+            DirSortBy.NONE_ON_TOP,
+            SortType(SortBy.RELEVANCE, SortOrder.ASC),
+            "abc"
+        )
+        val file1 = LayoutElementParcelable(
+            ApplicationProvider.getApplicationContext(),
+            "abc.efg",
+            "C:\\AmazeFileManager\\abc.efg",
+            "user",
+            "symlink",
+            "100",
+            123L,
+            true,
+            "1235",
+            false,
+            false,
+            OpenMode.UNKNOWN
+        )
+        val file2 = LayoutElementParcelable(
+            ApplicationProvider.getApplicationContext(),
+            "ABC_EFG",
+            "C:\\AmazeFileManager\\ABC_EFG",
+            "user",
+            "symlink",
+            "101",
+            124L,
+            true,
+            "1234",
+            false,
+            false,
+            OpenMode.UNKNOWN
+        )
+        Assert.assertEquals(1, fileListSorter.compare(file1, file2).toLong())
+    }
+
+    /**
+     * Purpose: when sort is [SortBy.RELEVANCE], if file1 matches the search term as much as file2,
+     * both start with search term, both contain the search term as a word and file2 date is more recent,
+     * result is positive
+     *
+     * Input: FileListSorter with [DirSortBy.NONE_ON_TOP], [SortBy.RELEVANCE], [SortOrder.ASC] and search term "abc"
+     * compare(file1,file2) file1 title matches "abc" as much as file2 title, both start with "abc",
+     * both contain "abc" as word and the date of both is the same
+     *
+     * Expected: return positive integer
+     */
+    @Test
+    fun testSortByRelevanceWithSameRelevance() {
+        val fileListSorter = FileListSorter(
+            DirSortBy.NONE_ON_TOP,
+            SortType(SortBy.RELEVANCE, SortOrder.ASC),
+            "abc"
+        )
+        val file1 = LayoutElementParcelable(
+            ApplicationProvider.getApplicationContext(),
+            "abc.efg",
+            "C:\\AmazeFileManager\\abc.efg",
+            "user",
+            "symlink",
+            "100",
+            123L,
+            true,
+            "1234",
+            false,
+            false,
+            OpenMode.UNKNOWN
+        )
+        val file2 = LayoutElementParcelable(
+            ApplicationProvider.getApplicationContext(),
+            "ABC_EFG",
+            "C:\\AmazeFileManager\\ABC_EFG",
+            "user",
+            "symlink",
+            "101",
+            124L,
+            true,
+            "1234",
+            false,
+            false,
+            OpenMode.UNKNOWN
+        )
+        Assert.assertEquals(0, fileListSorter.compare(file1, file2).toLong())
+    }
 }

--- a/app/src/test/java/com/amaze/filemanager/filesystem/files/FileListSorterTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/filesystem/files/FileListSorterTest.kt
@@ -1018,7 +1018,7 @@ class FileListSorterTest {
      * Input: FileListSorter with [DirSortBy.NONE_ON_TOP], [SortBy.RELEVANCE], [SortOrder.ASC] and search term "abc"
      * compare(file1,file2) file1 title matches "abc" more than file2 title
      *
-     * Expected: return positive integer
+     * Expected: return negative integer
      */
     @Test
     fun testSortByRelevanceWithFile1MoreMatchThanFile2() {
@@ -1055,16 +1055,16 @@ class FileListSorterTest {
             false,
             OpenMode.UNKNOWN
         )
-        Assert.assertEquals(1, fileListSorter.compare(file1, file2).toLong())
+        Assert.assertEquals(-1, fileListSorter.compare(file1, file2).toLong())
     }
 
     /**
-     * Purpose: when sort is [SortBy.RELEVANCE], if file1 matches the search term less than file2, result is negative
+     * Purpose: when sort is [SortBy.RELEVANCE], if file1 matches the search term less than file2, result is positive
      *
      * Input: FileListSorter with [DirSortBy.NONE_ON_TOP], [SortBy.RELEVANCE], [SortOrder.ASC] and search term "abc"
      * compare(file1,file2) file1 title matches "abc" less than file2 title
      *
-     * Expected: return negative integer
+     * Expected: return positive integer
      */
     @Test
     fun testSortByRelevanceWithFile1LessMatchThanFile2() {
@@ -1101,17 +1101,17 @@ class FileListSorterTest {
             false,
             OpenMode.UNKNOWN
         )
-        Assert.assertEquals(-1, fileListSorter.compare(file1, file2).toLong())
+        Assert.assertEquals(1, fileListSorter.compare(file1, file2).toLong())
     }
 
     /**
      * Purpose: when sort is [SortBy.RELEVANCE], if file1 matches the search term as much as file2
-     * and file1 starts with search term, result is positive
+     * and file1 starts with search term, result is negative
      *
      * Input: FileListSorter with [DirSortBy.NONE_ON_TOP], [SortBy.RELEVANCE], [SortOrder.ASC] and search term "abc"
      * compare(file1,file2) file1 title matches "abc" as much as file2 title and file1 starts with "abc"
      *
-     * Expected: return positive integer
+     * Expected: return negative integer
      */
     @Test
     fun testSortByRelevanceWithFile1StartsWithSearchTerm() {
@@ -1148,17 +1148,17 @@ class FileListSorterTest {
             false,
             OpenMode.UNKNOWN
         )
-        Assert.assertEquals(1, fileListSorter.compare(file1, file2).toLong())
+        Assert.assertEquals(-1, fileListSorter.compare(file1, file2).toLong())
     }
 
     /**
      * Purpose: when sort is [SortBy.RELEVANCE], if file1 matches the search term as much as file2
-     * and file2 starts with search term, result is negative
+     * and file2 starts with search term, result is positive
      *
      * Input: FileListSorter with [DirSortBy.NONE_ON_TOP], [SortBy.RELEVANCE], [SortOrder.ASC] and search term "abc"
      * compare(file1,file2) file1 title matches "abc" as much as file2 title and file2 starts with "abc"
      *
-     * Expected: return negative integer
+     * Expected: return positive integer
      */
     @Test
     fun testSortByRelevanceWithFile2StartWithSearchTerm() {
@@ -1195,19 +1195,19 @@ class FileListSorterTest {
             false,
             OpenMode.UNKNOWN
         )
-        Assert.assertEquals(-1, fileListSorter.compare(file1, file2).toLong())
+        Assert.assertEquals(1, fileListSorter.compare(file1, file2).toLong())
     }
 
     /**
      * Purpose: when sort is [SortBy.RELEVANCE], if file1 matches the search term as much as file2,
      * both start with search term and file1 contains the search term as a word (surrounded by
-     * separators), result is positive
+     * separators), result is negative
      *
      * Input: FileListSorter with [DirSortBy.NONE_ON_TOP], [SortBy.RELEVANCE], [SortOrder.ASC] and search term "abc"
      * compare(file1,file2) file1 title matches "abc" as much as file2 title, both start with "abc"
      * and file1 contains "abc" as word (separated by "-")
      *
-     * Expected: return positive integer
+     * Expected: return negative integer
      */
     @Test
     fun testSortByRelevanceWithFile1HasSearchTermAsWord() {
@@ -1244,19 +1244,19 @@ class FileListSorterTest {
             false,
             OpenMode.UNKNOWN
         )
-        Assert.assertEquals(1, fileListSorter.compare(file1, file2).toLong())
+        Assert.assertEquals(-1, fileListSorter.compare(file1, file2).toLong())
     }
 
     /**
      * Purpose: when sort is [SortBy.RELEVANCE], if file1 matches the search term as much as file2,
      * both start with search term and file2 contains the search term as a word (surrounded by
-     * separators), result is negative
+     * separators), result is positive
      *
      * Input: FileListSorter with [DirSortBy.NONE_ON_TOP], [SortBy.RELEVANCE], [SortOrder.ASC] and search term "abc"
      * compare(file1,file2) file1 title matches "abc" as much as file2 title, both start with "abc"
      * and file2 contains "abc" as word (separated by "_")
      *
-     * Expected: return negative integer
+     * Expected: return positive integer
      */
     @Test
     fun testSortByRelevanceWithFile2HasSearchTermAsWord() {
@@ -1293,19 +1293,19 @@ class FileListSorterTest {
             false,
             OpenMode.UNKNOWN
         )
-        Assert.assertEquals(-1, fileListSorter.compare(file1, file2).toLong())
+        Assert.assertEquals(1, fileListSorter.compare(file1, file2).toLong())
     }
 
     /**
      * Purpose: when sort is [SortBy.RELEVANCE], if file1 matches the search term as much as file2,
      * both start with search term and file2 contains the search term as a word (surrounded by
-     * separators), result is negative
+     * separators), result is positive
      *
      * Input: FileListSorter with [DirSortBy.NONE_ON_TOP], [SortBy.RELEVANCE], [SortOrder.ASC] and search term "abc"
      * compare(file1,file2) file1 title matches "abc" as much as file2 title, both start with "abc"
      * and file2 contains "abc" as word (separated by " ")
      *
-     * Expected: return negative integer
+     * Expected: return positive integer
      */
     @Test
     fun testSortByRelevanceWithSpaceWordSeparator() {
@@ -1342,19 +1342,19 @@ class FileListSorterTest {
             false,
             OpenMode.UNKNOWN
         )
-        Assert.assertEquals(-1, fileListSorter.compare(file1, file2).toLong())
+        Assert.assertEquals(1, fileListSorter.compare(file1, file2).toLong())
     }
 
     /**
      * Purpose: when sort is [SortBy.RELEVANCE], if file1 matches the search term as much as file2,
      * both start with search term and file2 contains the search term as a word (surrounded by
-     * separators), result is negative
+     * separators), result is positive
      *
      * Input: FileListSorter with [DirSortBy.NONE_ON_TOP], [SortBy.RELEVANCE], [SortOrder.ASC] and search term "abc"
      * compare(file1,file2) file1 title matches "abc" as much as file2 title, both start with "abc"
      * and file2 contains "abc" as word (separated by ".")
      *
-     * Expected: return negative integer
+     * Expected: return positive integer
      */
     @Test
     fun testSortByRelevanceWithDotWordSeparator() {
@@ -1391,7 +1391,7 @@ class FileListSorterTest {
             false,
             OpenMode.UNKNOWN
         )
-        Assert.assertEquals(-1, fileListSorter.compare(file1, file2).toLong())
+        Assert.assertEquals(1, fileListSorter.compare(file1, file2).toLong())
     }
 
     /**
@@ -1403,7 +1403,7 @@ class FileListSorterTest {
      * compare(file1,file2) file1 title matches "abc" as much as file2 title, both start with "abc",
      * both contain "abc" as word and file1 date is more recent
      *
-     * Expected: return negative integer
+     * Expected: return positive integer
      */
     @Test
     fun testSortByRelevanceWithFile1MoreRecent() {
@@ -1440,19 +1440,19 @@ class FileListSorterTest {
             false,
             OpenMode.UNKNOWN
         )
-        Assert.assertEquals(-1, fileListSorter.compare(file1, file2).toLong())
+        Assert.assertEquals(1, fileListSorter.compare(file1, file2).toLong())
     }
 
     /**
      * Purpose: when sort is [SortBy.RELEVANCE], if file1 matches the search term as much as file2,
      * both start with search term, both contain the search term as a word and file2 date is more recent,
-     * result is positive
+     * result is negative
      *
      * Input: FileListSorter with [DirSortBy.NONE_ON_TOP], [SortBy.RELEVANCE], [SortOrder.ASC] and search term "abc"
      * compare(file1,file2) file1 title matches "abc" as much as file2 title, both start with "abc",
      * both contain "abc" as word and file2 date is more recent
      *
-     * Expected: return positive integer
+     * Expected: return negative integer
      */
     @Test
     fun testSortByRelevanceWithFile2MoreRecent() {
@@ -1489,19 +1489,19 @@ class FileListSorterTest {
             false,
             OpenMode.UNKNOWN
         )
-        Assert.assertEquals(1, fileListSorter.compare(file1, file2).toLong())
+        Assert.assertEquals(-1, fileListSorter.compare(file1, file2).toLong())
     }
 
     /**
      * Purpose: when sort is [SortBy.RELEVANCE], if file1 matches the search term as much as file2,
      * both start with search term, both contain the search term as a word and file2 date is more recent,
-     * result is positive
+     * result is zero
      *
      * Input: FileListSorter with [DirSortBy.NONE_ON_TOP], [SortBy.RELEVANCE], [SortOrder.ASC] and search term "abc"
      * compare(file1,file2) file1 title matches "abc" as much as file2 title, both start with "abc",
      * both contain "abc" as word and the date of both is the same
      *
-     * Expected: return positive integer
+     * Expected: return zero
      */
     @Test
     fun testSortByRelevanceWithSameRelevance() {

--- a/app/src/test/java/com/amaze/filemanager/filesystem/files/FileListSorterTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/filesystem/files/FileListSorterTest.kt
@@ -25,6 +25,10 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.amaze.filemanager.adapters.data.LayoutElementParcelable
 import com.amaze.filemanager.fileoperations.filesystem.OpenMode
+import com.amaze.filemanager.filesystem.files.sort.DirSortBy
+import com.amaze.filemanager.filesystem.files.sort.SortBy
+import com.amaze.filemanager.filesystem.files.sort.SortOrder
+import com.amaze.filemanager.filesystem.files.sort.SortType
 import com.amaze.filemanager.shadows.ShadowMultiDex
 import org.hamcrest.Matchers
 import org.junit.Assert
@@ -44,13 +48,19 @@ import org.robolectric.annotation.Config
 @Suppress("StringLiteralDuplication", "ComplexMethod", "LongMethod", "LargeClass")
 class FileListSorterTest {
     /**
-     * Purpose: when dirsOnTop is 0, if file1 is directory && file2 is not directory, result is -1
-     * Input: FileListSorter(0,0,1) dir(=dirsOnTop) is 0 / compare(file1,file2) file1 is dir, file2 is
-     * not dir Expected: return -1
+     * Purpose: when dirsOnTop is [DirSortBy.DIR_ON_TOP], if file1 is directory && file2 is not directory, result is -1
+     *
+     * Input: FileListSorter with [DirSortBy.DIR_ON_TOP], [SortBy.NAME] and [SortOrder.ASC]
+     * compare(file1,file2) file1 is dir, file2 is not dir
+     *
+     * Expected: return -1
      */
     @Test
     fun testDir0File1DirAndFile2NoDir() {
-        val fileListSorter = FileListSorter(0, 0, 1)
+        val fileListSorter = FileListSorter(
+            DirSortBy.DIR_ON_TOP,
+            SortType(SortBy.NAME, SortOrder.ASC)
+        )
         val file1 = LayoutElementParcelable(
             ApplicationProvider.getApplicationContext(),
             "abc1",
@@ -88,13 +98,19 @@ class FileListSorterTest {
                                 String date, boolean isDirectory, boolean useThumbs, OpenMode openMode)
   */
     /**
-     * Purpose: when dirsOnTop is 0, if file1 is not directory && file2 is directory, result is 1
-     * Input: FileListSorter(0,0,1) dir(=dirsOnTop) is 0 / compare(file1,file2) file1 is not dir,
-     * file2 is dir Expected: return 1
+     * Purpose: when dirsOnTop is [DirSortBy.DIR_ON_TOP], if file1 is not directory && file2 is directory, result is 1
+     *
+     * Input: FileListSorter with [DirSortBy.DIR_ON_TOP], [SortBy.NAME] and [SortOrder.ASC]
+     * compare(file1,file2) file1 is not dir, file2 is dir
+     *
+     * Expected: return 1
      */
     @Test
     fun testDir0File1NoDirAndFile2Dir() {
-        val fileListSorter = FileListSorter(0, 0, 1)
+        val fileListSorter = FileListSorter(
+            DirSortBy.DIR_ON_TOP,
+            SortType(SortBy.NAME, SortOrder.ASC)
+        )
         val file1 = LayoutElementParcelable(
             ApplicationProvider.getApplicationContext(),
             "abc1.txt",
@@ -127,13 +143,19 @@ class FileListSorterTest {
     }
 
     /**
-     * Purpose: when dirsOnTop is 1, if file1 is directory && file2 is not directory, result is 1
-     * Input: FileListSorter(1,0,1) dir(=dirsOnTop) is 1 / compare(file1,file2) file1 is dir, file2 is
-     * not dir Expected: return 1
+     * Purpose: when dirsOnTop is [DirSortBy.FILE_ON_TOP], if file1 is directory && file2 is not directory, result is 1
+     *
+     * Input: FileListSorter with [DirSortBy.FILE_ON_TOP], [SortBy.NAME] and [SortOrder.ASC]
+     * compare(file1,file2) file1 is dir, file2 is not dir
+     *
+     * Expected: return 1
      */
     @Test
     fun testDir1File1DirAndFile2NoDir() {
-        val fileListSorter = FileListSorter(1, 0, 1)
+        val fileListSorter = FileListSorter(
+            DirSortBy.FILE_ON_TOP,
+            SortType(SortBy.NAME, SortOrder.ASC)
+        )
         val file1 = LayoutElementParcelable(
             ApplicationProvider.getApplicationContext(),
             "abc1",
@@ -166,13 +188,19 @@ class FileListSorterTest {
     }
 
     /**
-     * Purpose: when dirsOnTop is 1, if file1 is not directory && file2 is directory, result is -1
-     * Input: FileListSorter(1,0,1) dir(=dirsOnTop) is 1 / compare(file1,file2) file1 is not dir,
-     * file2 is dir Expected: return -1
+     * Purpose: when dirsOnTop is [DirSortBy.FILE_ON_TOP], if file1 is not directory && file2 is directory, result is -1
+     *
+     * Input: FileListSorter with [DirSortBy.FILE_ON_TOP], [SortBy.NAME] and [SortOrder.ASC]
+     * compare(file1,file2) file1 is not dir, file2 is dir
+     *
+     * Expected: return -1
      */
     @Test
     fun testDir1File1NoDirAndFile2Dir() {
-        val fileListSorter = FileListSorter(1, 0, 1)
+        val fileListSorter = FileListSorter(
+            DirSortBy.FILE_ON_TOP,
+            SortType(SortBy.NAME, SortOrder.ASC)
+        )
         val file1 = LayoutElementParcelable(
             ApplicationProvider.getApplicationContext(),
             "abc1.txt",
@@ -204,15 +232,22 @@ class FileListSorterTest {
         Assert.assertEquals(fileListSorter.compare(file1, file2).toLong(), -1)
     }
 
-    // From here, use dir is not 0 or 1. -> Select dir is -1
+    // From here, use dir is not DIR_ON_TOP or FILE_ON_TOP. -> Select dir is NONE_ON_TOP
     /**
-     * Purpose: when sort is 0, if file1 title's length bigger than file2 title's length, result is
-     * positive Input: FileListSorter(-1,0,1) sort is 0 / compare(file1,file2) file1 title's length >
-     * file2 title's length Expected: return positive integer
+     * Purpose: when sort is [SortBy.NAME], if file1 title's length bigger than file2 title's length, result is
+     * positive
+     *
+     * Input: FileListSorter with [DirSortBy.NONE_ON_TOP], [SortBy.NAME] and [SortOrder.ASC]
+     * compare(file1,file2) file1 title's length > file2 title's length
+     *
+     * Expected: return positive integer
      */
     @Test
     fun testSort0File1TitleBigger() {
-        val fileListSorter = FileListSorter(-1, 0, 1)
+        val fileListSorter = FileListSorter(
+            DirSortBy.NONE_ON_TOP,
+            SortType(SortBy.NAME, SortOrder.ASC)
+        )
         val file1 = LayoutElementParcelable(
             ApplicationProvider.getApplicationContext(),
             "abc1.txt",
@@ -245,13 +280,20 @@ class FileListSorterTest {
     }
 
     /**
-     * Purpose: when sort is 0, if file1 title's length smaller than file2 title's length, result is
-     * negative Input: FileListSorter(-1,0,1) sort is 0 / compare(file1,file2) file1 title's length <
-     * file2 title's length Expected: return negative integer
+     * Purpose: when sort is [SortBy.NAME], if file1 title's length smaller than file2 title's length, result is
+     * negative
+     *
+     * Input: FileListSorter with [DirSortBy.NONE_ON_TOP], [SortBy.NAME] and [SortOrder.ASC]
+     * compare(file1,file2) file1 title's length < file2 title's length
+     *
+     * Expected: return negative integer
      */
     @Test
     fun testSort0File2TitleBigger() {
-        val fileListSorter = FileListSorter(-1, 0, 1)
+        val fileListSorter = FileListSorter(
+            DirSortBy.NONE_ON_TOP,
+            SortType(SortBy.NAME, SortOrder.ASC)
+        )
         val file1 = LayoutElementParcelable(
             ApplicationProvider.getApplicationContext(),
             "abc.txt",
@@ -284,13 +326,20 @@ class FileListSorterTest {
     }
 
     /**
-     * Purpose: when sort is 0, if file1 title's length and file2 title's length are same, result is
-     * zero Input: FileListSorter(-1,0,1) sort is 0 / compare(file1,file2) file1 title's length =
-     * file2 title's length Expected: return zero
+     * Purpose: when sort is [SortBy.NAME], if file1 title's length and file2 title's length are same, result is
+     * zero
+     *
+     * Input: FileListSorter with [DirSortBy.NONE_ON_TOP], [SortBy.NAME] and [SortOrder.ASC]
+     * compare(file1,file2) file1 title's length = file2 title's length
+     *
+     * Expected: return zero
      */
     @Test
     fun testSort0TitleSame() {
-        val fileListSorter = FileListSorter(-1, 0, 1)
+        val fileListSorter = FileListSorter(
+            DirSortBy.NONE_ON_TOP,
+            SortType(SortBy.NAME, SortOrder.ASC)
+        )
         val file1 = LayoutElementParcelable(
             ApplicationProvider.getApplicationContext(),
             "abc.txt",
@@ -323,13 +372,19 @@ class FileListSorterTest {
     }
 
     /**
-     * Purpose: when sort is 1, if file1 date more recent than file2 date, result is positive Input:
-     * FileListSorter(-1,1,1) sort is 1 / compare(file1,file2) file1 date > file2 date Expected:
-     * return positive integer
+     * Purpose: when sort is [SortBy.LAST_MODIFIED], if file1 date more recent than file2 date, result is positive
+     *
+     * Input: FileListSorter with [DirSortBy.NONE_ON_TOP], [SortBy.LAST_MODIFIED] and [SortOrder.ASC]
+     * compare(file1,file2) file1 date > file2 date
+     *
+     * Expected: return positive integer
      */
     @Test
-    fun testSort1File1DateLastest() {
-        val fileListSorter = FileListSorter(-1, 1, 1)
+    fun testSort1File1DateLatest() {
+        val fileListSorter = FileListSorter(
+            DirSortBy.NONE_ON_TOP,
+            SortType(SortBy.LAST_MODIFIED, SortOrder.ASC)
+        )
         val file1 = LayoutElementParcelable(
             ApplicationProvider.getApplicationContext(),
             "abc.txt",
@@ -362,13 +417,19 @@ class FileListSorterTest {
     }
 
     /**
-     * Purpose: when sort is 1, if file2 date more recent than file1 date, result is negative Input:
-     * FileListSorter(-1,1,1) sort is 1 / compare(file1,file2) file1 date < file2 date Expected:
-     * return negative integer
+     * Purpose: when sort is [SortBy.LAST_MODIFIED], if file2 date more recent than file1 date, result is negative
+     *
+     * Input: FileListSorter with [DirSortBy.NONE_ON_TOP], [SortBy.LAST_MODIFIED] and [SortOrder.ASC]
+     * compare(file1,file2) file1 date < file2 date
+     *
+     * Expected: return negative integer
      */
     @Test
-    fun testSort1File2DateLastest() {
-        val fileListSorter = FileListSorter(-1, 1, 1)
+    fun testSort1File2DateLatest() {
+        val fileListSorter = FileListSorter(
+            DirSortBy.NONE_ON_TOP,
+            SortType(SortBy.LAST_MODIFIED, SortOrder.ASC)
+        )
         val file1 = LayoutElementParcelable(
             ApplicationProvider.getApplicationContext(),
             "abc.txt",
@@ -401,13 +462,19 @@ class FileListSorterTest {
     }
 
     /**
-     * Purpose: when sort is 1, if file1 date and file2 date are same, result is zero Input:
-     * FileListSorter(-1,1,1) sort is 1 / compare(file1,file2) file1 date = file2 date Expected:
-     * return zero
+     * Purpose: when sort is [SortBy.LAST_MODIFIED], if file1 date and file2 date are same, result is zero
+     *
+     * Input: FileListSorter with [DirSortBy.NONE_ON_TOP], [SortBy.LAST_MODIFIED] and [SortOrder.ASC]
+     * compare(file1,file2) file1 date = file2 date
+     *
+     * Expected: return zero
      */
     @Test
     fun testSort1FileDateSame() {
-        val fileListSorter = FileListSorter(-1, 1, 1)
+        val fileListSorter = FileListSorter(
+            DirSortBy.NONE_ON_TOP,
+            SortType(SortBy.LAST_MODIFIED, SortOrder.ASC)
+        )
         val file1 = LayoutElementParcelable(
             ApplicationProvider.getApplicationContext(),
             "abc.txt",
@@ -440,13 +507,20 @@ class FileListSorterTest {
     }
 
     /**
-     * Purpose: when sort is 2, if two file are not directory && file1 size bigger than file2 size,
-     * result is positive Input: FileListSorter(-1,2,1) sort is 2 / compare(file1,file2) file1 size >
-     * file2 size Expected: return positive integer
+     * Purpose: when sort is [SortBy.SIZE], if two file are not directory && file1 size bigger than file2 size,
+     * result is positive
+     *
+     * Input: FileListSorter with [DirSortBy.NONE_ON_TOP], [SortBy.SIZE] and [SortOrder.ASC]
+     * compare(file1,file2) file1 size > file2 size
+     *
+     * Expected: return positive integer
      */
     @Test
     fun testSort2NoDirAndFile1SizeBigger() {
-        val fileListSorter = FileListSorter(-1, 2, 1)
+        val fileListSorter = FileListSorter(
+            DirSortBy.NONE_ON_TOP,
+            SortType(SortBy.SIZE, SortOrder.ASC)
+        )
         val file1 = LayoutElementParcelable(
             ApplicationProvider.getApplicationContext(),
             "abc.txt",
@@ -479,13 +553,20 @@ class FileListSorterTest {
     }
 
     /**
-     * Purpose: when sort is 2, if two file are not directory && file1 size smaller than file2 size,
-     * result is negative Input: FileListSorter(-1,2,1) sort is 2 / compare(file1,file2) file1 size <
-     * file2 size Expected: return negative integer
+     * Purpose: when sort is [SortBy.SIZE], if two file are not directory && file1 size smaller than file2 size,
+     * result is negative
+     *
+     * Input: FileListSorter with [DirSortBy.NONE_ON_TOP], [SortBy.SIZE] and [SortOrder.ASC]
+     * compare(file1,file2) file1 size < file2 size
+     *
+     * Expected: return negative integer
      */
     @Test
     fun testSort2NoDirAndFile2SizeBigger() {
-        val fileListSorter = FileListSorter(-1, 2, 1)
+        val fileListSorter = FileListSorter(
+            DirSortBy.NONE_ON_TOP,
+            SortType(SortBy.SIZE, SortOrder.ASC)
+        )
         val file1 = LayoutElementParcelable(
             ApplicationProvider.getApplicationContext(),
             "abc.txt",
@@ -518,13 +599,20 @@ class FileListSorterTest {
     }
 
     /**
-     * Purpose: when sort is 2, if two file are not directory && file1 size and file2 size are same,
-     * result is zero Input: FileListSorter(-1,2,1) sort is 2 / compare(file1,file2) file1 size =
-     * file2 size Expected: return zero
+     * Purpose: when sort is [SortBy.SIZE], if two file are not directory && file1 size and file2 size are same,
+     * result is zero
+     *
+     * Input: FileListSorter with [DirSortBy.NONE_ON_TOP], [SortBy.SIZE] and [SortOrder.ASC]
+     * compare(file1,file2) file1 size = file2 size
+     *
+     * Expected: return zero
      */
     @Test
     fun testSort2NoDirAndFileSizeSame() {
-        val fileListSorter = FileListSorter(-1, 2, 1)
+        val fileListSorter = FileListSorter(
+            DirSortBy.NONE_ON_TOP,
+            SortType(SortBy.SIZE, SortOrder.ASC)
+        )
         val file1 = LayoutElementParcelable(
             ApplicationProvider.getApplicationContext(),
             "abc.txt",
@@ -557,14 +645,20 @@ class FileListSorterTest {
     }
 
     /**
-     * Purpose: when sort is 2, if file1 is directory && file1 title's length bigger than file2
-     * title's length, result is positive Input: FileListSorter(-1,2,1) sort is 2 /
-     * compare(file1,file2) file1 title's length > file2 title's length Expected: return positive
-     * integer
+     * Purpose: when sort is [SortBy.SIZE], if file1 is directory && file1 title's length bigger than file2
+     * title's length, result is positive
+     *
+     * Input: FileListSorter with [DirSortBy.NONE_ON_TOP], [SortBy.SIZE] and [SortOrder.ASC]
+     * compare(file1,file2) file1 title's length > file2 title's length
+     *
+     * Expected: return positive integer
      */
     @Test
     fun testSort2File1DirAndFile1TitleBigger() {
-        val fileListSorter = FileListSorter(-1, 2, 1)
+        val fileListSorter = FileListSorter(
+            DirSortBy.NONE_ON_TOP,
+            SortType(SortBy.SIZE, SortOrder.ASC)
+        )
         val file1 = LayoutElementParcelable(
             ApplicationProvider.getApplicationContext(),
             "abc1",
@@ -597,14 +691,20 @@ class FileListSorterTest {
     }
 
     /**
-     * Purpose: when sort is 2, if file1 is directory && file1 title's length smaller than file2
-     * title's length, result is negative Input: FileListSorter(-1,2,1) sort is 2 /
-     * compare(file1,file2) file1 title's length < file2 title's length Expected: return negative
-     * integer
+     * Purpose: when sort is [SortBy.SIZE], if file1 is directory && file1 title's length smaller than file2
+     * title's length, result is negative
+     *
+     * Input: FileListSorter with [DirSortBy.NONE_ON_TOP], [SortBy.SIZE] and [SortOrder.ASC]
+     * compare(file1,file2) file1 title's length < file2 title's length
+     *
+     * Expected: return negative integer
      */
     @Test
     fun testSort2File1DirAndFile2TitleBigger() {
-        val fileListSorter = FileListSorter(-1, 2, 1)
+        val fileListSorter = FileListSorter(
+            DirSortBy.NONE_ON_TOP,
+            SortType(SortBy.SIZE, SortOrder.ASC)
+        )
         val file1 = LayoutElementParcelable(
             ApplicationProvider.getApplicationContext(),
             "abc",
@@ -637,14 +737,20 @@ class FileListSorterTest {
     }
 
     /**
-     * Purpose: when sort is 2, if file2 is directory && file1 title's length bigger than file2
-     * title's length, result is positive Input: FileListSorter(-1,2,1) sort is 2 /
-     * compare(file1,file2) file1 title's length > file2 title's length Expected: return positive
-     * integer
+     * Purpose: when sort is [SortBy.SIZE], if file2 is directory && file1 title's length bigger than file2
+     * title's length, result is positive
+     *
+     * Input: FileListSorter with [DirSortBy.NONE_ON_TOP], [SortBy.SIZE] and [SortOrder.ASC]
+     * compare(file1,file2) file1 title's length > file2 title's length
+     *
+     * Expected: return positive integer
      */
     @Test
     fun testSort2File2DirAndFile1TitleBigger() {
-        val fileListSorter = FileListSorter(-1, 2, 1)
+        val fileListSorter = FileListSorter(
+            DirSortBy.NONE_ON_TOP,
+            SortType(SortBy.SIZE, SortOrder.ASC)
+        )
         val file1 = LayoutElementParcelable(
             ApplicationProvider.getApplicationContext(),
             "abc1.txt",
@@ -677,14 +783,20 @@ class FileListSorterTest {
     }
 
     /**
-     * Purpose: when sort is 2, if file2 is directory && file1 title's length smaller than file2
-     * title's length, result is negative Input: FileListSorter(-1,2,1) sort is 2 /
-     * compare(file1,file2) file1 title's length < file2 title's length Expected: return negative
-     * integer
+     * Purpose: when sort is [SortBy.SIZE], if file2 is directory && file1 title's length smaller than file2
+     * title's length, result is negative
+     *
+     * Input: FileListSorter with [DirSortBy.NONE_ON_TOP], [SortBy.SIZE] and [SortOrder.ASC]
+     * compare(file1,file2) file1 title's length < file2 title's length
+     *
+     * Expected: return negative integer
      */
     @Test
     fun testSort2File2DirAndFile2TitleBigger() {
-        val fileListSorter = FileListSorter(-1, 2, 1)
+        val fileListSorter = FileListSorter(
+            DirSortBy.NONE_ON_TOP,
+            SortType(SortBy.SIZE, SortOrder.ASC)
+        )
         val file1 = LayoutElementParcelable(
             ApplicationProvider.getApplicationContext(),
             "abc.txt",
@@ -717,13 +829,20 @@ class FileListSorterTest {
     }
 
     /**
-     * Purpose: when sort is 2, if file2 is directory && file1 title's length and file2 title's length
-     * are same, result is zero Input: FileListSorter(-1,2,1) sort is 2 / compare(file1,file2) file1
-     * title's length = file2 title's length Expected: return zero
+     * Purpose: when sort is [SortBy.SIZE], if file2 is directory && file1 title's length and file2 title's length
+     * are same, result is zero
+     *
+     * Input: FileListSorter with [DirSortBy.NONE_ON_TOP], [SortBy.SIZE] and [SortOrder.ASC]
+     * compare(file1,file2) file1 title's length = file2 title's length
+     *
+     * Expected: return zero
      */
     @Test
     fun testSort2File2DirAndFileTitleSame() {
-        val fileListSorter = FileListSorter(-1, 2, 1)
+        val fileListSorter = FileListSorter(
+            DirSortBy.NONE_ON_TOP,
+            SortType(SortBy.SIZE, SortOrder.ASC)
+        )
         val file1 = LayoutElementParcelable(
             ApplicationProvider.getApplicationContext(),
             "abc",
@@ -756,15 +875,20 @@ class FileListSorterTest {
     }
 
     /**
-     * Purpose: when sort is 3, if file1 extension's length and file2 extension's length are same &&
-     * file1 title's length bigger than file2 title's length, result is positive Input:
-     * FileListSorter(-1,3,1) sort is 3 / compare(file1,file2) file1 extension's length = file2
-     * extension's length && file1 title's length > file2 title's length Expected: return positive
-     * integer
+     * Purpose: when sort is [SortBy.TYPE], if file1 extension's length and file2 extension's length are same &&
+     * file1 title's length bigger than file2 title's length, result is positive
+     *
+     * Input: FileListSorter with [DirSortBy.NONE_ON_TOP], [SortBy.TYPE] and [SortOrder.ASC]
+     * compare(file1,file2) file1 extension's length = file2 extension's length && file1 title's length > file2 title's length
+     *
+     * Expected: return positive integer
      */
     @Test
     fun testSort3FileExtensionSameAndFile1TitleBigger() {
-        val fileListSorter = FileListSorter(-1, 3, 1)
+        val fileListSorter = FileListSorter(
+            DirSortBy.NONE_ON_TOP,
+            SortType(SortBy.TYPE, SortOrder.ASC)
+        )
         val file1 = LayoutElementParcelable(
             ApplicationProvider.getApplicationContext(),
             "abc1.txt",
@@ -797,15 +921,20 @@ class FileListSorterTest {
     }
 
     /**
-     * Purpose: when sort is 3, if file1 extension's length and file2 extension's length are same &&
-     * file1 title's length smaller than file2 title's length, result is negative Input:
-     * FileListSorter(-1,3,1) sort is 3 / compare(file1,file2) file1 extension's length = file2
-     * extension's length && file1 title's length < file2 title's length Expected: return negative
-     * integer
+     * Purpose: when sort is [SortBy.TYPE], if file1 extension's length and file2 extension's length are same &&
+     * file1 title's length smaller than file2 title's length, result is negative
+     *
+     * Input: FileListSorter with [DirSortBy.NONE_ON_TOP], [SortBy.TYPE] and [SortOrder.ASC]
+     * compare(file1,file2) file1 extension's length = file2 extension's length && file1 title's length < file2 title's length
+     *
+     * Expected: return negative integer
      */
     @Test
     fun testSort3FileExtensionSameAndFile2TitleBigger() {
-        val fileListSorter = FileListSorter(-1, 3, 1)
+        val fileListSorter = FileListSorter(
+            DirSortBy.NONE_ON_TOP,
+            SortType(SortBy.TYPE, SortOrder.ASC)
+        )
         val file1 = LayoutElementParcelable(
             ApplicationProvider.getApplicationContext(),
             "abc.txt",
@@ -838,52 +967,20 @@ class FileListSorterTest {
     }
 
     /**
-     * Purpose: when sort is 3, if file1 extension's length and file2 extension's length are same &&
-     * file1 title's length and file2 title's length are same, result is zero Input:
-     * FileListSorter(-1,3,1) sort is 3 / compare(file1,file2) file1 extension's length = file2
-     * extension's length && file1 title's length = file2 title's length Expected: return zero
-     */
-    @Test
-    fun testSort3FileExtensionSameAndFileTitleSame() {
-        val fileListSorter = FileListSorter(-1, 3, 1)
-        val file1 = LayoutElementParcelable(
-            ApplicationProvider.getApplicationContext(),
-            "abc.txt",
-            "C:\\AmazeFileManager\\abc",
-            "user",
-            "symlink",
-            "100",
-            123L,
-            true,
-            "1234",
-            false,
-            false,
-            OpenMode.UNKNOWN
-        )
-        val file2 = LayoutElementParcelable(
-            ApplicationProvider.getApplicationContext(),
-            "ABC.txt",
-            "C:\\AmazeFileManager\\ABC",
-            "user",
-            "symlink",
-            "101",
-            124L,
-            true,
-            "1234",
-            false,
-            false,
-            OpenMode.UNKNOWN
-        )
-        Assert.assertEquals(fileListSorter.compare(file1, file2).toLong(), 0)
-    }
-
-    /**
-     * Purpose: when sort is not 0,1,2,3, result is zero Input: FileListSorter(-1,4,1) sort is 4
+     * Purpose: when sort is [SortBy.TYPE], if file1 extension's length and file2 extension's length are same &&
+     * file1 title's length and file2 title's length are same, result is zero
+     *
+     * Input: FileListSorter with [DirSortBy.NONE_ON_TOP], [SortBy.TYPE] and [SortOrder.ASC]
+     * compare(file1,file2) file1 extension's length = file2 extension's length && file1 title's length = file2 title's length
+     *
      * Expected: return zero
      */
     @Test
-    fun testSortAnotherNumber() {
-        val fileListSorter = FileListSorter(-1, 4, 1)
+    fun testSort3FileExtensionSameAndFileTitleSame() {
+        val fileListSorter = FileListSorter(
+            DirSortBy.NONE_ON_TOP,
+            SortType(SortBy.TYPE, SortOrder.ASC)
+        )
         val file1 = LayoutElementParcelable(
             ApplicationProvider.getApplicationContext(),
             "abc.txt",

--- a/app/src/test/java/com/amaze/filemanager/filesystem/files/sort/DirSortByTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/filesystem/files/sort/DirSortByTest.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2014-2023 Arpit Khurana <arpitkh96@gmail.com>, Vishal Nehra <vishalmeham2@gmail.com>,
+ * Emmanuel Messulam<emmanuelbendavid@gmail.com>, Raymond Lai <airwave209gt at gmail.com> and Contributors.
+ *
+ * This file is part of Amaze File Manager.
+ *
+ * Amaze File Manager is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.amaze.filemanager.filesystem.files.sort
+
+import android.os.Build
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.amaze.filemanager.shadows.ShadowMultiDex
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import kotlin.random.Random
+
+@RunWith(AndroidJUnit4::class)
+@Config(
+    shadows = [ShadowMultiDex::class],
+    sdk = [Build.VERSION_CODES.KITKAT, Build.VERSION_CODES.P, Build.VERSION_CODES.R]
+)
+class DirSortByTest {
+    /** Tests if [DirSortBy.getDirSortBy] returns the correct [DirSortBy] corresponding to the given index */
+    @Test
+    fun getDirSortByTest() {
+        Assert.assertEquals(
+            "DirSortBy.getDirSortBy(0) did not return DIR_ON_TOP",
+            DirSortBy.DIR_ON_TOP,
+            DirSortBy.getDirSortBy(0)
+        )
+        Assert.assertEquals(
+            "DirSortBy.getDirSortBy(1) did not return FILE_ON_TOP",
+            DirSortBy.FILE_ON_TOP,
+            DirSortBy.getDirSortBy(1)
+        )
+        Assert.assertEquals(
+            "DirSortBy.getDirSortBy(2) did not return NONE_ON_TOP",
+            DirSortBy.NONE_ON_TOP,
+            DirSortBy.getDirSortBy(2)
+        )
+        // could be any int except 0 to 2
+        val randomIndex = Random.nextInt(3, Int.MAX_VALUE)
+        Assert.assertEquals(
+            "DirSortBy.getDirSortBy($randomIndex) did not return NONE_ON_TOP",
+            DirSortBy.NONE_ON_TOP,
+            DirSortBy.getDirSortBy(randomIndex)
+        )
+    }
+}

--- a/app/src/test/java/com/amaze/filemanager/filesystem/files/sort/SortByTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/filesystem/files/sort/SortByTest.kt
@@ -1,0 +1,107 @@
+/*
+ * Copyright (C) 2014-2023 Arpit Khurana <arpitkh96@gmail.com>, Vishal Nehra <vishalmeham2@gmail.com>,
+ * Emmanuel Messulam<emmanuelbendavid@gmail.com>, Raymond Lai <airwave209gt at gmail.com> and Contributors.
+ *
+ * This file is part of Amaze File Manager.
+ *
+ * Amaze File Manager is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.amaze.filemanager.filesystem.files.sort
+
+import android.os.Build
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.amaze.filemanager.shadows.ShadowMultiDex
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import kotlin.random.Random
+
+@RunWith(AndroidJUnit4::class)
+@Config(
+    shadows = [ShadowMultiDex::class],
+    sdk = [Build.VERSION_CODES.KITKAT, Build.VERSION_CODES.P, Build.VERSION_CODES.R]
+)
+class SortByTest {
+
+    /** Tests if [SortBy.getSortBy] returns the correct [SortBy] corresponding to the given index */
+    @Test
+    fun getSortByTest() {
+        Assert.assertEquals(
+            "SortBy.getSortBy(0) did not return NAME",
+            SortBy.NAME,
+            SortBy.getSortBy(0)
+        )
+        Assert.assertEquals(
+            "SortBy.getSortBy(1) did not return LAST_MODIFIED",
+            SortBy.LAST_MODIFIED,
+            SortBy.getSortBy(1)
+        )
+        Assert.assertEquals(
+            "SortBy.getSortBy(2) did not return SIZE",
+            SortBy.SIZE,
+            SortBy.getSortBy(2)
+        )
+        Assert.assertEquals(
+            "SortBy.getSortBy(3) did not return TYPE",
+            SortBy.TYPE,
+            SortBy.getSortBy(3)
+        )
+        Assert.assertEquals(
+            "SortBy.getSortBy(4) did not return RELEVANCE",
+            SortBy.RELEVANCE,
+            SortBy.getSortBy(4)
+        )
+        // could be any int except 0 to 4
+        val randomIndex = Random.nextInt(5, Int.MAX_VALUE)
+        Assert.assertEquals(
+            "SortBy.getDirectorySortBy($randomIndex) did not return NAME",
+            SortBy.NAME,
+            SortBy.getDirectorySortBy(randomIndex)
+        )
+    }
+
+    /** Tests if [SortBy.getDirectorySortBy] returns the correct [SortBy] corresponding to the given index */
+    @Test
+    fun getDirectorySortByTest() {
+        Assert.assertEquals(
+            "SortBy.getDirectorySortBy(0) did not return NAME",
+            SortBy.NAME,
+            SortBy.getDirectorySortBy(0)
+        )
+        Assert.assertEquals(
+            "SortBy.getDirectorySortBy(1) did not return LAST_MODIFIED",
+            SortBy.LAST_MODIFIED,
+            SortBy.getDirectorySortBy(1)
+        )
+        Assert.assertEquals(
+            "SortBy.getDirectorySortBy(2) did not return SIZE",
+            SortBy.SIZE,
+            SortBy.getDirectorySortBy(2)
+        )
+        Assert.assertEquals(
+            "SortBy.getDirectorySortBy(3) did not return TYPE",
+            SortBy.TYPE,
+            SortBy.getDirectorySortBy(3)
+        )
+        // could be any int except 0 to 3
+        val randomIndex = Random.nextInt(4, Int.MAX_VALUE)
+        Assert.assertEquals(
+            "SortBy.getDirectorySortBy($randomIndex) did not return NAME",
+            SortBy.NAME,
+            SortBy.getDirectorySortBy(randomIndex)
+        )
+    }
+}

--- a/app/src/test/java/com/amaze/filemanager/filesystem/files/sort/SortTypeTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/filesystem/files/sort/SortTypeTest.kt
@@ -1,0 +1,137 @@
+/*
+ * Copyright (C) 2014-2023 Arpit Khurana <arpitkh96@gmail.com>, Vishal Nehra <vishalmeham2@gmail.com>,
+ * Emmanuel Messulam<emmanuelbendavid@gmail.com>, Raymond Lai <airwave209gt at gmail.com> and Contributors.
+ *
+ * This file is part of Amaze File Manager.
+ *
+ * Amaze File Manager is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.amaze.filemanager.filesystem.files.sort
+
+import android.os.Build
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.amaze.filemanager.shadows.ShadowMultiDex
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+@RunWith(AndroidJUnit4::class)
+@Config(
+    shadows = [ShadowMultiDex::class],
+    sdk = [Build.VERSION_CODES.KITKAT, Build.VERSION_CODES.P, Build.VERSION_CODES.R]
+)
+class SortTypeTest {
+
+    /** Tests if the Int returned from [SortType.toDirectorySortInt] is as expected */
+    @Test
+    fun toDirectorySortIntTest() {
+        Assert.assertEquals(
+            "SortType with SortBy.NAME and SortOrder.ASC was not 0",
+            0,
+            SortType(SortBy.NAME, SortOrder.ASC).toDirectorySortInt()
+        )
+        Assert.assertEquals(
+            "SortType with SortBy.LAST_MODIFIED and SortOrder.ASC was not 1",
+            1,
+            SortType(SortBy.LAST_MODIFIED, SortOrder.ASC).toDirectorySortInt()
+        )
+        Assert.assertEquals(
+            "SortType with SortBy.SIZE and SortOrder.ASC was not 2",
+            2,
+            SortType(SortBy.SIZE, SortOrder.ASC).toDirectorySortInt()
+        )
+        Assert.assertEquals(
+            "SortType with SortBy.TYPE and SortOrder.ASC was not 3",
+            3,
+            SortType(SortBy.TYPE, SortOrder.ASC).toDirectorySortInt()
+        )
+        Assert.assertEquals(
+            "SortType with SortBy.NAME and SortOrder.DESC was not 4",
+            4,
+            SortType(SortBy.NAME, SortOrder.DESC).toDirectorySortInt()
+        )
+        Assert.assertEquals(
+            "SortType with SortBy.LAST_MODIFIED and SortOrder.DESC was not 5",
+            5,
+            SortType(SortBy.LAST_MODIFIED, SortOrder.DESC).toDirectorySortInt()
+        )
+        Assert.assertEquals(
+            "SortType with SortBy.SIZE and SortOrder.DESC was not 6",
+            6,
+            SortType(SortBy.SIZE, SortOrder.DESC).toDirectorySortInt()
+        )
+        Assert.assertEquals(
+            "SortType with SortBy.TYPE and SortOrder.DESC was not 7",
+            7,
+            SortType(SortBy.TYPE, SortOrder.DESC).toDirectorySortInt()
+        )
+        Assert.assertEquals(
+            "SortType with SortBy.RELEVANCE and SortOrder.ASC was not 0",
+            0,
+            SortType(SortBy.RELEVANCE, SortOrder.ASC).toDirectorySortInt()
+        )
+        Assert.assertEquals(
+            "SortType with SortBy.RELEVANCE and SortOrder.DESC was not 4",
+            4,
+            SortType(SortBy.RELEVANCE, SortOrder.DESC).toDirectorySortInt()
+        )
+    }
+
+    /** Tests if the [SortType] returned from [SortType.getDirectorySortType] corresponds to the given index */
+    @Test
+    fun getDirectorySortTypeTest() {
+        Assert.assertEquals(
+            "0 was not translated to SortType with SortBy.NAME and SortOrder.ASC",
+            SortType(SortBy.NAME, SortOrder.ASC),
+            SortType.getDirectorySortType(0)
+        )
+        Assert.assertEquals(
+            "1 was not translated to SortType with SortBy.LAST_MODIFIED and SortOrder.ASC",
+            SortType(SortBy.LAST_MODIFIED, SortOrder.ASC),
+            SortType.getDirectorySortType(1)
+        )
+        Assert.assertEquals(
+            "2 was not translated to SortType with SortBy.SIZE and SortOrder.ASC",
+            SortType(SortBy.SIZE, SortOrder.ASC),
+            SortType.getDirectorySortType(2)
+        )
+        Assert.assertEquals(
+            "3 was not translated to SortType with SortBy.TYPE and SortOrder.ASC",
+            SortType(SortBy.TYPE, SortOrder.ASC),
+            SortType.getDirectorySortType(3)
+        )
+        Assert.assertEquals(
+            "4 was not translated to SortType with SortBy.NAME and SortOrder.DESC",
+            SortType(SortBy.NAME, SortOrder.DESC),
+            SortType.getDirectorySortType(4)
+        )
+        Assert.assertEquals(
+            "5 was not translated to SortType with SortBy.LAST_MODIFIED and SortOrder.DESC",
+            SortType(SortBy.LAST_MODIFIED, SortOrder.DESC),
+            SortType.getDirectorySortType(5)
+        )
+        Assert.assertEquals(
+            "6 was not translated to SortType with SortBy.SIZE and SortOrder.DESC",
+            SortType(SortBy.SIZE, SortOrder.DESC),
+            SortType.getDirectorySortType(6)
+        )
+        Assert.assertEquals(
+            "7 was not translated to SortType with SortBy.TYPE and SortOrder.DESC",
+            SortType(SortBy.TYPE, SortOrder.DESC),
+            SortType.getDirectorySortType(7)
+        )
+    }
+}

--- a/app/src/test/java/com/amaze/filemanager/utils/CryptUtilTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/utils/CryptUtilTest.kt
@@ -110,7 +110,7 @@ class CryptUtilTest {
         CryptUtil(
             AppConfig.getInstance(),
             HybridFileParcelable(targetFile.absolutePath).also {
-                it.size = targetFile.length()
+                it.setSize(targetFile.length())
             },
             Environment.getExternalStorageDirectory().absolutePath,
             ProgressHandler(),


### PR DESCRIPTION
## Description
This PR adds the ability to sort the search results in the `SearchView`. For this, a button was added to the `SearchView` which opens a dialog similar to the one for sorting directories.

Additionally, to address issue #3357, this PR adds an option to sort the search results by relevance. This sorting is as described in [this comment](https://github.com/TeamAmaze/AmazeFileManager/issues/3357#issuecomment-1813236314) and is only available for sorting search results and not for directories.

To fully resolve issue #3357, the "old" search has to be embedded in the same search view as the new search view.
However, to avoid bloating this PR, I think it might be better to fix that separately.

#### Issue tracker   
<!-- Fixes will automatically close the related issue -->
<!-- Fixes # -->
<!-- Addresses won't automatically close the related issue -->
Addresses #3357

#### Automatic tests
<!-- remember to do manual testing when making UI changes! -->
- [x] Added test cases
  
#### Manual tests
- [x] Done  
  
Device:
- Pixel 7 emulator running Android 13
- HTC U11 life running Android 10

#### Build tasks success  
<!-- run these! -->
Successfully running following tasks on local:
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`

<!-- If there are related PRs please add them here -->
<!--
#### Related PR  
Related to PR #
-->