### PR TITLE
Fix file rename in drawer views

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/ui/fragments/MainFragment.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/fragments/MainFragment.java
@@ -1042,13 +1042,14 @@ public class MainFragment extends Fragment
               AppCompatEditText textfield =
                   dialog.getCustomView().findViewById(R.id.singleedittext_input);
               String name1 = textfield.getText().toString().trim();
+              String targetParent = f.getParent(requireContext());
 
               getMainActivity()
                   .mainActivityHelper
                   .rename(
-                      mainFragmentViewModel.getOpenMode(),
+                      f.getMode(),
                       f.getPath(),
-                      mainFragmentViewModel.getCurrentPath(),
+                      targetParent,
                       name1,
                       f.isDirectory(),
                       getActivity(),


### PR DESCRIPTION
Use file mode and parent directory from the selected item when invoking rename instead of fragment navigation state.

## Description

Rename operations launched from drawer category views could fail with
**Operation Unsuccessful** even when the same file could be renamed
successfully from a normal filesystem directory.

`MainFragment.rename()` was invoking rename using the fragment's current
navigation state:

* `mainFragmentViewModel.getOpenMode()`
* `mainFragmentViewModel.getCurrentPath()`

In drawer category views, those values represent the current category
view rather than the selected file's actual filesystem location.

This change uses the selected item's filesystem context instead:

* file mode via `f.getMode()`
* parent directory via `f.getParent(requireContext())`

Rename operations now resolve against the selected file's actual
location rather than the fragment's current navigation state.

#### Issue tracker
Fixes #4560

#### Automatic tests
- [ ] Added test cases

#### Manual tests
- [x] Done

- Device: Pixel 9 Pro emulator
- OS: Android 16
- Rooted: No
- Version: 3.11.2

#### Build tasks success
Successfully running following tasks on local:
- [x] `./gradlew assembleDebug`
- [x] `./gradlew spotlessCheck`