### PR TITLE
Proguard rules fix to include everything below org.bouncycastle.jcajce.provider.asymmetric

### DIFF
--- a/app/proguard.cfg
+++ b/app/proguard.cfg
@@ -86,17 +86,14 @@
 -keep class org.bouncycastle.crypto.prng.* {*;}
 -keep class org.bouncycastle.crypto.signers.* {*;}
 
--keep class org.bouncycastle.jcajce.provider.asymmetric.* {*;}
--keep class org.bouncycastle.jcajce.provider.asymmetric.util.* {*;}
--keep class org.bouncycastle.jcajce.provider.asymmetric.dh.* {*;}
--keep class org.bouncycastle.jcajce.provider.asymmetric.ec.* {*;}
--keep class org.bouncycastle.jcajce.provider.asymmetric.rsa.* {*;}
+-keep class org.bouncycastle.jcajce.provider.asymmetric.** {*;}
 
 -keep class org.bouncycastle.jcajce.provider.digest.** {*;}
 -keep class org.bouncycastle.jcajce.provider.keystore.** {*;}
 -keep class org.bouncycastle.jcajce.provider.symmetric.** {*;}
 -keep class org.bouncycastle.jcajce.spec.* {*;}
 -keep class org.bouncycastle.jce.** {*;}
+-keep class org.bouncycastle.openssl.** {*;}
 
 -dontwarn org.bouncycastle.jsse.**
 -dontwarn org.bouncycastle.asn1.ASN1ApplicationSpecific
@@ -128,3 +125,6 @@
 
 -keep class com.amaze.trashbin.** { *; }
 -dontwarn ch.qos.logback.core.net.*
+
+-keepattributes SourceFile,LineNumberTable
+-renamesourcefileattribute SourceFile


### PR DESCRIPTION
## Description

Update Proguard rules to fix SSH connection problems in recent release builds.

Source was from this `ClassNotFoundException` when attempting to create new connection, using `ed25519` SSH key in 3.11.2 release builds.

```java
Caused by: java.lang.ClassNotFoundException: Didn't find class "org.bouncycastle.jcajce.provider.asymmetric.edec.KeyPairGeneratorSpi$X25519" on path: DexPathList[[dex file "/data/data/com.amaze.filemanager/code_cache/.overlay/base.apk/classes.dex", dex file "/data/data/com.amaze.filemanager/code_cache/.overlay/base.apk/classes2.dex", zip file "/data/app/~~v1Lwt-x3qdOVJvGNkmr4Uw==/com.amaze.filemanager-vFjCNGE_AUHlBJMfD-Pkkw==/base.apk"],nativeLibraryDirectories=[/data/app/~~v1Lwt-x3qdOVJvGNkmr4Uw==/com.amaze.filemanager-vFjCNGE_AUHlBJMfD-Pkkw==/lib/arm64, /data/app/~~v1Lwt-x3qdOVJvGNkmr4Uw==/com.amaze.filemanager-vFjCNGE_AUHlBJMfD-Pkkw==/base.apk!/lib/arm64-v8a, /system/lib64, /system_ext/lib64]]
at dalvik.system.BaseDexClassLoader.findClass(BaseDexClassLoader.java:259)
at java.lang.ClassLoader.loadClass(ClassLoader.java:637)
at java.lang.ClassLoader.loadClass(ClassLoader.java:573)
at java.security.Provider$Service.getImplClass(Provider.java:1725)
... 20 more
```
Probably some changes to the BouncyCastle library we didn't notice, while we removed system's built-in `BC` provider, causing the problem.

#### Issue tracker   

#### Automatic tests
<!-- remember to do manual testing when making UI changes! -->
- [ ] Added test cases
  
#### Manual tests
- [x] Done  
  
- Device: Fairphone 5
- OS: LineageOS 23.0 (Android 16)
SftpConnectDialog should successfully save a new SSH connection, and hence be able to connect to the SSH server.

#### Build tasks success  
<!-- run these! -->
Successfully running following tasks on local:
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`