### PR TITLE
Implement support for big text files and Markdown preview

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -145,6 +145,10 @@ dependencies {
     implementation libs.androidX.constraintLayout
     implementation libs.androidX.multidex //Multiple dex files
     implementation libs.androidX.biometric
+    implementation libs.androidX.lifecycle.viewmodel.ktx
+    implementation libs.androidX.lifecycle.livedata.ktx
+    implementation libs.kotlinx.coroutines.core
+    implementation libs.kotlinx.coroutines.android
     implementation libs.room.runtime
     implementation libs.room.rxjava2
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -261,6 +261,10 @@ dependencies {
 
     implementation libs.gson
     implementation libs.amaze.trashBin
+
+    implementation libs.commonmark
+    implementation libs.commonmark.ext.gfm.tables
+    implementation libs.commonmark.ext.gfm.strikethrough
 }
 
 kotlin {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -94,6 +94,8 @@ android {
     }
 
     compileOptions {
+        // Flag to enable support for the new language APIs
+        coreLibraryDesugaringEnabled true
         sourceCompatibility JavaVersion.VERSION_17
         targetCompatibility JavaVersion.VERSION_17
     }
@@ -154,6 +156,7 @@ dependencies {
 
     ksp libs.room.compiler
     ksp libs.androidX.annotation
+    coreLibraryDesugaring libs.android.desugaring
 
     //For tests
     testImplementation libs.junit//tests the app logic

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/texteditor/read/FileWindowReader.kt
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/texteditor/read/FileWindowReader.kt
@@ -64,6 +64,7 @@ class FileWindowReader(
      * 4. Snaps the end to the last newline (unless at file end)
      * 5. Returns the decoded string and actual byte range consumed
      */
+    @Suppress("LongMethod")
     fun readWindow(
         byteOffset: Long,
         maxChars: Int,
@@ -161,7 +162,7 @@ class FileWindowReader(
      * past any continuation bytes (10xxxxxx pattern).
      */
     private fun snapToCharBoundary(offset: Long): Long {
-        if (offset <= 0L || offset >= fileSize) return offset.coerceIn(0L, fileSize)
+        if (offset !in 1..<fileSize) return offset.coerceIn(0L, fileSize)
 
         val buf = ByteBuffer.allocate(1)
         var pos = offset
@@ -226,16 +227,14 @@ class FileWindowReader(
                 channel = channel,
                 fileSize = size,
                 closeable =
-                    object : Closeable {
-                        override fun close() {
-                            try {
-                                fis.close()
-                            } catch (_: Exception) {
-                            }
-                            try {
-                                pfd.close()
-                            } catch (_: Exception) {
-                            }
+                    Closeable {
+                        try {
+                            fis.close()
+                        } catch (_: Exception) {
+                        }
+                        try {
+                            pfd.close()
+                        } catch (_: Exception) {
                         }
                     },
             )

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/texteditor/read/FileWindowReader.kt
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/texteditor/read/FileWindowReader.kt
@@ -1,0 +1,244 @@
+/*
+ * Copyright (C) 2014-2024 Arpit Khurana <arpitkh96@gmail.com>, Vishal Nehra <vishalmeham2@gmail.com>,
+ * Emmanuel Messulam<emmanuelbendavid@gmail.com>, Raymond Lai <airwave209gt at gmail.com> and Contributors.
+ *
+ * This file is part of Amaze File Manager.
+ *
+ * Amaze File Manager is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.amaze.filemanager.asynchronous.asynctasks.texteditor.read
+
+import android.content.ContentResolver
+import android.net.Uri
+import java.io.Closeable
+import java.io.File
+import java.io.FileInputStream
+import java.io.RandomAccessFile
+import java.nio.ByteBuffer
+import java.nio.channels.FileChannel
+import java.nio.charset.Charset
+import java.nio.charset.CodingErrorAction
+
+/**
+ * Seekable file reader that supports reading a window of characters from a file,
+ * snapping to UTF-8 character boundaries and line boundaries.
+ *
+ * All I/O methods are regular (non-suspend) functions — the caller is responsible
+ * for dispatching to Dispatchers.IO.
+ */
+class FileWindowReader(
+    private val channel: FileChannel,
+    private val charset: Charset = Charsets.UTF_8,
+    val fileSize: Long,
+    private val closeable: Closeable? = null,
+) : Closeable {
+    data class WindowResult(
+        val text: String,
+        /** Actual start byte offset (snapped to char/line boundary). */
+        val startByte: Long,
+        /** Byte offset after the last byte read. */
+        val endByte: Long,
+        val isStartOfFile: Boolean,
+        val isEndOfFile: Boolean,
+    )
+
+    /**
+     * Read a window of text starting at approximately [byteOffset].
+     *
+     * The method:
+     * 1. Adjusts the offset to land on a UTF-8 character boundary
+     * 2. Reads enough bytes to decode up to [maxChars] characters
+     * 3. Snaps the start to the first newline (unless at file start)
+     * 4. Snaps the end to the last newline (unless at file end)
+     * 5. Returns the decoded string and actual byte range consumed
+     */
+    fun readWindow(
+        byteOffset: Long,
+        maxChars: Int,
+    ): WindowResult {
+        val safeOffset = snapToCharBoundary(byteOffset.coerceIn(0L, fileSize))
+
+        // Read enough bytes for worst-case UTF-8: maxChars * 4
+        val maxBytes = (maxChars.toLong() * 4).coerceAtMost(fileSize - safeOffset)
+        if (maxBytes <= 0) {
+            return WindowResult(
+                text = "",
+                startByte = safeOffset,
+                endByte = safeOffset,
+                isStartOfFile = safeOffset == 0L,
+                isEndOfFile = true,
+            )
+        }
+
+        val buffer = ByteBuffer.allocate(maxBytes.toInt())
+        synchronized(channel) {
+            channel.position(safeOffset)
+            var totalRead = 0
+            while (totalRead < maxBytes) {
+                val read = channel.read(buffer)
+                if (read == -1) break
+                totalRead += read
+            }
+        }
+        buffer.flip()
+
+        val actualBytesRead = buffer.remaining()
+        if (actualBytesRead == 0) {
+            return WindowResult(
+                text = "",
+                startByte = safeOffset,
+                endByte = safeOffset,
+                isStartOfFile = safeOffset == 0L,
+                isEndOfFile = true,
+            )
+        }
+
+        // Decode bytes to string
+        val decoder =
+            charset.newDecoder()
+                .onMalformedInput(CodingErrorAction.REPLACE)
+                .onUnmappableCharacter(CodingErrorAction.REPLACE)
+
+        val decoded = decoder.decode(buffer).toString()
+
+        // Trim to maxChars
+        val trimmed = if (decoded.length > maxChars) decoded.substring(0, maxChars) else decoded
+
+        // Calculate the byte length of the trimmed text
+        val trimmedBytes = trimmed.toByteArray(charset)
+
+        val isAtStart = safeOffset == 0L
+        val isAtEnd = safeOffset + trimmedBytes.size >= fileSize
+
+        // Snap to line boundaries
+        var text = trimmed
+        var startByteAdjust = 0
+
+        // Snap start: if not at file start, skip to after first newline
+        if (!isAtStart) {
+            val firstNewline = text.indexOf('\n')
+            if (firstNewline >= 0 && firstNewline < text.length - 1) {
+                val skipped = text.substring(0, firstNewline + 1)
+                startByteAdjust = skipped.toByteArray(charset).size
+                text = text.substring(firstNewline + 1)
+            }
+        }
+
+        // Snap end: if not at file end, trim to last newline
+        if (!isAtEnd) {
+            val lastNewline = text.lastIndexOf('\n')
+            if (lastNewline >= 0) {
+                text = text.substring(0, lastNewline + 1)
+            }
+        }
+
+        val actualStartByte = safeOffset + startByteAdjust
+        val actualEndByte = actualStartByte + text.toByteArray(charset).size
+
+        return WindowResult(
+            text = text,
+            startByte = actualStartByte,
+            endByte = actualEndByte.coerceAtMost(fileSize),
+            isStartOfFile = actualStartByte == 0L,
+            isEndOfFile = actualEndByte >= fileSize,
+        )
+    }
+
+    /**
+     * Snap a byte offset to a UTF-8 character boundary by backing up
+     * past any continuation bytes (10xxxxxx pattern).
+     */
+    private fun snapToCharBoundary(offset: Long): Long {
+        if (offset <= 0L || offset >= fileSize) return offset.coerceIn(0L, fileSize)
+
+        val buf = ByteBuffer.allocate(1)
+        var pos = offset
+        // Back up at most 3 bytes (max UTF-8 continuation)
+        val minPos = (offset - 3).coerceAtLeast(0L)
+
+        while (pos > minPos) {
+            synchronized(channel) {
+                channel.position(pos)
+                buf.clear()
+                channel.read(buf)
+            }
+            buf.flip()
+            val b = buf.get().toInt() and 0xFF
+            // If this byte is NOT a continuation byte, we're at a char boundary
+            if (b and 0xC0 != 0x80) {
+                return pos
+            }
+            pos--
+        }
+        return pos
+    }
+
+    override fun close() {
+        try {
+            channel.close()
+        } catch (_: Exception) {
+        }
+        try {
+            closeable?.close()
+        } catch (_: Exception) {
+        }
+    }
+
+    companion object {
+        /**
+         * Create a FileWindowReader from a regular File using RandomAccessFile.
+         */
+        fun fromFile(file: File): FileWindowReader {
+            val raf = RandomAccessFile(file, "r")
+            return FileWindowReader(
+                channel = raf.channel,
+                fileSize = raf.length(),
+                closeable = raf,
+            )
+        }
+
+        /**
+         * Create a FileWindowReader from a content:// URI using ContentResolver.
+         */
+        fun fromContentUri(
+            contentResolver: ContentResolver,
+            uri: Uri,
+        ): FileWindowReader {
+            val pfd =
+                contentResolver.openFileDescriptor(uri, "r")
+                    ?: throw IllegalArgumentException("Cannot open file descriptor for URI: $uri")
+            val fis = FileInputStream(pfd.fileDescriptor)
+            val channel = fis.channel
+            val size = channel.size()
+            return FileWindowReader(
+                channel = channel,
+                fileSize = size,
+                closeable =
+                    object : Closeable {
+                        override fun close() {
+                            try {
+                                fis.close()
+                            } catch (_: Exception) {
+                            }
+                            try {
+                                pfd.close()
+                            } catch (_: Exception) {
+                            }
+                        }
+                    },
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/texteditor/read/ReadTextFileCallable.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/texteditor/read/ReadTextFileCallable.java
@@ -54,6 +54,9 @@ public class ReadTextFileCallable implements Callable<ReturnedValueOnReadFile> {
 
   private File cachedFile = null;
 
+  /** The resolved File used for reading (may be a cached copy for root files). */
+  private File resolvedFile = null;
+
   public ReadTextFileCallable(
       ContentResolver contentResolver,
       EditableFileAbstraction file,
@@ -83,7 +86,9 @@ public class ReadTextFileCallable implements Callable<ReturnedValueOnReadFile> {
           if (documentFile != null && documentFile.exists() && documentFile.canWrite()) {
             inputStream = contentResolver.openInputStream(documentFile.getUri());
           } else {
-            inputStream = loadFile(FileUtils.fromContentUri(fileAbstraction.uri));
+            File contentFile = FileUtils.fromContentUri(fileAbstraction.uri);
+            resolvedFile = contentFile;
+            inputStream = loadFile(contentFile);
           }
         } else {
           inputStream = contentResolver.openInputStream(fileAbstraction.uri);
@@ -94,6 +99,7 @@ public class ReadTextFileCallable implements Callable<ReturnedValueOnReadFile> {
         Objects.requireNonNull(hybridFileParcelable);
 
         File file = hybridFileParcelable.getFile();
+        resolvedFile = file;
         inputStream = loadFile(file);
 
         break;
@@ -121,7 +127,35 @@ public class ReadTextFileCallable implements Callable<ReturnedValueOnReadFile> {
       fileContents = String.valueOf(buffer, 0, readChars);
     }
 
-    return new ReturnedValueOnReadFile(fileContents, cachedFile, tooLong);
+    FileWindowReader fileWindowReader = null;
+    long totalFileSize = 0L;
+
+    if (tooLong) {
+      // Create a FileWindowReader for windowed mode
+      if (cachedFile != null) {
+        // Root file was cached locally
+        fileWindowReader = FileWindowReader.Companion.fromFile(cachedFile);
+        totalFileSize = cachedFile.length();
+      } else if (resolvedFile != null) {
+        fileWindowReader = FileWindowReader.Companion.fromFile(resolvedFile);
+        totalFileSize = resolvedFile.length();
+      } else if (fileAbstraction.scheme == EditableFileAbstraction.Scheme.CONTENT
+          && fileAbstraction.uri != null) {
+        try {
+          fileWindowReader =
+              FileWindowReader.Companion.fromContentUri(contentResolver, fileAbstraction.uri);
+          totalFileSize = fileWindowReader.getFileSize();
+        } catch (Exception e) {
+          // Content provider doesn't support seekable file descriptors;
+          // windowed mode won't be available but the initial chunk is still shown
+          fileWindowReader = null;
+          totalFileSize = 0L;
+        }
+      }
+    }
+
+    return new ReturnedValueOnReadFile(
+        fileContents, cachedFile, tooLong, fileWindowReader, totalFileSize);
   }
 
   private InputStream loadFile(File file) throws ShellNotRunningException, IOException {

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/texteditor/read/ReadTextFileCallable.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/texteditor/read/ReadTextFileCallable.java
@@ -45,7 +45,7 @@ import androidx.documentfile.provider.DocumentFile;
 
 public class ReadTextFileCallable implements Callable<ReturnedValueOnReadFile> {
 
-  public static final int MAX_FILE_SIZE_CHARS = 50 * 1024;
+  public static final int MAX_FILE_SIZE_CHARS = 100 * 1024;
 
   private final ContentResolver contentResolver;
   private final EditableFileAbstraction fileAbstraction;

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/texteditor/read/ReadTextFileTask.kt
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/texteditor/read/ReadTextFileTask.kt
@@ -129,6 +129,16 @@ class ReadTextFileTask(
 
         if (value.fileIsTooLong) {
             textEditorActivity.setReadOnly()
+
+            // Initialize windowed mode in the ViewModel
+            viewModel.isWindowed = true
+            viewModel.fileWindowReader = value.fileWindowReader
+            viewModel.totalFileSize = value.totalFileSize
+            viewModel.windowStartByte = 0L
+            // Estimate the end byte from the initial content
+            viewModel.windowEndByte =
+                value.fileContents.toByteArray(Charsets.UTF_8).size.toLong()
+
             val snackbar =
                 Snackbar.make(
                     textEditorActivity.mainTextView,
@@ -141,6 +151,9 @@ class ReadTextFileTask(
                     .uppercase(Locale.getDefault()),
             ) { snackbar.dismiss() }
             snackbar.show()
+
+            // Initialize windowed scroll listener after content is set
+            textEditorActivity.initWindowedScrollListener()
         }
     }
 }

--- a/app/src/main/java/com/amaze/filemanager/ui/activities/texteditor/MarkdownHtmlGenerator.kt
+++ b/app/src/main/java/com/amaze/filemanager/ui/activities/texteditor/MarkdownHtmlGenerator.kt
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2014-2024 Arpit Khurana <arpitkh96@gmail.com>, Vishal Nehra <vishalmeham2@gmail.com>,
+ * Emmanuel Messulam<emmanuelbendavid@gmail.com>, Raymond Lai <airwave209gt at gmail.com> and Contributors.
+ *
+ * This file is part of Amaze File Manager.
+ *
+ * Amaze File Manager is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.amaze.filemanager.ui.activities.texteditor
+
+import org.commonmark.ext.gfm.strikethrough.StrikethroughExtension
+import org.commonmark.ext.gfm.tables.TablesExtension
+import org.commonmark.parser.Parser
+import org.commonmark.renderer.html.HtmlRenderer
+
+/**
+ * Utility for Markdown preview in the text editor.
+ * Pure functions with no Android dependencies — easy to unit-test.
+ */
+object MarkdownHtmlGenerator {
+    /**
+     * Returns `true` if [fileName] ends with `.md` or `.markdown` (case-insensitive).
+     */
+    @JvmStatic
+    fun isMarkdownFile(fileName: String?): Boolean {
+        if (fileName == null) return false
+        val lower = fileName.lowercase()
+        return lower.endsWith(".md") || lower.endsWith(".markdown")
+    }
+
+    /**
+     * Parse Markdown source text and return the rendered HTML body fragment.
+     */
+    @JvmStatic
+    fun renderToHtml(markdownSource: String): String {
+        val extensions = listOf(TablesExtension.create(), StrikethroughExtension.create())
+        val parser = Parser.builder().extensions(extensions).build()
+        val document = parser.parse(markdownSource)
+        val renderer = HtmlRenderer.builder().extensions(extensions).build()
+        return renderer.render(document)
+    }
+
+    /**
+     * Wrap an HTML body fragment with a full HTML document including theme-aware CSS.
+     *
+     * FIXME: Move template to strings.xml
+     * FIXME: Use Android/Material native Color constants for easy maintenance
+     *
+     * @param bodyHtml the rendered Markdown HTML fragment
+     * @param isDarkTheme true for dark/black theme, false for light theme
+     * @return a complete HTML document string
+     */
+    @JvmStatic
+    fun wrapWithBaseHtml(
+        bodyHtml: String,
+        isDarkTheme: Boolean,
+    ): String {
+        val bgColor = if (isDarkTheme) "#1a1a1a" else "#ffffff"
+        val textColor = if (isDarkTheme) "#e0e0e0" else "#212121"
+        val linkColor = if (isDarkTheme) "#82b1ff" else "#1565c0"
+        val codeBg = if (isDarkTheme) "#2d2d2d" else "#f5f5f5"
+        val borderColor = if (isDarkTheme) "#444444" else "#dddddd"
+        val quoteColor = if (isDarkTheme) "#aaaaaa" else "#666666"
+
+        return """<!DOCTYPE html>
+<html><head><meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<style>
+body { font-family: sans-serif; padding: 16px; margin: 0; background-color: $bgColor; color: $textColor; line-height: 1.6; word-wrap: break-word; }
+a { color: $linkColor; }
+pre { background-color: $codeBg; padding: 12px; border-radius: 4px; overflow-x: auto; }
+code { background-color: $codeBg; padding: 2px 4px; border-radius: 2px; font-size: 90%; }
+pre code { padding: 0; background: none; }
+blockquote { border-left: 4px solid $borderColor; margin: 0; padding: 0 16px; color: $quoteColor; }
+table { border-collapse: collapse; width: 100%; }
+th, td { border: 1px solid $borderColor; padding: 8px; text-align: left; }
+th { background-color: $codeBg; }
+img { max-width: 100%; height: auto; }
+hr { border: none; border-top: 1px solid $borderColor; }
+h1, h2, h3, h4, h5, h6 { margin-top: 24px; margin-bottom: 16px; }
+</style></head><body>
+$bodyHtml
+</body></html>"""
+    }
+}

--- a/app/src/main/java/com/amaze/filemanager/ui/activities/texteditor/ReturnedValueOnReadFile.kt
+++ b/app/src/main/java/com/amaze/filemanager/ui/activities/texteditor/ReturnedValueOnReadFile.kt
@@ -20,10 +20,15 @@
 
 package com.amaze.filemanager.ui.activities.texteditor
 
+import com.amaze.filemanager.asynchronous.asynctasks.texteditor.read.FileWindowReader
 import java.io.File
 
 data class ReturnedValueOnReadFile(
     val fileContents: String,
     val cachedFile: File?,
     val fileIsTooLong: Boolean,
+    /** Non-null when fileIsTooLong — provides seekable access to the full file. */
+    val fileWindowReader: FileWindowReader? = null,
+    /** Total file size in bytes, set when fileIsTooLong. */
+    val totalFileSize: Long = 0L,
 )

--- a/app/src/main/java/com/amaze/filemanager/ui/activities/texteditor/TextEditorActivity.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/activities/texteditor/TextEditorActivity.java
@@ -54,12 +54,14 @@ import android.graphics.Typeface;
 import android.net.Uri;
 import android.os.Bundle;
 import android.text.Editable;
+import android.text.Layout;
 import android.text.Spanned;
 import android.text.TextWatcher;
 import android.text.style.BackgroundColorSpan;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
+import android.view.ViewTreeObserver;
 import android.view.animation.Animation;
 import android.view.animation.AnimationUtils;
 import android.view.inputmethod.EditorInfo;
@@ -98,6 +100,9 @@ public class TextEditorActivity extends ThemedActivity
   private Snackbar loadingSnackbar;
 
   private TextEditorActivityViewModel viewModel;
+
+  /** Scroll listener reference for windowed mode (so it can be removed if needed). */
+  private ViewTreeObserver.OnScrollChangedListener windowedScrollListener;
 
   @Override
   public void onCreate(Bundle savedInstanceState) {
@@ -173,10 +178,18 @@ public class TextEditorActivity extends ThemedActivity
       if (savedInstanceState.getBoolean(KEY_MONOFONT)) {
         mainTextView.setTypeface(inputTypefaceMono);
       }
+      // Restore windowed mode state after rotation
+      if (viewModel.isWindowed()) {
+        setReadOnly();
+        initWindowedScrollListener();
+      }
     } else {
       load(this);
     }
     initStatusBarResources(findViewById(R.id.textEditorRootView));
+
+    // Observe windowed-mode LiveData for new window content
+    observeWindowContent();
   }
 
   @Override
@@ -195,6 +208,12 @@ public class TextEditorActivity extends ThemedActivity
   private void checkUnsavedChanges() {
     final TextEditorActivityViewModel viewModel =
         new ViewModelProvider(this).get(TextEditorActivityViewModel.class);
+
+    // In windowed mode, the file is read-only — no unsaved changes possible
+    if (viewModel.isWindowed()) {
+      finish();
+      return;
+    }
 
     if (viewModel.getOriginal() != null
         && mainTextView.isShown()
@@ -282,7 +301,14 @@ public class TextEditorActivity extends ThemedActivity
     final TextEditorActivityViewModel viewModel =
         new ViewModelProvider(this).get(TextEditorActivityViewModel.class);
 
-    menu.findItem(R.id.save).setVisible(viewModel.getModified());
+    boolean windowed = viewModel.isWindowed();
+
+    // Hide save in windowed mode; otherwise show based on modification state
+    menu.findItem(R.id.save).setVisible(!windowed && viewModel.getModified());
+
+    // Hide search in windowed mode (search only works on in-memory text)
+    menu.findItem(R.id.find).setVisible(!windowed);
+
     menu.findItem(R.id.monofont).setChecked(inputTypefaceMono.equals(mainTextView.getTypeface()));
     return super.onPrepareOptionsMenu(menu);
   }
@@ -378,6 +404,10 @@ public class TextEditorActivity extends ThemedActivity
         && charSequence.hashCode() == mainTextView.getText().hashCode()) {
       final TextEditorActivityViewModel viewModel =
           new ViewModelProvider(this).get(TextEditorActivityViewModel.class);
+
+      // Skip modification tracking in windowed mode (text changes are window loads, not edits)
+      if (viewModel.isWindowed()) return;
+
       final Timer oldTimer = viewModel.getTimer();
       viewModel.setTimer(null);
 
@@ -613,5 +643,89 @@ public class TextEditorActivity extends ThemedActivity
         mainTextView.getText().removeSpan(colorSpan);
       }
     }
+  }
+
+  // ── Sliding Window Helpers ──────────────────────────────────────────
+
+  /**
+   * Observe the ViewModel's windowContent LiveData. When a new window is loaded, replace the
+   * EditText content and adjust the scroll position for visual continuity.
+   */
+  private void observeWindowContent() {
+    viewModel
+        .getWindowContent()
+        .observe(
+            this,
+            result -> {
+              if (result == null) return;
+
+              // Determine an anchor: find the text line near the middle of the current viewport
+              int oldScrollY = scrollView.getScrollY();
+              Layout oldLayout = mainTextView.getLayout();
+
+              // Replace text (TextWatcher will fire but windowed-mode guard skips modification
+              // tracking)
+              mainTextView.setText(result.getText());
+
+              // Adjust scroll position for visual continuity
+              mainTextView.post(
+                  () -> {
+                    Layout newLayout = mainTextView.getLayout();
+                    if (newLayout == null) return;
+
+                    TextEditorActivityViewModel.Direction direction;
+                    // Infer direction from old scroll position
+                    int viewportHeight = scrollView.getHeight();
+                    if (oldScrollY > viewportHeight / 2) {
+                      // Was scrolling down → new content has overlap at the top → scroll to top
+                      // area
+                      // The overlap is ~50% of the window, so position at roughly 25% down
+                      int targetLine = newLayout.getLineCount() / 4;
+                      int targetY = newLayout.getLineTop(targetLine);
+                      scrollView.scrollTo(0, targetY);
+                    } else {
+                      // Was scrolling up → new content has overlap at the bottom → scroll to bottom
+                      // area
+                      int targetLine = (newLayout.getLineCount() * 3) / 4;
+                      int targetY = newLayout.getLineTop(targetLine);
+                      scrollView.scrollTo(0, Math.max(0, targetY - viewportHeight));
+                    }
+
+                    invalidateOptionsMenu();
+                  });
+            });
+  }
+
+  /**
+   * Called by ReadTextFileTask after initializing windowed mode. Sets up a scroll listener that
+   * triggers window loads when the user scrolls near the top or bottom edge.
+   */
+  public void initWindowedScrollListener() {
+    if (windowedScrollListener != null) return; // already initialized
+
+    windowedScrollListener =
+        () -> {
+          if (!viewModel.isWindowed()) return;
+
+          int scrollY = scrollView.getScrollY();
+          int viewportHeight = scrollView.getHeight();
+          int contentHeight = mainTextView.getHeight();
+
+          if (contentHeight <= 0 || viewportHeight <= 0) return;
+
+          // Threshold: 20% of viewport
+          int threshold = viewportHeight / 5;
+
+          int distanceFromBottom = contentHeight - scrollY - viewportHeight;
+          int distanceFromTop = scrollY;
+
+          if (distanceFromBottom < threshold) {
+            viewModel.loadWindow(TextEditorActivityViewModel.Direction.FORWARD);
+          } else if (distanceFromTop < threshold) {
+            viewModel.loadWindow(TextEditorActivityViewModel.Direction.BACKWARD);
+          }
+        };
+
+    scrollView.getViewTreeObserver().addOnScrollChangedListener(windowedScrollListener);
   }
 }

--- a/app/src/main/java/com/amaze/filemanager/ui/activities/texteditor/TextEditorActivity.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/activities/texteditor/TextEditorActivity.java
@@ -66,6 +66,7 @@ import android.view.animation.Animation;
 import android.view.animation.AnimationUtils;
 import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputMethodManager;
+import android.webkit.WebView;
 import android.widget.ScrollView;
 import android.widget.Toast;
 
@@ -86,12 +87,14 @@ public class TextEditorActivity extends ThemedActivity
   private Typeface inputTypefaceMono;
   private androidx.appcompat.widget.Toolbar toolbar;
   ScrollView scrollView;
+  private WebView markdownWebView;
 
   private SearchTextTask searchTextTask;
   private static final String KEY_MODIFIED_TEXT = "modified";
   private static final String KEY_INDEX = "index";
   private static final String KEY_ORIGINAL_TEXT = "original";
   private static final String KEY_MONOFONT = "monofont";
+  private static final String KEY_MARKDOWN_PREVIEW = "markdown_preview";
 
   private ConstraintLayout searchViewLayout;
   public AppCompatImageButton upButton;
@@ -134,6 +137,8 @@ public class TextEditorActivity extends ThemedActivity
     }
     mainTextView = findViewById(R.id.textEditorMainEditText);
     scrollView = findViewById(R.id.textEditorScrollView);
+    markdownWebView = findViewById(R.id.textEditorMarkdownWebView);
+    markdownWebView.getSettings().setJavaScriptEnabled(false);
 
     final Uri uri = getIntent().getData();
     if (uri != null) {
@@ -178,6 +183,11 @@ public class TextEditorActivity extends ThemedActivity
       if (savedInstanceState.getBoolean(KEY_MONOFONT)) {
         mainTextView.setTypeface(inputTypefaceMono);
       }
+      // Restore markdown preview state
+      if (savedInstanceState.getBoolean(KEY_MARKDOWN_PREVIEW, false)) {
+        viewModel.setMarkdownPreviewEnabled(true);
+        toggleMarkdownPreview(true);
+      }
       // Restore windowed mode state after rotation
       if (viewModel.isWindowed()) {
         setReadOnly();
@@ -203,6 +213,7 @@ public class TextEditorActivity extends ThemedActivity
     outState.putInt(KEY_INDEX, mainTextView.getScrollY());
     outState.putString(KEY_ORIGINAL_TEXT, viewModel.getOriginal());
     outState.putBoolean(KEY_MONOFONT, inputTypefaceMono.equals(mainTextView.getTypeface()));
+    outState.putBoolean(KEY_MARKDOWN_PREVIEW, viewModel.getMarkdownPreviewEnabled());
   }
 
   private void checkUnsavedChanges() {
@@ -309,6 +320,11 @@ public class TextEditorActivity extends ThemedActivity
     // Hide search in windowed mode (search only works on in-memory text)
     menu.findItem(R.id.find).setVisible(!windowed);
 
+    // Show markdown preview item only for .md/.markdown files
+    MenuItem markdownItem = menu.findItem(R.id.markdown_preview);
+    markdownItem.setVisible(isMarkdownFile());
+    markdownItem.setChecked(viewModel.getMarkdownPreviewEnabled());
+
     menu.findItem(R.id.monofont).setChecked(inputTypefaceMono.equals(mainTextView.getTypeface()));
     return super.onPrepareOptionsMenu(menu);
   }
@@ -362,6 +378,11 @@ public class TextEditorActivity extends ThemedActivity
     } else if (item.getItemId() == R.id.monofont) {
       item.setChecked(!item.isChecked());
       mainTextView.setTypeface(item.isChecked() ? inputTypefaceMono : inputTypefaceDefault);
+    } else if (item.getItemId() == R.id.markdown_preview) {
+      boolean newState = !item.isChecked();
+      item.setChecked(newState);
+      viewModel.setMarkdownPreviewEnabled(newState);
+      toggleMarkdownPreview(newState);
     } else {
       return false;
     }
@@ -661,7 +682,6 @@ public class TextEditorActivity extends ThemedActivity
 
               // Determine an anchor: find the text line near the middle of the current viewport
               int oldScrollY = scrollView.getScrollY();
-              Layout oldLayout = mainTextView.getLayout();
 
               // Replace text (TextWatcher will fire but windowed-mode guard skips modification
               // tracking)
@@ -673,7 +693,6 @@ public class TextEditorActivity extends ThemedActivity
                     Layout newLayout = mainTextView.getLayout();
                     if (newLayout == null) return;
 
-                    TextEditorActivityViewModel.Direction direction;
                     // Infer direction from old scroll position
                     int viewportHeight = scrollView.getHeight();
                     if (oldScrollY > viewportHeight / 2) {
@@ -727,5 +746,47 @@ public class TextEditorActivity extends ThemedActivity
         };
 
     scrollView.getViewTreeObserver().addOnScrollChangedListener(windowedScrollListener);
+  }
+
+  // ── Markdown Preview Helpers ────────────────────────────────────────
+
+  /** Returns true if the currently opened file has a Markdown extension (.md or .markdown). */
+  private boolean isMarkdownFile() {
+    EditableFileAbstraction file = viewModel.getFile();
+    if (file == null) return false;
+    return MarkdownHtmlGenerator.isMarkdownFile(file.name);
+  }
+
+  /**
+   * Toggle between Markdown preview (WebView) and the normal EditText editor.
+   *
+   * @param enabled true to show the WebView with rendered Markdown; false to show EditText
+   */
+  private void toggleMarkdownPreview(boolean enabled) {
+    if (enabled) {
+      renderMarkdownToWebView();
+      scrollView.setVisibility(View.GONE);
+      markdownWebView.setVisibility(View.VISIBLE);
+    } else {
+      markdownWebView.setVisibility(View.GONE);
+      scrollView.setVisibility(View.VISIBLE);
+    }
+    invalidateOptionsMenu();
+  }
+
+  /**
+   * Parse the current EditText content as Markdown using commonmark, render to HTML, and load it
+   * into the WebView.
+   */
+  private void renderMarkdownToWebView() {
+    String markdownSource = "";
+    if (mainTextView.getText() != null) {
+      markdownSource = mainTextView.getText().toString();
+    }
+
+    String bodyHtml = MarkdownHtmlGenerator.renderToHtml(markdownSource);
+    boolean isDark = getAppTheme().equals(AppTheme.DARK) || getAppTheme().equals(AppTheme.BLACK);
+    String fullHtml = MarkdownHtmlGenerator.wrapWithBaseHtml(bodyHtml, isDark);
+    markdownWebView.loadDataWithBaseURL(null, fullHtml, "text/html", "UTF-8", null);
   }
 }

--- a/app/src/main/java/com/amaze/filemanager/ui/activities/texteditor/TextEditorActivity.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/activities/texteditor/TextEditorActivity.java
@@ -53,6 +53,7 @@ import android.content.Context;
 import android.graphics.Typeface;
 import android.net.Uri;
 import android.os.Bundle;
+import android.os.SystemClock;
 import android.text.Editable;
 import android.text.Layout;
 import android.text.Spanned;
@@ -106,6 +107,22 @@ public class TextEditorActivity extends ThemedActivity
 
   /** Scroll listener reference for windowed mode (so it can be removed if needed). */
   private ViewTreeObserver.OnScrollChangedListener windowedScrollListener;
+
+  /** Pre-draw listener used to position a freshly loaded window before it is first drawn. */
+  private ViewTreeObserver.OnPreDrawListener pendingWindowApplyPreDrawListener;
+
+  /** True while replacing window content and restoring scroll programmatically. */
+  private boolean isApplyingWindowContent;
+
+  /** Suppress edge-triggered loads briefly after programmatic scroll changes. */
+  private long suppressWindowLoadsUntilMs;
+
+  /**
+   * Duration (ms) to suppress edge-triggered window loads after a programmatic scroll change. Must
+   * be long enough to cover the layout pass after setText() + the scroll restoration; 400ms is a
+   * safe margin on most devices.
+   */
+  private static final long WINDOW_LOAD_SUPPRESSION_MS = 400L;
 
   @Override
   public void onCreate(Bundle savedInstanceState) {
@@ -391,6 +408,7 @@ public class TextEditorActivity extends ThemedActivity
 
   @Override
   public void onDestroy() {
+    clearPendingWindowApplyPreDrawListener();
     super.onDestroy();
     final TextEditorActivityViewModel viewModel =
         new ViewModelProvider(this).get(TextEditorActivityViewModel.class);
@@ -680,39 +698,155 @@ public class TextEditorActivity extends ThemedActivity
             result -> {
               if (result == null) return;
 
-              // Determine an anchor: find the text line near the middle of the current viewport
+              // Capture the currently visible text as an anchor before replacing content
+              String anchorText = null;
               int oldScrollY = scrollView.getScrollY();
+              int viewportHeight = scrollView.getHeight();
+
+              Layout oldLayout = mainTextView.getLayout();
+              if (oldLayout != null && mainTextView.getText() != null) {
+                // Find the line at the middle of the viewport
+                int anchorY = oldScrollY + viewportHeight / 2;
+                int anchorLine = oldLayout.getLineForVertical(anchorY);
+
+                if (anchorLine >= 0 && anchorLine < oldLayout.getLineCount()) {
+                  int lineStart = oldLayout.getLineStart(anchorLine);
+                  int lineEnd = oldLayout.getLineEnd(anchorLine);
+                  if (lineStart < lineEnd && lineEnd <= mainTextView.getText().length()) {
+                    // Get a distinctive snippet (up to 80 chars) from this line
+                    int snippetEnd = Math.min(lineEnd, lineStart + 80);
+                    anchorText =
+                        mainTextView.getText().subSequence(lineStart, snippetEnd).toString();
+                  }
+                }
+              }
 
               // Replace text (TextWatcher will fire but windowed-mode guard skips modification
               // tracking)
+              final String savedAnchorText = anchorText;
+              final TextEditorActivityViewModel.Direction lastDirection =
+                  viewModel.getLastLoadDirection();
+              isApplyingWindowContent = true;
+              suppressWindowLoadsUntilMs = SystemClock.uptimeMillis() + WINDOW_LOAD_SUPPRESSION_MS;
+              clearPendingWindowApplyPreDrawListener();
               mainTextView.setText(result.getText());
 
-              // Adjust scroll position for visual continuity
-              mainTextView.post(
+              pendingWindowApplyPreDrawListener =
                   () -> {
                     Layout newLayout = mainTextView.getLayout();
-                    if (newLayout == null) return;
-
-                    // Infer direction from old scroll position
-                    int viewportHeight = scrollView.getHeight();
-                    if (oldScrollY > viewportHeight / 2) {
-                      // Was scrolling down → new content has overlap at the top → scroll to top
-                      // area
-                      // The overlap is ~50% of the window, so position at roughly 25% down
-                      int targetLine = newLayout.getLineCount() / 4;
-                      int targetY = newLayout.getLineTop(targetLine);
-                      scrollView.scrollTo(0, targetY);
-                    } else {
-                      // Was scrolling up → new content has overlap at the bottom → scroll to bottom
-                      // area
-                      int targetLine = (newLayout.getLineCount() * 3) / 4;
-                      int targetY = newLayout.getLineTop(targetLine);
-                      scrollView.scrollTo(0, Math.max(0, targetY - viewportHeight));
+                    if (newLayout == null) {
+                      return true; // layout not ready yet, let the draw pass proceed
                     }
 
+                    int targetY =
+                        resolveWindowedTargetScrollY(
+                            newLayout, savedAnchorText, viewportHeight, lastDirection);
+
+                    suppressWindowLoadsUntilMs =
+                        SystemClock.uptimeMillis() + WINDOW_LOAD_SUPPRESSION_MS;
+                    scrollView.scrollTo(0, targetY);
+                    clearPendingWindowApplyPreDrawListener();
+                    scrollView.post(() -> isApplyingWindowContent = false);
                     invalidateOptionsMenu();
-                  });
+                    return true; // proceed with this draw pass using the corrected scroll
+                  };
+
+              ViewTreeObserver observer = scrollView.getViewTreeObserver();
+              if (observer.isAlive()) {
+                observer.addOnPreDrawListener(pendingWindowApplyPreDrawListener);
+              } else {
+                isApplyingWindowContent = false;
+              }
             });
+  }
+
+  private void clearPendingWindowApplyPreDrawListener() {
+    if (pendingWindowApplyPreDrawListener == null) return;
+
+    ViewTreeObserver observer = scrollView.getViewTreeObserver();
+    if (observer.isAlive()) {
+      observer.removeOnPreDrawListener(pendingWindowApplyPreDrawListener);
+    }
+    pendingWindowApplyPreDrawListener = null;
+  }
+
+  private int resolveWindowedTargetScrollY(
+      Layout newLayout,
+      String savedAnchorText,
+      int viewportHeight,
+      TextEditorActivityViewModel.Direction lastDirection) {
+    if (savedAnchorText != null && mainTextView.getText() != null) {
+      String newText = mainTextView.getText().toString();
+      int anchorIndex = findAnchorNearExpectedPosition(newText, savedAnchorText, lastDirection);
+
+      if (anchorIndex >= 0) {
+        int anchorLine = newLayout.getLineForOffset(anchorIndex);
+        int anchorLineTop = newLayout.getLineTop(anchorLine);
+        return Math.max(0, anchorLineTop - viewportHeight / 2);
+      }
+    }
+
+    return inferScrollPositionFallback(newLayout, viewportHeight, lastDirection);
+  }
+
+  /**
+   * Find the anchor text in the new content, preferring the occurrence closest to where it is
+   * expected given the load direction and 60% overlap.
+   *
+   * <p>For a FORWARD load the old viewport-center content should end up in roughly the first 30–40%
+   * of the new window (because 60% overlaps). For a BACKWARD load it should be in the last 30–40%.
+   * We estimate an expected char offset and pick the occurrence nearest to it.
+   *
+   * <p>This avoids the problem with naive {@code indexOf}/{@code lastIndexOf} picking a wrong
+   * duplicate occurrence in files with many repeated lines (e.g. log files).
+   */
+  private static int findAnchorNearExpectedPosition(
+      String newText, String anchor, TextEditorActivityViewModel.Direction direction) {
+    if (newText.isEmpty() || anchor.isEmpty()) return -1;
+
+    // Estimate where in the new text the anchor should be
+    int expectedPos;
+    if (direction == TextEditorActivityViewModel.Direction.FORWARD) {
+      // After a 40% forward shift with 60% overlap, the old viewport center
+      // (≈50% of old window) maps to ≈ (50%-40%) / (100%) ≈ first 10-30% of new window
+      expectedPos = (int) (newText.length() * 0.20);
+    } else {
+      // After a 40% backward shift, the old viewport center maps to ≈ last 70-80%
+      expectedPos = (int) (newText.length() * 0.80);
+    }
+
+    int bestIndex = -1;
+    int bestDistance = Integer.MAX_VALUE;
+    int searchFrom = 0;
+
+    while (searchFrom <= newText.length() - anchor.length()) {
+      int idx = newText.indexOf(anchor, searchFrom);
+      if (idx < 0) break;
+
+      int distance = Math.abs(idx - expectedPos);
+      if (distance < bestDistance) {
+        bestDistance = distance;
+        bestIndex = idx;
+      }
+      searchFrom = idx + 1;
+    }
+
+    return bestIndex;
+  }
+
+  /**
+   * Fallback method when anchor text is not found. Keep the viewport in the middle band so edge
+   * thresholds do not immediately trigger another opposite-direction window load.
+   */
+  private int inferScrollPositionFallback(
+      Layout newLayout, int viewportHeight, TextEditorActivityViewModel.Direction direction) {
+    int targetLine = newLayout.getLineCount() / 2;
+    if (direction == TextEditorActivityViewModel.Direction.BACKWARD) {
+      targetLine = (newLayout.getLineCount() * 55) / 100;
+    } else if (direction == TextEditorActivityViewModel.Direction.FORWARD) {
+      targetLine = (newLayout.getLineCount() * 45) / 100;
+    }
+    return Math.max(0, newLayout.getLineTop(targetLine) - viewportHeight / 2);
   }
 
   /**
@@ -725,6 +859,8 @@ public class TextEditorActivity extends ThemedActivity
     windowedScrollListener =
         () -> {
           if (!viewModel.isWindowed()) return;
+          if (isApplyingWindowContent) return;
+          if (SystemClock.uptimeMillis() < suppressWindowLoadsUntilMs) return;
 
           int scrollY = scrollView.getScrollY();
           int viewportHeight = scrollView.getHeight();

--- a/app/src/main/java/com/amaze/filemanager/ui/activities/texteditor/TextEditorActivity.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/activities/texteditor/TextEditorActivity.java
@@ -68,6 +68,7 @@ import android.view.animation.AnimationUtils;
 import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputMethodManager;
 import android.webkit.WebView;
+import android.widget.ProgressBar;
 import android.widget.ScrollView;
 import android.widget.Toast;
 
@@ -89,6 +90,7 @@ public class TextEditorActivity extends ThemedActivity
   private androidx.appcompat.widget.Toolbar toolbar;
   ScrollView scrollView;
   private WebView markdownWebView;
+  private ProgressBar windowLoadingIndicator;
 
   private SearchTextTask searchTextTask;
   private static final String KEY_MODIFIED_TEXT = "modified";
@@ -156,6 +158,7 @@ public class TextEditorActivity extends ThemedActivity
     scrollView = findViewById(R.id.textEditorScrollView);
     markdownWebView = findViewById(R.id.textEditorMarkdownWebView);
     markdownWebView.getSettings().setJavaScriptEnabled(false);
+    windowLoadingIndicator = findViewById(R.id.textEditorWindowLoadingIndicator);
 
     final Uri uri = getIntent().getData();
     if (uri != null) {
@@ -217,6 +220,7 @@ public class TextEditorActivity extends ThemedActivity
 
     // Observe windowed-mode LiveData for new window content
     observeWindowContent();
+    observeWindowLoadingIndicator();
   }
 
   @Override
@@ -289,8 +293,12 @@ public class TextEditorActivity extends ThemedActivity
   private static void load(final TextEditorActivity activity) {
     activity.dismissLoadingSnackbar();
 
+    // Use LENGTH_INDEFINITE (dismissed manually via dismissLoadingSnackbar()) rather than
+    // LENGTH_SHORT: for large files the read can legitimately take several seconds, and a
+    // LENGTH_SHORT snackbar would disappear long before loading actually finishes, making the
+    // app look like it's stuck/unresponsive.
     activity.loadingSnackbar =
-        Snackbar.make(activity.scrollView, R.string.loading, Snackbar.LENGTH_SHORT);
+        Snackbar.make(activity.scrollView, R.string.loading, Snackbar.LENGTH_INDEFINITE);
     activity.loadingSnackbar.show();
 
     final WeakReference<TextEditorActivity> textEditorActivityWR = new WeakReference<>(activity);
@@ -354,11 +362,13 @@ public class TextEditorActivity extends ThemedActivity
 
     if (item.getItemId() == android.R.id.home) {
       checkUnsavedChanges();
+      return true;
     } else if (item.getItemId() == R.id.save) {
       // Make sure EditText is visible before saving!
       if (mainTextView.getText() != null) {
         saveFile(this, mainTextView.getText().toString());
       }
+      return true;
     } else if (item.getItemId() == R.id.details) {
       if (editableFileAbstraction.scheme.equals(FILE)
           && editableFileAbstraction.hybridFileParcelable.getFile() != null
@@ -377,6 +387,7 @@ public class TextEditorActivity extends ThemedActivity
       } else {
         Toast.makeText(this, R.string.no_obtainable_info, Toast.LENGTH_SHORT).show();
       }
+      return true;
     } else if (item.getItemId() == R.id.openwith) {
       if (editableFileAbstraction != null && editableFileAbstraction.scheme.equals(FILE)) {
         File currentFile = editableFileAbstraction.hybridFileParcelable.getFile();
@@ -389,19 +400,26 @@ public class TextEditorActivity extends ThemedActivity
       } else {
         Toast.makeText(this, R.string.reopen_from_source, Toast.LENGTH_SHORT).show();
       }
+      return true;
     } else if (item.getItemId() == R.id.find) {
       if (searchViewLayout.isShown()) hideSearchView();
       else revealSearchView();
+      return true;
     } else if (item.getItemId() == R.id.monofont) {
+      // NOTE: for a checkable menu item, the Android framework itself toggles the item's
+      // checked state right after this callback returns *if this method returns false*
+      // (i.e. the event is considered unhandled). Returning true here is required, otherwise
+      // the checked flag gets silently flipped back by the framework and the font can never
+      // be switched back to the default (see PR #4576 review feedback).
       item.setChecked(!item.isChecked());
       mainTextView.setTypeface(item.isChecked() ? inputTypefaceMono : inputTypefaceDefault);
+      return true;
     } else if (item.getItemId() == R.id.markdown_preview) {
       boolean newState = !item.isChecked();
       item.setChecked(newState);
       viewModel.setMarkdownPreviewEnabled(newState);
       toggleMarkdownPreview(newState);
-    } else {
-      return false;
+      return true;
     }
     return super.onOptionsItemSelected(item);
   }
@@ -687,6 +705,25 @@ public class TextEditorActivity extends ThemedActivity
   // ── Sliding Window Helpers ──────────────────────────────────────────
 
   /**
+   * Observe the ViewModel's isLoadingWindow LiveData to show/hide a small progress indicator
+   * whenever a window (initial chunk or a subsequent forward/backward slide) is being read from
+   * disk. Without this, large/slow reads (e.g. root-cached files, content providers, or simply big
+   * files) can appear as if the app has frozen.
+   */
+  private void observeWindowLoadingIndicator() {
+    viewModel
+        .isLoadingWindow()
+        .observe(
+            this,
+            loading -> {
+              if (windowLoadingIndicator != null) {
+                windowLoadingIndicator.setVisibility(
+                    Boolean.TRUE.equals(loading) ? View.VISIBLE : View.GONE);
+              }
+            });
+  }
+
+  /**
    * Observe the ViewModel's windowContent LiveData. When a new window is loaded, replace the
    * EditText content and adjust the scroll position for visual continuity.
    */
@@ -698,10 +735,15 @@ public class TextEditorActivity extends ThemedActivity
             result -> {
               if (result == null) return;
 
-              // Capture the currently visible text as an anchor before replacing content
-              String anchorText = null;
+              // Capture the scroll anchor as an absolute byte offset in the file (rather than a
+              // text snippet). This is both correct and fast: a text-snippet search
+              // (indexOf-based) is ambiguous for repetitive content (e.g. sequential numbers,
+              // log files) and can degrade to O(n * matches) on the main thread for large
+              // windows, causing visible jumps and ANRs on large files.
               int oldScrollY = scrollView.getScrollY();
               int viewportHeight = scrollView.getHeight();
+
+              long anchorAbsoluteByte = -1L;
 
               Layout oldLayout = mainTextView.getLayout();
               if (oldLayout != null && mainTextView.getText() != null) {
@@ -711,19 +753,20 @@ public class TextEditorActivity extends ThemedActivity
 
                 if (anchorLine >= 0 && anchorLine < oldLayout.getLineCount()) {
                   int lineStart = oldLayout.getLineStart(anchorLine);
-                  int lineEnd = oldLayout.getLineEnd(anchorLine);
-                  if (lineStart < lineEnd && lineEnd <= mainTextView.getText().length()) {
-                    // Get a distinctive snippet (up to 80 chars) from this line
-                    int snippetEnd = Math.min(lineEnd, lineStart + 80);
-                    anchorText =
-                        mainTextView.getText().subSequence(lineStart, snippetEnd).toString();
+                  String oldText = mainTextView.getText().toString();
+                  if (lineStart <= oldText.length()) {
+                    long byteOffsetInOldWindow = byteOffsetForCharIndex(oldText, lineStart);
+                    anchorAbsoluteByte =
+                        viewModel.getPreviousWindowStartByte() + byteOffsetInOldWindow;
                   }
                 }
               }
 
               // Replace text (TextWatcher will fire but windowed-mode guard skips modification
               // tracking)
-              final String savedAnchorText = anchorText;
+              final long finalAnchorAbsoluteByte = anchorAbsoluteByte;
+              final long newStartByte = result.getStartByte();
+              final long newEndByte = result.getEndByte();
               final TextEditorActivityViewModel.Direction lastDirection =
                   viewModel.getLastLoadDirection();
               isApplyingWindowContent = true;
@@ -740,7 +783,12 @@ public class TextEditorActivity extends ThemedActivity
 
                     int targetY =
                         resolveWindowedTargetScrollY(
-                            newLayout, savedAnchorText, viewportHeight, lastDirection);
+                            newLayout,
+                            finalAnchorAbsoluteByte,
+                            newStartByte,
+                            newEndByte,
+                            viewportHeight,
+                            lastDirection);
 
                     suppressWindowLoadsUntilMs =
                         SystemClock.uptimeMillis() + WINDOW_LOAD_SUPPRESSION_MS;
@@ -772,71 +820,80 @@ public class TextEditorActivity extends ThemedActivity
 
   private int resolveWindowedTargetScrollY(
       Layout newLayout,
-      String savedAnchorText,
+      long anchorAbsoluteByte,
+      long newStartByte,
+      long newEndByte,
       int viewportHeight,
       TextEditorActivityViewModel.Direction lastDirection) {
-    if (savedAnchorText != null && mainTextView.getText() != null) {
+    if (anchorAbsoluteByte >= newStartByte
+        && anchorAbsoluteByte <= newEndByte
+        && mainTextView.getText() != null) {
       String newText = mainTextView.getText().toString();
-      int anchorIndex = findAnchorNearExpectedPosition(newText, savedAnchorText, lastDirection);
-
-      if (anchorIndex >= 0) {
-        int anchorLine = newLayout.getLineForOffset(anchorIndex);
-        int anchorLineTop = newLayout.getLineTop(anchorLine);
-        return Math.max(0, anchorLineTop - viewportHeight / 2);
-      }
+      long relativeByteOffset = anchorAbsoluteByte - newStartByte;
+      int anchorIndex = charIndexForByteOffset(newText, relativeByteOffset);
+      anchorIndex = Math.min(anchorIndex, newText.length());
+      int anchorLine = newLayout.getLineForOffset(anchorIndex);
+      int anchorLineTop = newLayout.getLineTop(anchorLine);
+      return Math.max(0, anchorLineTop - viewportHeight / 2);
     }
 
     return inferScrollPositionFallback(newLayout, viewportHeight, lastDirection);
   }
 
   /**
-   * Find the anchor text in the new content, preferring the occurrence closest to where it is
-   * expected given the load direction and 60% overlap.
-   *
-   * <p>For a FORWARD load the old viewport-center content should end up in roughly the first 30–40%
-   * of the new window (because 60% overlaps). For a BACKWARD load it should be in the last 30–40%.
-   * We estimate an expected char offset and pick the occurrence nearest to it.
-   *
-   * <p>This avoids the problem with naive {@code indexOf}/{@code lastIndexOf} picking a wrong
-   * duplicate occurrence in files with many repeated lines (e.g. log files).
+   * Counts the number of UTF-8 bytes needed to encode the first {@code charIndex} chars of {@code
+   * text}. Runs in O(charIndex) without allocating a byte array.
    */
-  private static int findAnchorNearExpectedPosition(
-      String newText, String anchor, TextEditorActivityViewModel.Direction direction) {
-    if (newText.isEmpty() || anchor.isEmpty()) return -1;
-
-    // Estimate where in the new text the anchor should be
-    int expectedPos;
-    if (direction == TextEditorActivityViewModel.Direction.FORWARD) {
-      // After a 40% forward shift with 60% overlap, the old viewport center
-      // (≈50% of old window) maps to ≈ (50%-40%) / (100%) ≈ first 10-30% of new window
-      expectedPos = (int) (newText.length() * 0.20);
-    } else {
-      // After a 40% backward shift, the old viewport center maps to ≈ last 70-80%
-      expectedPos = (int) (newText.length() * 0.80);
+  private static long byteOffsetForCharIndex(String text, int charIndex) {
+    long byteCount = 0;
+    int limit = Math.min(charIndex, text.length());
+    int i = 0;
+    while (i < limit) {
+      int codePoint = text.codePointAt(i);
+      byteCount += utf8ByteLength(codePoint);
+      i += Character.charCount(codePoint);
     }
-
-    int bestIndex = -1;
-    int bestDistance = Integer.MAX_VALUE;
-    int searchFrom = 0;
-
-    while (searchFrom <= newText.length() - anchor.length()) {
-      int idx = newText.indexOf(anchor, searchFrom);
-      if (idx < 0) break;
-
-      int distance = Math.abs(idx - expectedPos);
-      if (distance < bestDistance) {
-        bestDistance = distance;
-        bestIndex = idx;
-      }
-      searchFrom = idx + 1;
-    }
-
-    return bestIndex;
+    return byteCount;
   }
 
   /**
-   * Fallback method when anchor text is not found. Keep the viewport in the middle band so edge
-   * thresholds do not immediately trigger another opposite-direction window load.
+   * Finds the char index in {@code text} whose UTF-8 byte offset is closest to (but not past)
+   * {@code targetByteOffset}. Runs in O(text.length()) without allocating a byte array.
+   */
+  private static int charIndexForByteOffset(String text, long targetByteOffset) {
+    if (targetByteOffset <= 0) return 0;
+
+    long byteCount = 0;
+    int i = 0;
+    int length = text.length();
+    while (i < length) {
+      int codePoint = text.codePointAt(i);
+      long byteLen = utf8ByteLength(codePoint);
+      if (byteCount + byteLen > targetByteOffset) {
+        return i;
+      }
+      byteCount += byteLen;
+      i += Character.charCount(codePoint);
+    }
+    return length;
+  }
+
+  private static int utf8ByteLength(int codePoint) {
+    if (codePoint <= 0x7F) {
+      return 1;
+    } else if (codePoint <= 0x7FF) {
+      return 2;
+    } else if (codePoint <= 0xFFFF) {
+      return 3;
+    } else {
+      return 4;
+    }
+  }
+
+  /**
+   * Fallback method when the anchor byte offset falls outside the newly loaded window (should be
+   * rare). Keep the viewport in the middle band so edge thresholds do not immediately trigger
+   * another opposite-direction window load.
    */
   private int inferScrollPositionFallback(
       Layout newLayout, int viewportHeight, TextEditorActivityViewModel.Direction direction) {

--- a/app/src/main/java/com/amaze/filemanager/ui/activities/texteditor/TextEditorActivityViewModel.kt
+++ b/app/src/main/java/com/amaze/filemanager/ui/activities/texteditor/TextEditorActivityViewModel.kt
@@ -66,6 +66,11 @@ class TextEditorActivityViewModel : ViewModel() {
 
     var file: EditableFileAbstraction? = null
 
+    // ── Markdown preview state ────────────────────────────────────────
+
+    /** Whether Markdown preview mode is currently enabled. */
+    var markdownPreviewEnabled = false
+
     // ── Sliding window state ──────────────────────────────────────────
 
     /** Whether the editor is in windowed (read-only) mode for large files. */

--- a/app/src/main/java/com/amaze/filemanager/ui/activities/texteditor/TextEditorActivityViewModel.kt
+++ b/app/src/main/java/com/amaze/filemanager/ui/activities/texteditor/TextEditorActivityViewModel.kt
@@ -85,6 +85,15 @@ class TextEditorActivityViewModel : ViewModel() {
     /** Byte offset just past the end of the currently displayed window. */
     var windowEndByte: Long = 0L
 
+    /**
+     * Byte offset of the start of the window that was displayed *before* the most recently
+     * loaded window. Used by the Activity to translate a scroll anchor position (captured while
+     * the previous window's text was still on screen) into an absolute byte offset in the file,
+     * so the new window's scroll position can be resolved precisely without doing an expensive
+     * (and ambiguous, for repetitive content) text search.
+     */
+    var previousWindowStartByte: Long = 0L
+
     /** Total file size in bytes. */
     var totalFileSize: Long = 0L
 
@@ -95,6 +104,14 @@ class TextEditorActivityViewModel : ViewModel() {
 
     /** Observed by the Activity to update the EditText when a new window is loaded. */
     val windowContent: LiveData<FileWindowReader.WindowResult> = _windowContent
+
+    private val _isLoadingWindow = MutableLiveData(false)
+
+    /**
+     * Observed by the Activity to show/hide a progress indicator while a window (initial or
+     * subsequent) is being loaded from disk.
+     */
+    val isLoadingWindow: LiveData<Boolean> = _isLoadingWindow
 
     private var windowLoadJob: Job? = null
 
@@ -133,16 +150,24 @@ class TextEditorActivityViewModel : ViewModel() {
                 }
             }
 
+        val startOfCurrentWindow = windowStartByte
+
         windowLoadJob =
             viewModelScope.launch {
-                val result =
-                    withContext(ioDispatcher) {
-                        reader.readWindow(targetOffset, ReadTextFileCallable.MAX_FILE_SIZE_CHARS)
-                    }
-                windowStartByte = result.startByte
-                windowEndByte = result.endByte
-                lastLoadDirection = direction
-                _windowContent.value = result
+                _isLoadingWindow.value = true
+                try {
+                    val result =
+                        withContext(ioDispatcher) {
+                            reader.readWindow(targetOffset, ReadTextFileCallable.MAX_FILE_SIZE_CHARS)
+                        }
+                    previousWindowStartByte = startOfCurrentWindow
+                    windowStartByte = result.startByte
+                    windowEndByte = result.endByte
+                    lastLoadDirection = direction
+                    _windowContent.value = result
+                } finally {
+                    _isLoadingWindow.value = false
+                }
             }
     }
 

--- a/app/src/main/java/com/amaze/filemanager/ui/activities/texteditor/TextEditorActivityViewModel.kt
+++ b/app/src/main/java/com/amaze/filemanager/ui/activities/texteditor/TextEditorActivityViewModel.kt
@@ -20,8 +20,18 @@
 
 package com.amaze.filemanager.ui.activities.texteditor
 
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.amaze.filemanager.asynchronous.asynctasks.texteditor.read.FileWindowReader
+import com.amaze.filemanager.asynchronous.asynctasks.texteditor.read.ReadTextFileCallable
 import com.amaze.filemanager.filesystem.EditableFileAbstraction
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import java.io.File
 import java.util.Timer
 
@@ -55,4 +65,79 @@ class TextEditorActivityViewModel : ViewModel() {
     var timer: Timer? = null
 
     var file: EditableFileAbstraction? = null
+
+    // ── Sliding window state ──────────────────────────────────────────
+
+    /** Whether the editor is in windowed (read-only) mode for large files. */
+    var isWindowed = false
+
+    /** Seekable reader for the underlying file; lives in ViewModel to survive rotation. */
+    var fileWindowReader: FileWindowReader? = null
+
+    /** Byte offset of the start of the currently displayed window. */
+    var windowStartByte: Long = 0L
+
+    /** Byte offset just past the end of the currently displayed window. */
+    var windowEndByte: Long = 0L
+
+    /** Total file size in bytes. */
+    var totalFileSize: Long = 0L
+
+    /** Dispatcher for IO operations. Override in tests with a test dispatcher. */
+    var ioDispatcher: CoroutineDispatcher = Dispatchers.IO
+
+    private val _windowContent = MutableLiveData<FileWindowReader.WindowResult>()
+
+    /** Observed by the Activity to update the EditText when a new window is loaded. */
+    val windowContent: LiveData<FileWindowReader.WindowResult> = _windowContent
+
+    private var windowLoadJob: Job? = null
+
+    enum class Direction { FORWARD, BACKWARD }
+
+    /**
+     * Loads the next or previous window of text from the file.
+     * Debounced: if a load is already in flight, the call is ignored.
+     */
+    fun loadWindow(direction: Direction) {
+        if (windowLoadJob?.isActive == true) return // debounce
+        val reader = fileWindowReader ?: return
+
+        val windowSize = windowEndByte - windowStartByte
+        val halfWindow = windowSize / 2
+
+        val targetOffset =
+            when (direction) {
+                Direction.FORWARD -> {
+                    // Don't shift if already at end of file
+                    if (windowEndByte >= totalFileSize) return
+                    windowStartByte + halfWindow
+                }
+                Direction.BACKWARD -> {
+                    // Don't shift if already at start of file
+                    if (windowStartByte <= 0L) return
+                    maxOf(0L, windowStartByte - halfWindow)
+                }
+            }
+
+        windowLoadJob =
+            viewModelScope.launch {
+                val result =
+                    withContext(ioDispatcher) {
+                        reader.readWindow(targetOffset, ReadTextFileCallable.MAX_FILE_SIZE_CHARS)
+                    }
+                windowStartByte = result.startByte
+                windowEndByte = result.endByte
+                _windowContent.value = result
+            }
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        windowLoadJob?.cancel()
+        try {
+            fileWindowReader?.close()
+        } catch (_: Exception) {
+        }
+    }
 }

--- a/app/src/main/java/com/amaze/filemanager/ui/activities/texteditor/TextEditorActivityViewModel.kt
+++ b/app/src/main/java/com/amaze/filemanager/ui/activities/texteditor/TextEditorActivityViewModel.kt
@@ -100,28 +100,36 @@ class TextEditorActivityViewModel : ViewModel() {
 
     enum class Direction { FORWARD, BACKWARD }
 
+    /** Direction of the most recent successful window load. */
+    var lastLoadDirection: Direction? = null
+
     /**
      * Loads the next or previous window of text from the file.
      * Debounced: if a load is already in flight, the call is ignored.
+     *
+     * The method attempts to maintain ~60% overlap between consecutive windows to provide
+     * smooth scrolling. Due to line-boundary snapping, exact overlap cannot be guaranteed,
+     * but this provides better continuity than 50% overlap.
      */
     fun loadWindow(direction: Direction) {
         if (windowLoadJob?.isActive == true) return // debounce
         val reader = fileWindowReader ?: return
 
         val windowSize = windowEndByte - windowStartByte
-        val halfWindow = windowSize / 2
+        // Use 40% shift (60% overlap) for smoother transitions
+        val shiftAmount = (windowSize * 0.4).toLong()
 
         val targetOffset =
             when (direction) {
                 Direction.FORWARD -> {
                     // Don't shift if already at end of file
                     if (windowEndByte >= totalFileSize) return
-                    windowStartByte + halfWindow
+                    windowStartByte + shiftAmount
                 }
                 Direction.BACKWARD -> {
                     // Don't shift if already at start of file
                     if (windowStartByte <= 0L) return
-                    maxOf(0L, windowStartByte - halfWindow)
+                    maxOf(0L, windowStartByte - shiftAmount)
                 }
             }
 
@@ -133,6 +141,7 @@ class TextEditorActivityViewModel : ViewModel() {
                     }
                 windowStartByte = result.startByte
                 windowEndByte = result.endByte
+                lastLoadDirection = direction
                 _windowContent.value = result
             }
     }

--- a/app/src/main/res/layout/search.xml
+++ b/app/src/main/res/layout/search.xml
@@ -73,6 +73,16 @@
             android:layout_height="match_parent"
             android:visibility="gone" />
 
+        <ProgressBar
+            android:id="@+id/textEditorWindowLoadingIndicator"
+            style="?android:attr/progressBarStyleSmall"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="top|center_horizontal"
+            android:layout_marginTop="12dp"
+            android:visibility="gone"
+            tools:visibility="visible" />
+
     </FrameLayout>
 
 </androidx.appcompat.widget.LinearLayoutCompat>

--- a/app/src/main/res/layout/search.xml
+++ b/app/src/main/res/layout/search.xml
@@ -43,23 +43,36 @@
 
     </LinearLayout>
 
-    <ScrollView
-        android:id="@+id/textEditorScrollView"
+    <FrameLayout
+        android:id="@+id/textEditorContentFrame"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:fillViewport="true">
+        android:layout_height="match_parent">
 
-        <androidx.appcompat.widget.AppCompatEditText
-            android:id="@+id/textEditorMainEditText"
+        <ScrollView
+            android:id="@+id/textEditorScrollView"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:fontFamily="sans-serif-light"
-            android:gravity="start|top"
-            android:inputType="textCapSentences|textMultiLine"
-            android:lineSpacingExtra="1dp"
-            android:padding="16dp"
-            android:textSize="14sp" />
+            android:layout_height="match_parent"
+            android:fillViewport="true">
 
-    </ScrollView>
+            <androidx.appcompat.widget.AppCompatEditText
+                android:id="@+id/textEditorMainEditText"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:fontFamily="sans-serif-light"
+                android:gravity="start|top"
+                android:inputType="textCapSentences|textMultiLine"
+                android:lineSpacingExtra="1dp"
+                android:padding="16dp"
+                android:textSize="14sp" />
+
+        </ScrollView>
+
+        <WebView
+            android:id="@+id/textEditorMarkdownWebView"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:visibility="gone" />
+
+    </FrameLayout>
 
 </androidx.appcompat.widget.LinearLayoutCompat>

--- a/app/src/main/res/menu/text.xml
+++ b/app/src/main/res/menu/text.xml
@@ -42,4 +42,10 @@
         android:title="@string/monofont"
         android:checkable="true"
         app:showAsAction="never" />
+    <item
+        android:id="@+id/markdown_preview"
+        android:title="@string/markdown_preview"
+        android:checkable="true"
+        android:visible="false"
+        app:showAsAction="never" />
 </menu>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -479,6 +479,7 @@
     <string name="copy_low_memory">メモリ不足。メモリを解放してください</string>
     <string name="cloud_token_lost">トークンを失われた。もう一度サインインしてください。</string>
     <string name="monofont">等幅フォント</string>
+    <string name="markdown_preview">Markdown プレビュー</string>
     <string name="showHeaders">ヘッダーを表示する</string>
 	
 	<!--FROM HERE ON STRINGS ARE EXCLUSIVELY USED IN plurals.xml-->

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -479,6 +479,7 @@
     <string name="copy_low_memory">Не вистачає пам\'яті, будь ласка звільніть оперативну пам\'ять</string>
     <string name="cloud_token_lost">Token втрачено, будь ласка авторизуйтесь знову</string>
     <string name="monofont">Моноширинний шрифт</string>
+    <string name="markdown_preview">Попередній перегляд Markdown</string>
     <string name="showHeaders">Відображати заголовки</string>
 	
 	<!--FROM HERE ON STRINGS ARE EXCLUSIVELY USED IN plurals.xml-->

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -485,6 +485,7 @@
     <string name="copy_low_memory">運行記憶體不足，請清除一些背景處理程式</string>
     <string name="cloud_token_lost">權限遺失，請重新登入</string>
     <string name="monofont">等寬字型</string>
+    <string name="markdown_preview">Markdown 預覽</string>
     <string name="showHeaders">顯示標頭</string>
 	
 	<!--FROM HERE ON STRINGS ARE EXCLUSIVELY USED IN plurals.xml-->

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -485,6 +485,7 @@
     <string name="copy_low_memory">執行記憶體不足，請清除一些背景處理程式</string>
     <string name="cloud_token_lost">許可權遺失，請重新登入</string>
     <string name="monofont">等寬字型</string>
+    <string name="markdown_preview">Markdown 預覽</string>
     <string name="showHeaders">顯示標頭</string>
 	
 	<!--FROM HERE ON STRINGS ARE EXCLUSIVELY USED IN plurals.xml-->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -566,6 +566,7 @@
     <string name="copy_low_memory">Running out of memory, please clear some RAM</string>
     <string name="cloud_token_lost">Token lost, please sign-in again</string>
     <string name="monofont">Monospace Font</string>
+    <string name="markdown_preview">Markdown Preview</string>
     <string name="showHeaders">Show Headers</string>
 	
 	<!--FROM HERE ON STRINGS ARE EXCLUSIVELY USED IN plurals.xml-->

--- a/app/src/test/java/com/amaze/filemanager/asynchronous/asynctasks/texteditor/read/FileWindowReaderTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/asynchronous/asynctasks/texteditor/read/FileWindowReaderTest.kt
@@ -31,23 +31,25 @@ import java.io.File
 
 /**
  * Unit tests for [FileWindowReader].
- *
- * These are pure JVM tests (no Android/Robolectric needed) since FileWindowReader
- * only depends on java.io and java.nio classes.
  */
+@Suppress("StringLiteralDuplication")
 class FileWindowReaderTest {
     @get:Rule
     val tempFolder = TemporaryFolder()
 
     private lateinit var testFile: File
 
+    /**
+     * Pre-test setup
+     */
     @Before
     fun setUp() {
         testFile = tempFolder.newFile("test.txt")
     }
 
-    // ── Basic reading ────────────────────────────────────────────────
-
+    /**
+     * Test reading empty file.
+     */
     @Test
     fun testReadEmptyFile() {
         testFile.writeText("")
@@ -62,6 +64,9 @@ class FileWindowReaderTest {
         }
     }
 
+    /**
+     * Test reading file fitting the window.
+     */
     @Test
     fun testReadSmallFileFitsInWindow() {
         val content = "Hello, World!\nSecond line\nThird line\n"
@@ -76,6 +81,9 @@ class FileWindowReaderTest {
         }
     }
 
+    /**
+     * Test reading a file with a single line that has no newline at the end.
+     */
     @Test
     fun testReadSingleLineFile() {
         val content = "No newline at end"
@@ -89,6 +97,9 @@ class FileWindowReaderTest {
         }
     }
 
+    /**
+     * Test file size is correctly reported.
+     */
     @Test
     fun testFileSizeCorrect() {
         val content = "Hello"
@@ -99,8 +110,9 @@ class FileWindowReaderTest {
         }
     }
 
-    // ── Window limiting ──────────────────────────────────────────────
-
+    /**
+     * Test maxChars limits the output and snaps to line boundaries.
+     */
     @Test
     fun testMaxCharsLimitsOutput() {
         // Create content with multiple lines, each larger than 5 chars
@@ -117,6 +129,10 @@ class FileWindowReaderTest {
         }
     }
 
+    /**
+     * Test window read from the start of the file correctly identifies start of file
+     * and returns expected content.
+     */
     @Test
     fun testWindowFromStartOfFile() {
         val lines = (1..100).map { "Line number $it here\n" }
@@ -132,8 +148,10 @@ class FileWindowReaderTest {
         }
     }
 
-    // ── Mid-file window with line snapping ───────────────────────────
-
+    /**
+     * Test window read from the middle of the file snaps to the next line start and does not
+     * include partial lines at the start.
+     */
     @Test
     fun testWindowFromMiddleSnapsToLineStart() {
         val lines = (1..20).map { "Line $it\n" }
@@ -153,6 +171,9 @@ class FileWindowReaderTest {
         }
     }
 
+    /**
+     * Test when window end falls in the middle of a line, it snaps back to the previous newline
+     */
     @Test
     fun testWindowEndSnapsToNewline() {
         // Large content so the window can't contain it all
@@ -172,8 +193,10 @@ class FileWindowReaderTest {
         }
     }
 
-    // ── Window reading near end of file ──────────────────────────────
-
+    /**
+     * Test reading a window starting near the end of the file where requested maxChars
+     * exceeds remaining chars
+     */
     @Test
     fun testWindowNearEndOfFile() {
         val lines = (1..50).map { "Line $it\n" }
@@ -192,6 +215,10 @@ class FileWindowReaderTest {
         }
     }
 
+    /**
+     * Test reading a window starting exactly at the end of the file should return empty text and
+     * indicate end of file.
+     */
     @Test
     fun testWindowAtExactEndOfFile() {
         val content = "Hello\nWorld\n"
@@ -204,8 +231,9 @@ class FileWindowReaderTest {
         }
     }
 
-    // ── UTF-8 multi-byte character handling ──────────────────────────
-
+    /**
+     * Test UTF-8 multibyte boundary handling
+     */
     @Test
     fun testUtf8MultiByteBoundary() {
         // Use multibyte UTF-8 characters (emoji = 4 bytes each)
@@ -220,6 +248,9 @@ class FileWindowReaderTest {
         }
     }
 
+    /**
+     * Test seeking to a byte offset that falls in the middle of a multibyte UTF-8 character
+     */
     @Test
     fun testUtf8SeekIntoMiddleOfMultibyteChar() {
         // 2-byte UTF-8 chars: é = C3 A9 (2 bytes)
@@ -235,6 +266,9 @@ class FileWindowReaderTest {
         }
     }
 
+    /**
+     * Test reading a file with CJK characters
+     */
     @Test
     fun testCjkCharacters() {
         // 3-byte UTF-8 chars: Chinese characters
@@ -250,8 +284,9 @@ class FileWindowReaderTest {
         }
     }
 
-    // ── Consecutive window reads (simulating scroll) ─────────────────
-
+    /**
+     * Test consecutive forward window reads
+     */
     @Test
     fun testConsecutiveForwardWindowReads() {
         val lines = (1..200).map { "Line $it\n" }
@@ -274,6 +309,9 @@ class FileWindowReaderTest {
         }
     }
 
+    /**
+     * Test overlapping windows share content correctly and the overlapping lines are consistent
+     */
     @Test
     fun testOverlappingWindowsShareContent() {
         val lines = (1..200).map { "Line $it content here\n" }
@@ -298,8 +336,9 @@ class FileWindowReaderTest {
         }
     }
 
-    // ── Edge cases ───────────────────────────────────────────────────
-
+    /**
+     * Test negative offset
+     */
     @Test
     fun testNegativeOffset() {
         val content = "Hello\nWorld\n"
@@ -313,6 +352,9 @@ class FileWindowReaderTest {
         }
     }
 
+    /**
+     * Test offset beyond file size
+     */
     @Test
     fun testOffsetBeyondFileSize() {
         val content = "Hello\nWorld\n"
@@ -325,6 +367,9 @@ class FileWindowReaderTest {
         }
     }
 
+    /**
+     * Test maxChars=0, should return empty text
+     */
     @Test
     fun testMaxCharsZero() {
         val content = "Hello\nWorld\n"
@@ -337,6 +382,10 @@ class FileWindowReaderTest {
         }
     }
 
+    /**
+     * Test file with only newlines, should return correct number of newlines
+     * and indicate start/end of file
+     */
     @Test
     fun testFileWithOnlyNewlines() {
         val content = "\n\n\n\n\n"
@@ -350,6 +399,10 @@ class FileWindowReaderTest {
         }
     }
 
+    /**
+     * Test very long single line that exceeds maxChars.
+     * Should return up to maxChars and indicate start of file
+     */
     @Test
     fun testVeryLongSingleLine() {
         // Single line with no newlines at all
@@ -366,8 +419,9 @@ class FileWindowReaderTest {
         }
     }
 
-    // ── Close behavior ───────────────────────────────────────────────
-
+    /**
+     * Test close reader should release resources and allow for double close without exception
+     */
     @Test
     fun testCloseReleasesChannel() {
         val content = "Hello"
@@ -378,8 +432,9 @@ class FileWindowReaderTest {
         reader.close()
     }
 
-    // ── fromFile factory ─────────────────────────────────────────────
-
+    /**
+     * Test FileWindowReader.fromFile()
+     */
     @Test
     fun testFromFileFactory() {
         val content = "Factory test\nLine 2\n"
@@ -391,8 +446,9 @@ class FileWindowReaderTest {
         }
     }
 
-    // ── Byte offset tracking ─────────────────────────────────────────
-
+    /**
+     * Test byte offset consistency: startByte + text byte length should equal endByte
+     */
     @Test
     fun testByteOffsetsAreConsistent() {
         val lines = (1..50).map { "Line $it\n" }
@@ -407,6 +463,10 @@ class FileWindowReaderTest {
         }
     }
 
+    /**
+     * Test that when reading from a mid-file offset, the returned startByte is at or after
+     * the requested offset and that the text corresponds to the byte range.
+     */
     @Test
     fun testByteOffsetsForMidFileRead() {
         val lines = (1..100).map { "Line $it\n" }

--- a/app/src/test/java/com/amaze/filemanager/asynchronous/asynctasks/texteditor/read/FileWindowReaderTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/asynchronous/asynctasks/texteditor/read/FileWindowReaderTest.kt
@@ -1,0 +1,427 @@
+/*
+ * Copyright (C) 2014-2024 Arpit Khurana <arpitkh96@gmail.com>, Vishal Nehra <vishalmeham2@gmail.com>,
+ * Emmanuel Messulam<emmanuelbendavid@gmail.com>, Raymond Lai <airwave209gt at gmail.com> and Contributors.
+ *
+ * This file is part of Amaze File Manager.
+ *
+ * Amaze File Manager is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.amaze.filemanager.asynchronous.asynctasks.texteditor.read
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+/**
+ * Unit tests for [FileWindowReader].
+ *
+ * These are pure JVM tests (no Android/Robolectric needed) since FileWindowReader
+ * only depends on java.io and java.nio classes.
+ */
+class FileWindowReaderTest {
+    @get:Rule
+    val tempFolder = TemporaryFolder()
+
+    private lateinit var testFile: File
+
+    @Before
+    fun setUp() {
+        testFile = tempFolder.newFile("test.txt")
+    }
+
+    // ── Basic reading ────────────────────────────────────────────────
+
+    @Test
+    fun testReadEmptyFile() {
+        testFile.writeText("")
+        val reader = FileWindowReader.fromFile(testFile)
+        reader.use {
+            val result = it.readWindow(0, 1024)
+            assertEquals("", result.text)
+            assertEquals(0L, result.startByte)
+            assertEquals(0L, result.endByte)
+            assertTrue(result.isStartOfFile)
+            assertTrue(result.isEndOfFile)
+        }
+    }
+
+    @Test
+    fun testReadSmallFileFitsInWindow() {
+        val content = "Hello, World!\nSecond line\nThird line\n"
+        testFile.writeText(content)
+        val reader = FileWindowReader.fromFile(testFile)
+        reader.use {
+            val result = it.readWindow(0, 1024)
+            assertEquals(content, result.text)
+            assertEquals(0L, result.startByte)
+            assertTrue(result.isStartOfFile)
+            assertTrue(result.isEndOfFile)
+        }
+    }
+
+    @Test
+    fun testReadSingleLineFile() {
+        val content = "No newline at end"
+        testFile.writeText(content)
+        val reader = FileWindowReader.fromFile(testFile)
+        reader.use {
+            val result = it.readWindow(0, 1024)
+            assertEquals(content, result.text)
+            assertTrue(result.isStartOfFile)
+            assertTrue(result.isEndOfFile)
+        }
+    }
+
+    @Test
+    fun testFileSizeCorrect() {
+        val content = "Hello"
+        testFile.writeText(content)
+        val reader = FileWindowReader.fromFile(testFile)
+        reader.use {
+            assertEquals(content.toByteArray().size.toLong(), it.fileSize)
+        }
+    }
+
+    // ── Window limiting ──────────────────────────────────────────────
+
+    @Test
+    fun testMaxCharsLimitsOutput() {
+        // Create content with multiple lines, each larger than 5 chars
+        val content = "Line1\nLine2\nLine3\nLine4\nLine5\n"
+        testFile.writeText(content)
+        val reader = FileWindowReader.fromFile(testFile)
+        reader.use {
+            // Request only 12 chars — should get at most 12 chars snapped to line boundaries
+            val result = it.readWindow(0, 12)
+            assertTrue(result.text.length <= 12)
+            assertTrue(result.isStartOfFile)
+            // With line snapping, it shouldn't include trailing partial lines
+            assertTrue(result.text.endsWith("\n"))
+        }
+    }
+
+    @Test
+    fun testWindowFromStartOfFile() {
+        val lines = (1..100).map { "Line number $it here\n" }
+        val content = lines.joinToString("")
+        testFile.writeText(content)
+        val reader = FileWindowReader.fromFile(testFile)
+        reader.use {
+            val result = it.readWindow(0, 200)
+            assertTrue(result.isStartOfFile)
+            assertFalse(result.isEndOfFile)
+            assertTrue(result.text.startsWith("Line number 1 here\n"))
+            assertTrue(result.text.endsWith("\n"))
+        }
+    }
+
+    // ── Mid-file window with line snapping ───────────────────────────
+
+    @Test
+    fun testWindowFromMiddleSnapsToLineStart() {
+        val lines = (1..20).map { "Line $it\n" }
+        val content = lines.joinToString("")
+        testFile.writeText(content)
+        val reader = FileWindowReader.fromFile(testFile)
+        reader.use {
+            // Seek to the middle of the file (byte offset in the middle of a line)
+            val midOffset = content.toByteArray().size / 2L
+            val result = it.readWindow(midOffset, 200)
+
+            // When starting mid-file, the first partial line should be skipped
+            assertFalse(result.isStartOfFile)
+            // The result should start at a complete line
+            assertTrue(result.text.startsWith("Line"))
+            assertTrue(result.text.endsWith("\n"))
+        }
+    }
+
+    @Test
+    fun testWindowEndSnapsToNewline() {
+        // Large content so the window can't contain it all
+        val lines = (1..1000).map { "Line number $it with some padding text to make it longer\n" }
+        val content = lines.joinToString("")
+        testFile.writeText(content)
+        val reader = FileWindowReader.fromFile(testFile)
+        reader.use {
+            // Read a small window from the start
+            val result = it.readWindow(0, 200)
+            assertTrue(result.isStartOfFile)
+            assertFalse(result.isEndOfFile)
+            // End should be at a line boundary
+            assertTrue(result.text.endsWith("\n"))
+            // No partial lines
+            assertFalse(result.text.trimEnd('\n').contains("Line number").not())
+        }
+    }
+
+    // ── Window reading near end of file ──────────────────────────────
+
+    @Test
+    fun testWindowNearEndOfFile() {
+        val lines = (1..50).map { "Line $it\n" }
+        val content = lines.joinToString("")
+        testFile.writeText(content)
+        val fileBytes = content.toByteArray()
+        val reader = FileWindowReader.fromFile(testFile)
+        reader.use {
+            // Read from near the end — request more chars than remain
+            val nearEnd = (fileBytes.size - 30L).coerceAtLeast(0L)
+            val result = it.readWindow(nearEnd, 10000)
+            assertTrue(result.isEndOfFile)
+            assertFalse(result.isStartOfFile)
+            // Should contain the last line
+            assertTrue(result.text.contains("Line 50\n"))
+        }
+    }
+
+    @Test
+    fun testWindowAtExactEndOfFile() {
+        val content = "Hello\nWorld\n"
+        testFile.writeText(content)
+        val reader = FileWindowReader.fromFile(testFile)
+        reader.use {
+            val result = it.readWindow(content.toByteArray().size.toLong(), 1024)
+            assertEquals("", result.text)
+            assertTrue(result.isEndOfFile)
+        }
+    }
+
+    // ── UTF-8 multi-byte character handling ──────────────────────────
+
+    @Test
+    fun testUtf8MultiByteBoundary() {
+        // Use multibyte UTF-8 characters (emoji = 4 bytes each)
+        val content = "Hello\n\uD83D\uDE00\uD83D\uDE01\uD83D\uDE02\n" // 😀😁😂
+        testFile.writeBytes(content.toByteArray(Charsets.UTF_8))
+        val reader = FileWindowReader.fromFile(testFile)
+        reader.use {
+            val result = it.readWindow(0, 1024)
+            assertTrue(result.text.contains("😀"))
+            assertTrue(result.text.contains("😁"))
+            assertTrue(result.text.contains("😂"))
+        }
+    }
+
+    @Test
+    fun testUtf8SeekIntoMiddleOfMultibyteChar() {
+        // 2-byte UTF-8 chars: é = C3 A9 (2 bytes)
+        val content = "café\ncafé\ncafé\n"
+        testFile.writeBytes(content.toByteArray(Charsets.UTF_8))
+        val reader = FileWindowReader.fromFile(testFile)
+        reader.use {
+            // Seek to byte 4 which is the second byte of 'é' in "café"
+            // The snapToCharBoundary should back up to byte 3
+            val result = it.readWindow(4, 1024)
+            // Should be valid UTF-8 text, no replacement characters
+            assertFalse(result.text.contains("\uFFFD"))
+        }
+    }
+
+    @Test
+    fun testCjkCharacters() {
+        // 3-byte UTF-8 chars: Chinese characters
+        val content = "第一行\n第二行\n第三行\n"
+        testFile.writeBytes(content.toByteArray(Charsets.UTF_8))
+        val reader = FileWindowReader.fromFile(testFile)
+        reader.use {
+            val result = it.readWindow(0, 1024)
+            assertTrue(result.text.contains("第一行"))
+            assertTrue(result.text.contains("第三行"))
+            assertTrue(result.isStartOfFile)
+            assertTrue(result.isEndOfFile)
+        }
+    }
+
+    // ── Consecutive window reads (simulating scroll) ─────────────────
+
+    @Test
+    fun testConsecutiveForwardWindowReads() {
+        val lines = (1..200).map { "Line $it\n" }
+        val content = lines.joinToString("")
+        testFile.writeText(content)
+        val reader = FileWindowReader.fromFile(testFile)
+        reader.use {
+            // First window from start
+            val first = it.readWindow(0, 100)
+            assertTrue(first.isStartOfFile)
+            assertFalse(first.isEndOfFile)
+            assertTrue(first.text.isNotEmpty())
+
+            // Second window starting at half of first window's end
+            val midPoint = (first.endByte - first.startByte) / 2 + first.startByte
+            val second = it.readWindow(midPoint, 100)
+            assertFalse(second.isStartOfFile)
+            // Should have progressed past the first window start
+            assertTrue(second.startByte > first.startByte)
+        }
+    }
+
+    @Test
+    fun testOverlappingWindowsShareContent() {
+        val lines = (1..200).map { "Line $it content here\n" }
+        val content = lines.joinToString("")
+        testFile.writeText(content)
+        val reader = FileWindowReader.fromFile(testFile)
+        reader.use {
+            val first = it.readWindow(0, 500)
+            // Read second window with 50% overlap
+            val overlapStart = first.startByte + (first.endByte - first.startByte) / 2
+            val second = it.readWindow(overlapStart, 500)
+
+            // There should be overlapping content between the two windows
+            val firstLines = first.text.lines().filter { l -> l.isNotEmpty() }
+            val secondLines = second.text.lines().filter { l -> l.isNotEmpty() }
+
+            val overlap = firstLines.intersect(secondLines.toSet())
+            assertTrue(
+                "Windows should overlap, got first=${firstLines.size} second=${secondLines.size} overlap=${overlap.size}",
+                overlap.isNotEmpty(),
+            )
+        }
+    }
+
+    // ── Edge cases ───────────────────────────────────────────────────
+
+    @Test
+    fun testNegativeOffset() {
+        val content = "Hello\nWorld\n"
+        testFile.writeText(content)
+        val reader = FileWindowReader.fromFile(testFile)
+        reader.use {
+            // Should clamp to 0
+            val result = it.readWindow(-100, 1024)
+            assertTrue(result.isStartOfFile)
+            assertEquals(content, result.text)
+        }
+    }
+
+    @Test
+    fun testOffsetBeyondFileSize() {
+        val content = "Hello\nWorld\n"
+        testFile.writeText(content)
+        val reader = FileWindowReader.fromFile(testFile)
+        reader.use {
+            val result = it.readWindow(100000, 1024)
+            assertEquals("", result.text)
+            assertTrue(result.isEndOfFile)
+        }
+    }
+
+    @Test
+    fun testMaxCharsZero() {
+        val content = "Hello\nWorld\n"
+        testFile.writeText(content)
+        val reader = FileWindowReader.fromFile(testFile)
+        reader.use {
+            // maxChars=0 → maxBytes will be 0, should return empty
+            val result = it.readWindow(0, 0)
+            assertEquals("", result.text)
+        }
+    }
+
+    @Test
+    fun testFileWithOnlyNewlines() {
+        val content = "\n\n\n\n\n"
+        testFile.writeText(content)
+        val reader = FileWindowReader.fromFile(testFile)
+        reader.use {
+            val result = it.readWindow(0, 1024)
+            assertEquals(content, result.text)
+            assertTrue(result.isStartOfFile)
+            assertTrue(result.isEndOfFile)
+        }
+    }
+
+    @Test
+    fun testVeryLongSingleLine() {
+        // Single line with no newlines at all
+        val content = "A".repeat(10000)
+        testFile.writeText(content)
+        val reader = FileWindowReader.fromFile(testFile)
+        reader.use {
+            // Request a small window — since there are no newlines, end-snap
+            // won't find a newline. Because we're at start and end, full content
+            // up to maxChars is returned.
+            val result = it.readWindow(0, 500)
+            assertTrue(result.text.length <= 500)
+            assertTrue(result.isStartOfFile)
+        }
+    }
+
+    // ── Close behavior ───────────────────────────────────────────────
+
+    @Test
+    fun testCloseReleasesChannel() {
+        val content = "Hello"
+        testFile.writeText(content)
+        val reader = FileWindowReader.fromFile(testFile)
+        reader.close()
+        // Double close should not throw
+        reader.close()
+    }
+
+    // ── fromFile factory ─────────────────────────────────────────────
+
+    @Test
+    fun testFromFileFactory() {
+        val content = "Factory test\nLine 2\n"
+        testFile.writeText(content)
+        FileWindowReader.fromFile(testFile).use { reader ->
+            assertEquals(content.toByteArray().size.toLong(), reader.fileSize)
+            val result = reader.readWindow(0, 1024)
+            assertEquals(content, result.text)
+        }
+    }
+
+    // ── Byte offset tracking ─────────────────────────────────────────
+
+    @Test
+    fun testByteOffsetsAreConsistent() {
+        val lines = (1..50).map { "Line $it\n" }
+        val content = lines.joinToString("")
+        testFile.writeText(content)
+        val reader = FileWindowReader.fromFile(testFile)
+        reader.use {
+            val result = it.readWindow(0, 100)
+            // endByte should equal startByte + byte length of returned text
+            val expectedEndByte = result.startByte + result.text.toByteArray(Charsets.UTF_8).size
+            assertEquals(expectedEndByte, result.endByte)
+        }
+    }
+
+    @Test
+    fun testByteOffsetsForMidFileRead() {
+        val lines = (1..100).map { "Line $it\n" }
+        val content = lines.joinToString("")
+        testFile.writeText(content)
+        val reader = FileWindowReader.fromFile(testFile)
+        reader.use {
+            val result = it.readWindow(50, 100)
+            // startByte should be >= 50 (snapped forward past partial line)
+            assertTrue(result.startByte >= 50)
+            // endByte should be > startByte
+            assertTrue(result.endByte > result.startByte)
+            // Byte range should match text length
+            val textBytes = result.text.toByteArray(Charsets.UTF_8).size
+            assertEquals(result.endByte, result.startByte + textBytes)
+        }
+    }
+}

--- a/app/src/test/java/com/amaze/filemanager/asynchronous/asynctasks/texteditor/read/ReadTextFileCallableTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/asynchronous/asynctasks/texteditor/read/ReadTextFileCallableTest.kt
@@ -166,7 +166,7 @@ class ReadTextFileCallableTest {
     fun testReadBigFileViaFileUriCreatesWindowReader() {
         val random = Random(456)
         val letters = ('A'..'Z').toSet() + ('a'..'z').toSet()
-        val bigContent = List(MAX_FILE_SIZE_CHARS * 2) { letters.random(random) }.joinToString("")
+        val bigContent = List((MAX_FILE_SIZE_CHARS * 1.05).toInt()) { letters.random(random) }.joinToString("")
 
         val file = tempFolder.newFile("bigfile.txt")
         file.writeText(bigContent)

--- a/app/src/test/java/com/amaze/filemanager/asynchronous/asynctasks/texteditor/read/ReadTextFileCallableTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/asynchronous/asynctasks/texteditor/read/ReadTextFileCallableTest.kt
@@ -35,7 +35,9 @@ import com.amaze.filemanager.filesystem.RandomPathGenerator
 import com.amaze.filemanager.shadows.ShadowMultiDex
 import com.amaze.filemanager.ui.activities.texteditor.ReturnedValueOnReadFile
 import org.junit.Assert
+import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.TemporaryFolder
 import org.junit.runner.RunWith
 import org.robolectric.Shadows
 import org.robolectric.annotation.Config
@@ -49,6 +51,9 @@ import kotlin.random.Random
     sdk = [LOLLIPOP, P, Build.VERSION_CODES.R],
 )
 class ReadTextFileCallableTest {
+    @get:Rule
+    val tempFolder = TemporaryFolder()
+
     /**
      * Test read an empty file with [ReadTextFileCallable]
      */
@@ -149,5 +154,102 @@ class ReadTextFileCallableTest {
     private fun generatePath(): Uri {
         val path = RandomPathGenerator.generateRandomPath(Random(123), 50)
         return Uri.parse("content://com.amaze.filemanager.test/$path/foobar.txt")
+    }
+
+    // ── New tests for windowed mode (file:// URI with FileWindowReader) ──
+
+    /**
+     * Test that reading a big file via file:// URI produces a FileWindowReader
+     * and correct total file size.
+     */
+    @Test
+    fun testReadBigFileViaFileUriCreatesWindowReader() {
+        val random = Random(456)
+        val letters = ('A'..'Z').toSet() + ('a'..'z').toSet()
+        val bigContent = List(MAX_FILE_SIZE_CHARS * 2) { letters.random(random) }.joinToString("")
+
+        val file = tempFolder.newFile("bigfile.txt")
+        file.writeText(bigContent)
+
+        val ctx = ApplicationProvider.getApplicationContext<Context>()
+        val uri = Uri.fromFile(file)
+        val task =
+            ReadTextFileCallable(
+                ctx.contentResolver,
+                EditableFileAbstraction(ctx, uri),
+                tempFolder.root,
+                false,
+            )
+        val result = task.call()
+
+        Assert.assertTrue("File should be too long", result.fileIsTooLong)
+        Assert.assertEquals(
+            bigContent.substring(0, MAX_FILE_SIZE_CHARS),
+            result.fileContents,
+        )
+        Assert.assertNotNull("FileWindowReader should be created for file:// URI", result.fileWindowReader)
+        Assert.assertEquals(file.length(), result.totalFileSize)
+
+        // Verify the reader works
+        val windowResult = result.fileWindowReader!!.readWindow(0, 100)
+        Assert.assertTrue(windowResult.text.isNotEmpty())
+        Assert.assertTrue(windowResult.isStartOfFile)
+
+        result.fileWindowReader!!.close()
+    }
+
+    /**
+     * Test that reading a small file via file:// URI does NOT create a FileWindowReader.
+     */
+    @Test
+    fun testReadSmallFileViaFileUriNoWindowReader() {
+        val content = "Small file content\n"
+
+        val file = tempFolder.newFile("smallfile.txt")
+        file.writeText(content)
+
+        val ctx = ApplicationProvider.getApplicationContext<Context>()
+        val uri = Uri.fromFile(file)
+        val task =
+            ReadTextFileCallable(
+                ctx.contentResolver,
+                EditableFileAbstraction(ctx, uri),
+                tempFolder.root,
+                false,
+            )
+        val result = task.call()
+
+        Assert.assertFalse("File should not be too long", result.fileIsTooLong)
+        Assert.assertEquals(content, result.fileContents)
+        Assert.assertNull("FileWindowReader should be null for small files", result.fileWindowReader)
+        Assert.assertEquals(0L, result.totalFileSize)
+    }
+
+    /**
+     * Test that big file via content:// URI gracefully handles missing seekable descriptor
+     * (fileWindowReader remains null).
+     */
+    @Test
+    fun testReadBigFileViaContentUriFallsBackGracefully() {
+        val random = Random(789)
+        val letters = ('A'..'Z').toSet() + ('a'..'z').toSet()
+        val bigContent = List(MAX_FILE_SIZE_CHARS * 2) { letters.random(random) }.joinToString("")
+
+        val uri = generatePath()
+        val ctx = ApplicationProvider.getApplicationContext<Context>()
+        val cr = ctx.contentResolver
+        Shadows.shadowOf(cr).registerInputStream(uri, ByteArrayInputStream(bigContent.toByteArray()))
+
+        val task = ReadTextFileCallable(cr, EditableFileAbstraction(ctx, uri), null, false)
+        val result = task.call()
+
+        Assert.assertTrue("File should be too long", result.fileIsTooLong)
+        // Content provider shadow doesn't support openFileDescriptor,
+        // so FileWindowReader creation should have failed gracefully
+        Assert.assertNull(
+            "FileWindowReader should be null when content provider doesn't support seek",
+            result.fileWindowReader,
+        )
+        Assert.assertEquals(0L, result.totalFileSize)
     }
 }

--- a/app/src/test/java/com/amaze/filemanager/asynchronous/services/ftp/FtpReceiverTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/asynchronous/services/ftp/FtpReceiverTest.kt
@@ -99,7 +99,7 @@ class FtpReceiverTest {
      * Test [Context.startForegroundService()] called for post-Nougat Androids.
      */
     @Test
-    @Config(minSdk = O)
+    @Config(minSdk = O, maxSdk = Build.VERSION_CODES.R)
     fun testStartForegroundServiceCalled() {
         val ctx = AppConfig.getInstance()
         val spy = spyk(ctx)

--- a/app/src/test/java/com/amaze/filemanager/ui/activities/texteditor/MarkdownHtmlGeneratorTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/ui/activities/texteditor/MarkdownHtmlGeneratorTest.kt
@@ -1,0 +1,261 @@
+/*
+ * Copyright (C) 2014-2024 Arpit Khurana <arpitkh96@gmail.com>, Vishal Nehra <vishalmeham2@gmail.com>,
+ * Emmanuel Messulam<emmanuelbendavid@gmail.com>, Raymond Lai <airwave209gt at gmail.com> and Contributors.
+ *
+ * This file is part of Amaze File Manager.
+ *
+ * Amaze File Manager is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.amaze.filemanager.ui.activities.texteditor
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Tests for [MarkdownHtmlGenerator].
+ */
+@Suppress("StringLiteralDuplication")
+class MarkdownHtmlGeneratorTest {
+    /**
+     * Tests isMarkdownFile
+     */
+    @Test
+    fun testIsMarkdownFile_md() {
+        assertTrue(MarkdownHtmlGenerator.isMarkdownFile("README.md"))
+        assertTrue(MarkdownHtmlGenerator.isMarkdownFile("notes.markdown"))
+        assertTrue(MarkdownHtmlGenerator.isMarkdownFile("CHANGELOG.MD"))
+        assertTrue(MarkdownHtmlGenerator.isMarkdownFile("readme.Markdown"))
+        assertFalse(MarkdownHtmlGenerator.isMarkdownFile("file.txt"))
+        assertFalse(MarkdownHtmlGenerator.isMarkdownFile("Main.java"))
+        assertFalse(MarkdownHtmlGenerator.isMarkdownFile("file.md.bak"))
+        assertFalse(MarkdownHtmlGenerator.isMarkdownFile(null))
+        assertFalse(MarkdownHtmlGenerator.isMarkdownFile(""))
+        assertTrue(MarkdownHtmlGenerator.isMarkdownFile(".md"))
+        assertFalse(MarkdownHtmlGenerator.isMarkdownFile("README"))
+    }
+
+    /**
+     * Tests renderToHtml with styles and formatting
+     */
+    @Test
+    fun testRenderToHtmlStyles() {
+        var html = MarkdownHtmlGenerator.renderToHtml("# Hello")
+        assertTrue("Should contain <h1>", html.contains("<h1>Hello</h1>"))
+        html = MarkdownHtmlGenerator.renderToHtml("Some text")
+        assertTrue("Should contain <p>", html.contains("<p>Some text</p>"))
+        html = MarkdownHtmlGenerator.renderToHtml("**bold**")
+        assertTrue("Should contain <strong>", html.contains("<strong>bold</strong>"))
+        html = MarkdownHtmlGenerator.renderToHtml("*italic*")
+        assertTrue("Should contain <em>", html.contains("<em>italic</em>"))
+    }
+
+    /**
+     * Tests renderToHtml with lists
+     */
+    @Test
+    fun testRenderUnorderedList() {
+        var md = "- item1\n- item2\n- item3"
+        var html = MarkdownHtmlGenerator.renderToHtml(md)
+        assertTrue("Should contain <ul>", html.contains("<ul>"))
+        assertTrue("Should contain <li>", html.contains("<li>item1</li>"))
+        assertTrue("Should contain <li>", html.contains("<li>item2</li>"))
+
+        md = "1. first\n2. second"
+        html = MarkdownHtmlGenerator.renderToHtml(md)
+        assertTrue("Should contain <ol>", html.contains("<ol>"))
+        assertTrue("Should contain <li>", html.contains("<li>first</li>"))
+    }
+
+    /**
+     * Tests renderToHtml with links
+     */
+    @Test
+    fun testRenderLink() {
+        val html = MarkdownHtmlGenerator.renderToHtml("[click](https://example.com)")
+        assertTrue("Should contain <a>", html.contains("<a"))
+        assertTrue("Should contain href", html.contains("href=\"https://example.com\""))
+        assertTrue("Should contain link text", html.contains(">click</a>"))
+    }
+
+    /**
+     * Test renderToHtml with inline code and code blocks
+     */
+    @Test
+    fun testRenderInlineCode() {
+        var html = MarkdownHtmlGenerator.renderToHtml("Use `println()`")
+        assertTrue("Should contain <code>", html.contains("<code>println()</code>"))
+
+        val md = "```\nval x = 1\n```"
+        html = MarkdownHtmlGenerator.renderToHtml(md)
+        assertTrue("Should contain <pre>", html.contains("<pre>"))
+        assertTrue("Should contain <code>", html.contains("<code>"))
+        assertTrue("Should contain code content", html.contains("val x = 1"))
+    }
+
+    /**
+     * Test renderToHtml with blockquotes
+     */
+    @Test
+    fun testRenderBlockquote() {
+        val html = MarkdownHtmlGenerator.renderToHtml("> quote text")
+        assertTrue("Should contain <blockquote>", html.contains("<blockquote>"))
+        assertTrue("Should contain quote text", html.contains("quote text"))
+    }
+
+    /**
+     * Test renderToHtml with horizontal rule
+     */
+    @Test
+    fun testRenderHorizontalRule() {
+        val html = MarkdownHtmlGenerator.renderToHtml("---")
+        assertTrue("Should contain <hr>", html.contains("<hr"))
+    }
+
+    /**
+     * Test renderToHtml with empty string
+     */
+    @Test
+    fun testRenderEmptyString() {
+        val html = MarkdownHtmlGenerator.renderToHtml("")
+        // Empty input should produce empty or whitespace-only output
+        assertTrue("Should be empty or whitespace", html.trim().isEmpty())
+    }
+
+    /**
+     * Tests renderToHtml with multiple headings
+     */
+    @Test
+    fun testRenderMultipleHeadings() {
+        val md = "# H1\n## H2\n### H3"
+        val html = MarkdownHtmlGenerator.renderToHtml(md)
+        assertTrue(html.contains("<h1>H1</h1>"))
+        assertTrue(html.contains("<h2>H2</h2>"))
+        assertTrue(html.contains("<h3>H3</h3>"))
+    }
+
+    /**
+     * Test renderToHtml with image tags
+     */
+    @Test
+    fun testRenderImage() {
+        val html = MarkdownHtmlGenerator.renderToHtml("![alt](image.png)")
+        assertTrue("Should contain <img>", html.contains("<img"))
+        assertTrue("Should contain src", html.contains("src=\"image.png\""))
+        assertTrue("Should contain alt", html.contains("alt=\"alt\""))
+    }
+
+    /**
+     * Test wrapWithBaseHtml
+     */
+    @Test
+    fun testWrapLightThemeContainsDoctype() {
+        var result = MarkdownHtmlGenerator.wrapWithBaseHtml("<p>Hello</p>", isDarkTheme = false)
+        assertTrue("Should start with DOCTYPE", result.contains("<!DOCTYPE html>"))
+        result = MarkdownHtmlGenerator.wrapWithBaseHtml("<p>Hello</p>", isDarkTheme = false)
+        assertTrue("Should contain body content", result.contains("<p>Hello</p>"))
+    }
+
+    /**
+     * Test wrapWithBaseHtml applies correct colors for light and dark themes
+     */
+    @Test
+    fun testWrapCorrectThemeColors() {
+        var result = MarkdownHtmlGenerator.wrapWithBaseHtml("<p>Test</p>", isDarkTheme = false)
+        assertTrue("Light bg should be #ffffff", result.contains("#ffffff"))
+        assertTrue("Light text should be #212121", result.contains("#212121"))
+        assertTrue("Light link should be #1565c0", result.contains("#1565c0"))
+        assertTrue("Light code bg should be #f5f5f5", result.contains("#f5f5f5"))
+        assertTrue("Light border should be #dddddd", result.contains("#dddddd"))
+
+        result = MarkdownHtmlGenerator.wrapWithBaseHtml("<p>Test</p>", isDarkTheme = true)
+        assertTrue("Dark bg should be #1a1a1a", result.contains("#1a1a1a"))
+        assertTrue("Dark text should be #e0e0e0", result.contains("#e0e0e0"))
+        assertTrue("Dark link should be #82b1ff", result.contains("#82b1ff"))
+        assertTrue("Dark code bg should be #2d2d2d", result.contains("#2d2d2d"))
+        assertTrue("Dark border should be #444444", result.contains("#444444"))
+    }
+
+    /**
+     * Test wrapWithBaseHtml contains correct meta tags and CSS rules
+     */
+    @Test
+    fun testWrapContainsMeta() {
+        var result = MarkdownHtmlGenerator.wrapWithBaseHtml("<p>X</p>", isDarkTheme = false)
+        assertTrue("Should contain viewport meta", result.contains("viewport"))
+        assertTrue("Should contain width=device-width", result.contains("width=device-width"))
+
+        result = MarkdownHtmlGenerator.wrapWithBaseHtml("<p>X</p>", isDarkTheme = false)
+        assertTrue("Should contain charset UTF-8", result.contains("charset=\"UTF-8\""))
+
+        result = MarkdownHtmlGenerator.wrapWithBaseHtml("<p>X</p>", isDarkTheme = false)
+        assertTrue("Should contain style block", result.contains("<style>"))
+        assertTrue("Should style body", result.contains("body {"))
+        assertTrue("Should style pre", result.contains("pre {"))
+        assertTrue("Should style code", result.contains("code {"))
+        assertTrue("Should style blockquote", result.contains("blockquote {"))
+        assertTrue("Should style table", result.contains("table {"))
+        assertTrue("Should style headings", result.contains("h1, h2, h3"))
+    }
+
+    /**
+     * Test wrapWithBaseHtml with empty body content
+     */
+    @Test
+    fun testWrapEmptyBody() {
+        val result = MarkdownHtmlGenerator.wrapWithBaseHtml("", isDarkTheme = false)
+        assertTrue("Should still produce valid HTML", result.contains("<!DOCTYPE html>"))
+        assertTrue("Should have body tags", result.contains("<body>"))
+        assertTrue("Should close body", result.contains("</body>"))
+    }
+
+    /**
+     * Test wrapWithBaseHtml preserves HTML entities in the body content
+     */
+    @Test
+    fun testWrapPreservesHtmlEntities() {
+        val body = "<p>5 &gt; 3 &amp; 2 &lt; 4</p>"
+        val result = MarkdownHtmlGenerator.wrapWithBaseHtml(body, isDarkTheme = false)
+        assertTrue("Should preserve HTML entities", result.contains("5 &gt; 3 &amp; 2 &lt; 4"))
+    }
+
+    /**
+     * Test end to end rendering and wrapping
+     */
+    @Test
+    fun testEndToEndRenderAndWrap() {
+        val md = "# Title\n\nSome **bold** text."
+        val bodyHtml = MarkdownHtmlGenerator.renderToHtml(md)
+        val fullHtml = MarkdownHtmlGenerator.wrapWithBaseHtml(bodyHtml, isDarkTheme = false)
+
+        assertTrue("Full doc should contain DOCTYPE", fullHtml.contains("<!DOCTYPE html>"))
+        assertTrue("Full doc should contain h1", fullHtml.contains("<h1>Title</h1>"))
+        assertTrue("Full doc should contain strong", fullHtml.contains("<strong>bold</strong>"))
+        assertTrue("Full doc should close html", fullHtml.contains("</html>"))
+    }
+
+    /**
+     * Test end to end rendering with dark theme
+     */
+    @Test
+    fun testEndToEndDarkTheme() {
+        val md = "Hello *world*"
+        val bodyHtml = MarkdownHtmlGenerator.renderToHtml(md)
+        val fullHtml = MarkdownHtmlGenerator.wrapWithBaseHtml(bodyHtml, isDarkTheme = true)
+
+        assertTrue("Should use dark bg", fullHtml.contains("#1a1a1a"))
+        assertTrue("Should contain em", fullHtml.contains("<em>world</em>"))
+    }
+}

--- a/app/src/test/java/com/amaze/filemanager/ui/activities/texteditor/ReturnedValueOnReadFileTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/ui/activities/texteditor/ReturnedValueOnReadFileTest.kt
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2014-2024 Arpit Khurana <arpitkh96@gmail.com>, Vishal Nehra <vishalmeham2@gmail.com>,
+ * Emmanuel Messulam<emmanuelbendavid@gmail.com>, Raymond Lai <airwave209gt at gmail.com> and Contributors.
+ *
+ * This file is part of Amaze File Manager.
+ *
+ * Amaze File Manager is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.amaze.filemanager.ui.activities.texteditor
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Tests for [ReturnedValueOnReadFile] data class, including new windowed mode fields.
+ */
+class ReturnedValueOnReadFileTest {
+    @Test
+    fun testDefaultValues() {
+        val result = ReturnedValueOnReadFile("content", null, false)
+        assertEquals("content", result.fileContents)
+        assertNull(result.cachedFile)
+        assertFalse(result.fileIsTooLong)
+        assertNull(result.fileWindowReader)
+        assertEquals(0L, result.totalFileSize)
+    }
+
+    @Test
+    fun testExplicitNullReader() {
+        val result = ReturnedValueOnReadFile("content", null, true, null, 0L)
+        assertTrue(result.fileIsTooLong)
+        assertNull(result.fileWindowReader)
+        assertEquals(0L, result.totalFileSize)
+    }
+
+    @Test
+    fun testEqualityWithDefaultParams() {
+        val a = ReturnedValueOnReadFile("hello", null, false)
+        val b = ReturnedValueOnReadFile("hello", null, false, null, 0L)
+        assertEquals(a, b)
+    }
+
+    @Test
+    fun testEqualityDifferentContent() {
+        val a = ReturnedValueOnReadFile("hello", null, false)
+        val b = ReturnedValueOnReadFile("world", null, false)
+        assertFalse(a == b)
+    }
+
+    @Test
+    fun testCopyWithTotalFileSize() {
+        val original = ReturnedValueOnReadFile("content", null, false)
+        val modified = original.copy(fileIsTooLong = true, totalFileSize = 999L)
+        assertTrue(modified.fileIsTooLong)
+        assertEquals(999L, modified.totalFileSize)
+        assertEquals("content", modified.fileContents)
+    }
+
+    @Test
+    fun testToString() {
+        val result = ReturnedValueOnReadFile("hi", null, false)
+        val str = result.toString()
+        assertTrue(str.contains("fileContents=hi"))
+        assertTrue(str.contains("fileIsTooLong=false"))
+    }
+}

--- a/app/src/test/java/com/amaze/filemanager/ui/activities/texteditor/ReturnedValueOnReadFileTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/ui/activities/texteditor/ReturnedValueOnReadFileTest.kt
@@ -27,9 +27,13 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
- * Tests for [ReturnedValueOnReadFile] data class, including new windowed mode fields.
+ * Tests for [ReturnedValueOnReadFile] data class.
  */
+@Suppress("StringLiteralDuplication")
 class ReturnedValueOnReadFileTest {
+    /**
+     * Test default values
+     */
     @Test
     fun testDefaultValues() {
         val result = ReturnedValueOnReadFile("content", null, false)
@@ -40,6 +44,9 @@ class ReturnedValueOnReadFileTest {
         assertEquals(0L, result.totalFileSize)
     }
 
+    /**
+     * Test explicit null values for optional parameters
+     */
     @Test
     fun testExplicitNullReader() {
         val result = ReturnedValueOnReadFile("content", null, true, null, 0L)
@@ -48,6 +55,9 @@ class ReturnedValueOnReadFileTest {
         assertEquals(0L, result.totalFileSize)
     }
 
+    /**
+     *
+     */
     @Test
     fun testEqualityWithDefaultParams() {
         val a = ReturnedValueOnReadFile("hello", null, false)
@@ -55,6 +65,9 @@ class ReturnedValueOnReadFileTest {
         assertEquals(a, b)
     }
 
+    /**
+     * Test equality with different file contents
+     */
     @Test
     fun testEqualityDifferentContent() {
         val a = ReturnedValueOnReadFile("hello", null, false)
@@ -62,6 +75,9 @@ class ReturnedValueOnReadFileTest {
         assertFalse(a == b)
     }
 
+    /**
+     * Test the copy method with modified fileIsTooLong and totalFileSize
+     */
     @Test
     fun testCopyWithTotalFileSize() {
         val original = ReturnedValueOnReadFile("content", null, false)
@@ -71,6 +87,11 @@ class ReturnedValueOnReadFileTest {
         assertEquals("content", modified.fileContents)
     }
 
+    /**
+     * Test toString().
+     *
+     * WARNING: return value can be expensive if content is big!
+     */
     @Test
     fun testToString() {
         val result = ReturnedValueOnReadFile("hi", null, false)

--- a/app/src/test/java/com/amaze/filemanager/ui/activities/texteditor/TextEditorActivityViewModelTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/ui/activities/texteditor/TextEditorActivityViewModelTest.kt
@@ -98,6 +98,24 @@ class TextEditorActivityViewModelTest {
         assertEquals(-1, vm.current)
         assertEquals(0, vm.line)
         assertTrue(vm.searchResultIndices.isEmpty())
+        assertFalse(vm.markdownPreviewEnabled)
+    }
+
+    // ── Markdown preview state ───────────────────────────────────────
+
+    @Test
+    fun testMarkdownPreviewDefaultDisabled() {
+        val vm = TextEditorActivityViewModel()
+        assertFalse(vm.markdownPreviewEnabled)
+    }
+
+    @Test
+    fun testMarkdownPreviewToggle() {
+        val vm = TextEditorActivityViewModel()
+        vm.markdownPreviewEnabled = true
+        assertTrue(vm.markdownPreviewEnabled)
+        vm.markdownPreviewEnabled = false
+        assertFalse(vm.markdownPreviewEnabled)
     }
 
     // ── Windowed state initialization ────────────────────────────────

--- a/app/src/test/java/com/amaze/filemanager/ui/activities/texteditor/TextEditorActivityViewModelTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/ui/activities/texteditor/TextEditorActivityViewModelTest.kt
@@ -66,18 +66,25 @@ class TextEditorActivityViewModelTest {
 
     private val testDispatcher = StandardTestDispatcher()
 
+    /**
+     * Setup before test.
+     */
     @Before
     fun setUp() {
         Dispatchers.setMain(testDispatcher)
     }
 
+    /**
+     * Cleanup after test.
+     */
     @After
     fun tearDown() {
         Dispatchers.resetMain()
     }
 
-    // ── Default state ────────────────────────────────────────────────
-
+    /**
+     * Test default state of the ViewModel is non-windowed with null reader and zero offsets.
+     */
     @Test
     fun testDefaultStateNotWindowed() {
         val vm = TextEditorActivityViewModel()
@@ -86,9 +93,13 @@ class TextEditorActivityViewModelTest {
         assertEquals(0L, vm.windowStartByte)
         assertEquals(0L, vm.windowEndByte)
         assertEquals(0L, vm.totalFileSize)
+        assertNull(vm.lastLoadDirection)
         assertNull(vm.windowContent.value)
     }
 
+    /**
+     * Test non-windowed state properties are initialized to expected defaults (null/false/empty).
+     */
     @Test
     fun testDefaultNonWindowedState() {
         val vm = TextEditorActivityViewModel()
@@ -101,14 +112,18 @@ class TextEditorActivityViewModelTest {
         assertFalse(vm.markdownPreviewEnabled)
     }
 
-    // ── Markdown preview state ───────────────────────────────────────
-
+    /**
+     * Test markdown preview is disabled by default and can be toggled on/off correctly.
+     */
     @Test
     fun testMarkdownPreviewDefaultDisabled() {
         val vm = TextEditorActivityViewModel()
         assertFalse(vm.markdownPreviewEnabled)
     }
 
+    /**
+     * Test toggling markdown preview on and off updates the state as expected.
+     */
     @Test
     fun testMarkdownPreviewToggle() {
         val vm = TextEditorActivityViewModel()
@@ -118,8 +133,9 @@ class TextEditorActivityViewModelTest {
         assertFalse(vm.markdownPreviewEnabled)
     }
 
-    // ── Windowed state initialization ────────────────────────────────
-
+    /**
+     * Test initializing windowed mode properties with a valid reader and file size sets the state correctly.
+     */
     @Test
     fun testInitializeWindowedMode() {
         val vm = TextEditorActivityViewModel()
@@ -141,8 +157,10 @@ class TextEditorActivityViewModelTest {
         reader.close()
     }
 
-    // ── loadWindow: forward ──────────────────────────────────────────
-
+    /**
+     * Test loadWindow shifts the window forward and emits new content when a reader is set and
+     * not at end of file.
+     */
     @Test
     fun testLoadWindowForward() =
         runTest(testDispatcher) {
@@ -169,8 +187,10 @@ class TextEditorActivityViewModelTest {
             reader.close()
         }
 
-    // ── loadWindow: backward ─────────────────────────────────────────
-
+    /**
+     * Test loadWindow shifts the window backward and emits new content when a reader is set and
+     * not at start of file.
+     */
     @Test
     fun testLoadWindowBackward() =
         runTest(testDispatcher) {
@@ -197,8 +217,10 @@ class TextEditorActivityViewModelTest {
             reader.close()
         }
 
-    // ── loadWindow: no-op at boundaries ──────────────────────────────
-
+    /**
+     * Test loadWindow does not emit new content when trying to shift forward at end of file
+     * (no-op).
+     */
     @Test
     fun testLoadWindowForwardNoOpAtEndOfFile() =
         runTest(testDispatcher) {
@@ -224,6 +246,10 @@ class TextEditorActivityViewModelTest {
             reader.close()
         }
 
+    /**
+     * Test loadWindow does not emit new content when trying to shift backward at start of file
+     * (no-op).
+     */
     @Test
     fun testLoadWindowBackwardNoOpAtStartOfFile() =
         runTest(testDispatcher) {
@@ -248,8 +274,9 @@ class TextEditorActivityViewModelTest {
             reader.close()
         }
 
-    // ── loadWindow: no-op when no reader ─────────────────────────────
-
+    /**
+     * Test loadWindow does not emit new content when no reader is set (no-op).
+     */
     @Test
     fun testLoadWindowNoOpWithoutReader() =
         runTest(testDispatcher) {
@@ -266,8 +293,10 @@ class TextEditorActivityViewModelTest {
             assertNull(result)
         }
 
-    // ── Window byte offsets updated after load ───────────────────────
-
+    /**
+     * Test after loadWindow, the windowStartByte and windowEndByte are updated to reflect
+     * the new window position based on the result from the reader.
+     */
     @Test
     fun testWindowByteOffsetsUpdatedAfterLoad() =
         runTest(testDispatcher) {
@@ -293,14 +322,45 @@ class TextEditorActivityViewModelTest {
             // Offsets should reflect the new window position from the result
             assertEquals(result!!.startByte, vm.windowStartByte)
             assertEquals(result!!.endByte, vm.windowEndByte)
+            assertEquals(TextEditorActivityViewModel.Direction.FORWARD, vm.lastLoadDirection)
             // Should have shifted
             assertTrue(vm.windowStartByte > originalStart || vm.windowEndByte > originalEnd)
 
             reader.close()
         }
 
-    // ── onCleared closes reader ──────────────────────────────────────
+    /**
+     * Test load direction metadata is updated only after a successful load.
+     */
+    @Test
+    fun testLastLoadDirectionUpdatedOnSuccessfulLoadOnly() =
+        runTest(testDispatcher) {
+            val vm = createWindowedViewModel()
+            val file = createLargeTestFile()
+            val reader = FileWindowReader.fromFile(file)
 
+            vm.fileWindowReader = reader
+            vm.totalFileSize = file.length()
+            vm.windowStartByte = 0L
+            vm.windowEndByte = 200L
+
+            vm.loadWindow(TextEditorActivityViewModel.Direction.BACKWARD)
+            advanceUntilIdle()
+
+            // No-op at start of file should keep direction unset
+            assertNull(vm.lastLoadDirection)
+
+            vm.loadWindow(TextEditorActivityViewModel.Direction.FORWARD)
+            advanceUntilIdle()
+
+            assertEquals(TextEditorActivityViewModel.Direction.FORWARD, vm.lastLoadDirection)
+            reader.close()
+        }
+
+    /**
+     * Test TextEditorActivityViewModel.onCleared properly closes FileWindowReader to release
+     * resources.
+     */
     @Test
     fun testOnClearedClosesReader() {
         val vm = TextEditorActivityViewModel()
@@ -319,14 +379,15 @@ class TextEditorActivityViewModelTest {
         var threwException = false
         try {
             reader.readWindow(0, 100)
-        } catch (e: Exception) {
+        } catch (_: Throwable) {
             threwException = true
         }
         assertTrue("Reader should be closed after onCleared", threwException)
     }
 
-    // ── Direction enum values ────────────────────────────────────────
-
+    /**
+     * Test that the Direction enum has the expected values and order.
+     */
     @Test
     fun testDirectionEnum() {
         val values = TextEditorActivityViewModel.Direction.values()
@@ -334,8 +395,6 @@ class TextEditorActivityViewModelTest {
         assertEquals(TextEditorActivityViewModel.Direction.FORWARD, values[0])
         assertEquals(TextEditorActivityViewModel.Direction.BACKWARD, values[1])
     }
-
-    // ── Helpers ──────────────────────────────────────────────────────
 
     /** Creates a ViewModel configured for windowed mode with testDispatcher for IO. */
     private fun createWindowedViewModel(): TextEditorActivityViewModel {

--- a/app/src/test/java/com/amaze/filemanager/ui/activities/texteditor/TextEditorActivityViewModelTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/ui/activities/texteditor/TextEditorActivityViewModelTest.kt
@@ -1,0 +1,342 @@
+/*
+ * Copyright (C) 2014-2024 Arpit Khurana <arpitkh96@gmail.com>, Vishal Nehra <vishalmeham2@gmail.com>,
+ * Emmanuel Messulam<emmanuelbendavid@gmail.com>, Raymond Lai <airwave209gt at gmail.com> and Contributors.
+ *
+ * This file is part of Amaze File Manager.
+ *
+ * Amaze File Manager is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.amaze.filemanager.ui.activities.texteditor
+
+import android.os.Build
+import android.os.Build.VERSION_CODES.LOLLIPOP
+import android.os.Build.VERSION_CODES.P
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.amaze.filemanager.asynchronous.asynctasks.texteditor.read.FileWindowReader
+import com.amaze.filemanager.shadows.ShadowMultiDex
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import java.io.File
+
+/**
+ * Tests for [TextEditorActivityViewModel] windowed mode state and loadWindow logic.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(AndroidJUnit4::class)
+@Config(
+    shadows = [ShadowMultiDex::class],
+    sdk = [LOLLIPOP, P, Build.VERSION_CODES.R],
+)
+class TextEditorActivityViewModelTest {
+    @get:Rule
+    val instantTaskRule = InstantTaskExecutorRule()
+
+    @get:Rule
+    val tempFolder = TemporaryFolder()
+
+    private val testDispatcher = StandardTestDispatcher()
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    // ── Default state ────────────────────────────────────────────────
+
+    @Test
+    fun testDefaultStateNotWindowed() {
+        val vm = TextEditorActivityViewModel()
+        assertFalse(vm.isWindowed)
+        assertNull(vm.fileWindowReader)
+        assertEquals(0L, vm.windowStartByte)
+        assertEquals(0L, vm.windowEndByte)
+        assertEquals(0L, vm.totalFileSize)
+        assertNull(vm.windowContent.value)
+    }
+
+    @Test
+    fun testDefaultNonWindowedState() {
+        val vm = TextEditorActivityViewModel()
+        assertNull(vm.original)
+        assertNull(vm.cacheFile)
+        assertFalse(vm.modified)
+        assertEquals(-1, vm.current)
+        assertEquals(0, vm.line)
+        assertTrue(vm.searchResultIndices.isEmpty())
+    }
+
+    // ── Windowed state initialization ────────────────────────────────
+
+    @Test
+    fun testInitializeWindowedMode() {
+        val vm = TextEditorActivityViewModel()
+        val file = createLargeTestFile()
+        val reader = FileWindowReader.fromFile(file)
+
+        vm.isWindowed = true
+        vm.fileWindowReader = reader
+        vm.totalFileSize = file.length()
+        vm.windowStartByte = 0L
+        vm.windowEndByte = 1000L
+
+        assertTrue(vm.isWindowed)
+        assertNotNull(vm.fileWindowReader)
+        assertEquals(file.length(), vm.totalFileSize)
+        assertEquals(0L, vm.windowStartByte)
+        assertEquals(1000L, vm.windowEndByte)
+
+        reader.close()
+    }
+
+    // ── loadWindow: forward ──────────────────────────────────────────
+
+    @Test
+    fun testLoadWindowForward() =
+        runTest(testDispatcher) {
+            val vm = createWindowedViewModel()
+            val file = createLargeTestFile()
+            val reader = FileWindowReader.fromFile(file)
+
+            vm.fileWindowReader = reader
+            vm.totalFileSize = file.length()
+            vm.windowStartByte = 0L
+            vm.windowEndByte = 200L
+
+            // Observe LiveData
+            var result: FileWindowReader.WindowResult? = null
+            vm.windowContent.observeForever { result = it }
+
+            vm.loadWindow(TextEditorActivityViewModel.Direction.FORWARD)
+            advanceUntilIdle()
+
+            assertNotNull(result)
+            assertTrue("Window should have shifted forward", vm.windowStartByte > 0L)
+            assertTrue(result!!.text.isNotEmpty())
+
+            reader.close()
+        }
+
+    // ── loadWindow: backward ─────────────────────────────────────────
+
+    @Test
+    fun testLoadWindowBackward() =
+        runTest(testDispatcher) {
+            val vm = createWindowedViewModel()
+            val file = createLargeTestFile()
+            val reader = FileWindowReader.fromFile(file)
+
+            vm.fileWindowReader = reader
+            vm.totalFileSize = file.length()
+            // Start at a mid-file position
+            vm.windowStartByte = 500L
+            vm.windowEndByte = 700L
+
+            var result: FileWindowReader.WindowResult? = null
+            vm.windowContent.observeForever { result = it }
+
+            vm.loadWindow(TextEditorActivityViewModel.Direction.BACKWARD)
+            advanceUntilIdle()
+
+            assertNotNull(result)
+            assertTrue("Window should have shifted backward", vm.windowStartByte < 500L)
+            assertTrue(result!!.text.isNotEmpty())
+
+            reader.close()
+        }
+
+    // ── loadWindow: no-op at boundaries ──────────────────────────────
+
+    @Test
+    fun testLoadWindowForwardNoOpAtEndOfFile() =
+        runTest(testDispatcher) {
+            val vm = createWindowedViewModel()
+            val file = createLargeTestFile()
+            val reader = FileWindowReader.fromFile(file)
+
+            vm.fileWindowReader = reader
+            vm.totalFileSize = file.length()
+            // Position at the end
+            vm.windowStartByte = file.length() - 100
+            vm.windowEndByte = file.length()
+
+            var result: FileWindowReader.WindowResult? = null
+            vm.windowContent.observeForever { result = it }
+
+            vm.loadWindow(TextEditorActivityViewModel.Direction.FORWARD)
+            advanceUntilIdle()
+
+            // Should not have emitted anything (no-op)
+            assertNull(result)
+
+            reader.close()
+        }
+
+    @Test
+    fun testLoadWindowBackwardNoOpAtStartOfFile() =
+        runTest(testDispatcher) {
+            val vm = createWindowedViewModel()
+            val file = createLargeTestFile()
+            val reader = FileWindowReader.fromFile(file)
+
+            vm.fileWindowReader = reader
+            vm.totalFileSize = file.length()
+            vm.windowStartByte = 0L
+            vm.windowEndByte = 200L
+
+            var result: FileWindowReader.WindowResult? = null
+            vm.windowContent.observeForever { result = it }
+
+            vm.loadWindow(TextEditorActivityViewModel.Direction.BACKWARD)
+            advanceUntilIdle()
+
+            // Should not have emitted anything (no-op)
+            assertNull(result)
+
+            reader.close()
+        }
+
+    // ── loadWindow: no-op when no reader ─────────────────────────────
+
+    @Test
+    fun testLoadWindowNoOpWithoutReader() =
+        runTest(testDispatcher) {
+            val vm = createWindowedViewModel()
+            // No fileWindowReader set
+            vm.fileWindowReader = null
+
+            var result: FileWindowReader.WindowResult? = null
+            vm.windowContent.observeForever { result = it }
+
+            vm.loadWindow(TextEditorActivityViewModel.Direction.FORWARD)
+            advanceUntilIdle()
+
+            assertNull(result)
+        }
+
+    // ── Window byte offsets updated after load ───────────────────────
+
+    @Test
+    fun testWindowByteOffsetsUpdatedAfterLoad() =
+        runTest(testDispatcher) {
+            val vm = createWindowedViewModel()
+            val file = createLargeTestFile()
+            val reader = FileWindowReader.fromFile(file)
+
+            vm.fileWindowReader = reader
+            vm.totalFileSize = file.length()
+            vm.windowStartByte = 0L
+            vm.windowEndByte = 400L
+
+            val originalStart = vm.windowStartByte
+            val originalEnd = vm.windowEndByte
+
+            var result: FileWindowReader.WindowResult? = null
+            vm.windowContent.observeForever { result = it }
+
+            vm.loadWindow(TextEditorActivityViewModel.Direction.FORWARD)
+            advanceUntilIdle()
+
+            assertNotNull(result)
+            // Offsets should reflect the new window position from the result
+            assertEquals(result!!.startByte, vm.windowStartByte)
+            assertEquals(result!!.endByte, vm.windowEndByte)
+            // Should have shifted
+            assertTrue(vm.windowStartByte > originalStart || vm.windowEndByte > originalEnd)
+
+            reader.close()
+        }
+
+    // ── onCleared closes reader ──────────────────────────────────────
+
+    @Test
+    fun testOnClearedClosesReader() {
+        val vm = TextEditorActivityViewModel()
+        val file = createSmallTestFile()
+        val reader = FileWindowReader.fromFile(file)
+        vm.fileWindowReader = reader
+
+        // Trigger onCleared via reflection (it's protected)
+        val method =
+            TextEditorActivityViewModel::class.java
+                .getDeclaredMethod("onCleared")
+        method.isAccessible = true
+        method.invoke(vm)
+
+        // Verify the reader was closed (reading should throw or return empty)
+        var threwException = false
+        try {
+            reader.readWindow(0, 100)
+        } catch (e: Exception) {
+            threwException = true
+        }
+        assertTrue("Reader should be closed after onCleared", threwException)
+    }
+
+    // ── Direction enum values ────────────────────────────────────────
+
+    @Test
+    fun testDirectionEnum() {
+        val values = TextEditorActivityViewModel.Direction.values()
+        assertEquals(2, values.size)
+        assertEquals(TextEditorActivityViewModel.Direction.FORWARD, values[0])
+        assertEquals(TextEditorActivityViewModel.Direction.BACKWARD, values[1])
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────
+
+    /** Creates a ViewModel configured for windowed mode with testDispatcher for IO. */
+    private fun createWindowedViewModel(): TextEditorActivityViewModel {
+        val vm = TextEditorActivityViewModel()
+        vm.isWindowed = true
+        vm.ioDispatcher = testDispatcher
+        return vm
+    }
+
+    private fun createLargeTestFile(): File {
+        val file = tempFolder.newFile("large.txt")
+        val lines = (1..500).map { "Line number $it with some padding content\n" }
+        file.writeText(lines.joinToString(""))
+        return file
+    }
+
+    private fun createSmallTestFile(): File {
+        val file = tempFolder.newFile("small.txt")
+        file.writeText("Hello\nWorld\n")
+        return file
+    }
+}

--- a/app/src/test/scripts/create-huge-complex-markdown.sh
+++ b/app/src/test/scripts/create-huge-complex-markdown.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 output="realistic.md"
 > "$output"
 
-for i in {1..20}; do
+for i in {1..2}; do
   cat <<PART >> "$output"
 
 # Document #$i – $(date --utc +%Y-%m-%dT%H:%M:%SZ)
@@ -34,17 +34,17 @@ $(for ((j=1; j<=300; j++)); do
 
 [
 $(for ((k=1; k<=80; k++)); do
-    # Smaller random payload to keep generation speed reasonable
-    payload=$(head -c $((60 + (k % 140))) /dev/urandom 2>/dev/null | base64 -w 0 | head -c 120)
-    cat <<JSON
+    json=$(cat <<JSON
   {
     "id": $((i*1000 + k)),
     "timestamp": "$(date --utc +%Y-%m-%dT%H:%M:%SZ)",
     "event": "click",
-    "payload": "$payload",
+    "payload": "$(head -c $((60 + (k % 140))) /dev/urandom 2>/dev/null | base64 -w 0 | head -c 120)",
     "ip": "192.168.$((i % 255)).$((k % 255))"
   }$( [[ $k -lt 80 ]] && echo "," || echo "" )
 JSON
+)
+    echo "$json"
   done
 )
 
@@ -65,13 +65,13 @@ done)
 
 ## Image & link references
 
-![Widget $(printf %04d $i)](https://picsum.photos/seed/doc$i/1200/800?grayscale)
+![Widget $(printf "%04d$i")](https://picsum.photos/seed/doc$i/1200/800?grayscale)
 → [Open report #$i](https://demo.app/reports/$i?token=$(head -c 8 /dev/urandom | xxd -p -c 16))
 
 PART
 
   # Show progress
-  (( i % 200 == 0 )) && du -h "$output" | awk '{print "  → " $1 " so far (document " "'$i'")}'
+  (( i % 200 == 0 )) && du -h "$output" | awk "{print \"  → \" $1 \" so far (document \" \"'$i'\")}"
 
 done
 

--- a/app/src/test/scripts/create-huge-complex-markdown.sh
+++ b/app/src/test/scripts/create-huge-complex-markdown.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+output="realistic.md"
+> "$output"
+
+for i in {1..20}; do
+  cat <<PART >> "$output"
+
+# Document #$i – $(date --utc +%Y-%m-%dT%H:%M:%SZ)
+
+This is sample paragraph content repeated for realistic document size testing.
+Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+
+## Recent log excerpt (simulated)
+
+$(for ((j=1; j<=300; j++)); do
+    seconds_ago=$(( (i*17 + j*3) % 86400 ))
+    ts=$(date --utc --date "now - ${seconds_ago} seconds" +%Y-%m-%dT%H:%M:%S.%3NZ 2>/dev/null || date --utc +%Y-%m-%dT%H:%M:%S.%3NZ)
+
+    # Rotate log level without array (POSIX-friendly)
+    case $((j % 4)) in
+      0) level="INFO"  ;;
+      1) level="WARN"  ;;
+      2) level="ERROR" ;;
+      *) level="DEBUG" ;;
+    esac
+
+    user="user$((1000 + (i+j) % 9000))@example.com"
+    echo "$ts [$level] Processing request id=${i}j${j} from $user – status=success"
+  done)
+
+## JSON payload sample
+
+[
+$(for ((k=1; k<=80; k++)); do
+    # Smaller random payload to keep generation speed reasonable
+    payload=$(head -c $((60 + (k % 140))) /dev/urandom 2>/dev/null | base64 -w 0 | head -c 120)
+    cat <<JSON
+  {
+    "id": $((i*1000 + k)),
+    "timestamp": "$(date --utc +%Y-%m-%dT%H:%M:%SZ)",
+    "event": "click",
+    "payload": "$payload",
+    "ip": "192.168.$((i % 255)).$((k % 255))"
+  }$( [[ $k -lt 80 ]] && echo "," || echo "" )
+JSON
+  done
+)
+
+## Recent activity log (table)
+
+| Time                  | User                        | Action             | Amount    | Status     | Location          |
+|-----------------------|-----------------------------|--------------------|-----------|------------|-------------------|
+$(for ((r=1; r<=40; r++)); do
+  mins_ago=$(( (i*11 + r*7) % 1440 ))
+  ts=$(date --utc --date "now - ${mins_ago} minutes" +%H:%M:%S)
+  user="u$(printf "%04d" $((8000 + (i+r) % 1999)))"
+  action=$(printf "%s" "view" "purchase" "update" "login" "search" "cart" | shuf -n1)
+  amount=$(printf "%.2f" "$(echo "scale=2; 5 + $RANDOM % 380" | bc)")
+  status=$(printf "%s" "success" "success" "success" "failed" "pending" | shuf -n1)
+  loc=$(printf "%s" "EU-West" "US-East" "AP-Southeast" "US-West" "EU-Central" | shuf -n1)
+  printf "| %s | %s@example.com | %s | \$%s | %s | %s |\n" "$ts" "$user" "$action" "$amount" "$status" "$loc"
+done)
+
+## Image & link references
+
+![Widget $(printf %04d $i)](https://picsum.photos/seed/doc$i/1200/800?grayscale)
+→ [Open report #$i](https://demo.app/reports/$i?token=$(head -c 8 /dev/urandom | xxd -p -c 16))
+
+PART
+
+  # Show progress
+  (( i % 200 == 0 )) && du -h "$output" | awk '{print "  → " $1 " so far (document " "'$i'")}'
+
+done
+
+# Big final block (~250–300 MB)
+echo -e "\n\n# Large base64 attachment (simulated binary)\n\`\`\`text" >> "$output"
+head -c $((280 * 1024 * 1024)) /dev/urandom | base64 -w 76 >> "$output" 2>/dev/null
+echo '```' >> "$output"
+
+echo "Done. Final size:"
+du -h "$output"

--- a/app/src/test/scripts/create-huge-markdown-with-images.sh
+++ b/app/src/test/scripts/create-huge-markdown-with-images.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+printf '# Huge link & image reference test\n' > links.md
+
+printf '![Image %05d](https://picsum.photos/seed/img%05d/800/600)\n' {0..19999} {0..19999} >> links.md

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,6 +29,7 @@ androidXPalette = "1.0.0"
 androidXCardView = "1.0.0"
 androidXConstraintLayout = "1.1.3"
 androidXBiometric = "1.1.0"
+androidXLifecycle = "2.6.2"
 androidXTest = "1.6.1"
 androidXTestRunner = "1.6.2"
 androidXTestExt = "1.2.1"
@@ -95,6 +96,8 @@ androidX-palette = { module = "androidx.palette:palette-ktx", version.ref = "and
 androidX-preference = { module = "androidx.preference:preference-ktx", version.ref = "androidXPref" }
 androidX-vectordrawable-animated = { module = "androidx.vectordrawable:vectordrawable-animated", version.ref = "vectordrawableAnimated" }
 androidX-biometric = { module = "androidx.biometric:biometric", version.ref = "androidXBiometric" }
+androidX-lifecycle-viewmodel-ktx = { module = "androidx.lifecycle:lifecycle-viewmodel-ktx", version.ref = "androidXLifecycle" }
+androidX-lifecycle-livedata-ktx = { module = "androidx.lifecycle:lifecycle-livedata-ktx", version.ref = "androidXLifecycle" }
 
 androidX-test-core = { module = "androidx.test:core", version.ref = "androidXTest" }
 androidX-test-runner = { module = "androidx.test:runner", version.ref = "androidXTestRunner" }
@@ -124,6 +127,8 @@ jsoup = { module = "org.jsoup:jsoup", version.ref = "jsoup" }
 
 kotlin-stdlib-jdk8 = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8", version.ref = "kotlinStdlibJdk8" }
 kotlin-coroutine-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinxCoroutines" }
+kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinxCoroutines" }
+kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "kotlinxCoroutines" }
 
 libsu-core = { module = "com.github.topjohnwu.libsu:core", version.ref = "libsu" }
 libsu-io = { module = "com.github.topjohnwu.libsu:io", version.ref = "libsu" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -35,6 +35,7 @@ androidXTestRunner = "1.6.2"
 androidXTestExt = "1.2.1"
 androidXArchCoreTest = "2.2.0"
 androidXMultidex = "2.0.1"
+androidDesugaring = "2.1.5"
 autoService = "1.1.1"
 kotlinxCoroutines = "1.7.3"
 kotlinStdlibJdk8 = "1.9.20"
@@ -99,6 +100,7 @@ androidX-vectordrawable-animated = { module = "androidx.vectordrawable:vectordra
 androidX-biometric = { module = "androidx.biometric:biometric", version.ref = "androidXBiometric" }
 androidX-lifecycle-viewmodel-ktx = { module = "androidx.lifecycle:lifecycle-viewmodel-ktx", version.ref = "androidXLifecycle" }
 androidX-lifecycle-livedata-ktx = { module = "androidx.lifecycle:lifecycle-livedata-ktx", version.ref = "androidXLifecycle" }
+android-desugaring = { module = "com.android.tools:desugar_jdk_libs", version.ref = "androidDesugaring" }
 
 androidX-test-core = { module = "androidx.test:core", version.ref = "androidXTest" }
 androidX-test-runner = { module = "androidx.test:runner", version.ref = "androidXTestRunner" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -74,6 +74,7 @@ concurrentTrees = "2.6.1"
 aboutLibraries = "6.1.1"
 amazeTrashBin = "1.0.10"
 rustAndroidGradle = "0.9.6"
+commonmark = "0.27.1"
 
 [libraries]
 gradle = { module = "com.android.tools.build:gradle", version.ref = "gradle" }
@@ -181,3 +182,7 @@ acra-core = { module = "ch.acra:acra-core", version.ref = "acraCore" }
 leakcanary-android = { module = "com.squareup.leakcanary:leakcanary-android", version.ref = "leakcanaryAndroid" }
 
 amaze-trashBin = { module = "com.github.TeamAmaze:AmazeTrashBin", version.ref = "amazeTrashBin" }
+
+commonmark = { module = "org.commonmark:commonmark", version.ref = "commonmark" }
+commonmark-ext-gfm-tables = { module = "org.commonmark:commonmark-ext-gfm-tables", version.ref = "commonmark" }
+commonmark-ext-gfm-strikethrough = { module = "org.commonmark:commonmark-ext-gfm-strikethrough", version.ref = "commonmark" }


### PR DESCRIPTION
## Description

Implement support for big files and Markdown preview.

With this PR, sliding window is used for buffering big files to prevent OutOfMemory error.

https://github.com/user-attachments/assets/814b5490-ee59-4236-84e6-3363d7de17b3

The sliding window currently is set to 102400 characters.

Additionally, using https://github.com/commonmark/commonmark-java support for Markdown preview is also added.

<img width="306" height="675" alt="Screenshot_20260226-223920_Amaze Debug" src="https://github.com/user-attachments/assets/dfa74697-4c12-462c-83bf-3495ea60a6df" />
<img width="306" height="675" alt="Screenshot_20260226-223930_Amaze Debug" src="https://github.com/user-attachments/assets/188a0429-a5f8-4720-8215-d5b89aca55cd" />

Note however, due to the way Commonmark works that it doesn't support dynamically updating output HTML from InputStream, when switching to Markdown preview, it will only render what's inside the sliding window above, if file content is bigger than the sliding window.

#### Issue tracker   

#### Automatic tests
<!-- remember to do manual testing when making UI changes! -->
- [x] Added test cases
  
#### Manual tests
- [x] Done  

Device: Fairphone 5
OS: LineageOS 23.2 (Android 16)  

#### Build tasks success  
Successfully running following tasks on local:
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`