### PR TITLE
Fix edit SMB connection unable to populate value to dialog

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/ui/dialogs/SmbConnectDialog.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/dialogs/SmbConnectDialog.java
@@ -32,7 +32,6 @@ import static java.net.URLEncoder.encode;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
-import java.net.URL;
 import java.security.GeneralSecurityException;
 
 import org.slf4j.Logger;
@@ -55,6 +54,7 @@ import com.google.android.material.textfield.TextInputLayout;
 
 import android.app.Dialog;
 import android.content.Context;
+import android.net.Uri;
 import android.net.UrlQuerySanitizer;
 import android.os.Bundle;
 import android.text.Editable;
@@ -258,7 +258,7 @@ public class SmbConnectDialog extends DialogFragment {
 
       conName.setText(name);
       try {
-        URL a = new URL(path);
+        Uri a = Uri.parse(path);
         String userinfo = a.getUserInfo();
         if (userinfo != null) {
           String inf = decode(userinfo, Charsets.UTF_8.name());
@@ -296,8 +296,6 @@ public class SmbConnectDialog extends DialogFragment {
         }
       } catch (UnsupportedEncodingException | IllegalArgumentException e) {
         LOG.warn("failed to load smb dialog info for path {}", path, e);
-      } catch (MalformedURLException e) {
-        LOG.warn("failed to load smb dialog info", e);
       }
 
     } else if (path != null && path.length() > 0) {

--- a/app/src/test/java/com/amaze/filemanager/ui/dialogs/SmbConnectDialogTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/ui/dialogs/SmbConnectDialogTest.kt
@@ -36,6 +36,7 @@ import com.amaze.filemanager.utils.smb.SmbUtil
 import io.mockk.confirmVerified
 import io.mockk.spyk
 import io.mockk.verify
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.robolectric.shadows.ShadowDialog
@@ -45,6 +46,64 @@ import org.robolectric.shadows.ShadowLooper
  * Tests [SmbConnectDialog].
  */
 class SmbConnectDialogTest : AbstractMainActivityTestBase() {
+    /**
+     * Test editing an existing connection pre-fills all dialog fields.
+     * Regression test for https://github.com/TeamAmaze/AmazeFileManager/issues/4543
+     */
+    @Test
+    fun testEditConnectionPreFillsAllFields() {
+        val listener = spyk<SmbConnectionListener>()
+        val encryptedPath =
+            SmbUtil.getSmbEncryptedPath(
+                AppConfig.getInstance(),
+                "smb://user:password@192.168.1.100/share",
+            )
+        doTestWithDialog(
+            listener = listener,
+            arguments =
+                Bundle().also {
+                    it.putString(ARG_NAME, "My SMB Connection")
+                    it.putString(ARG_PATH, encryptedPath)
+                    it.putBoolean(ARG_EDIT, true)
+                },
+            withDialog = { dialog, _ ->
+                dialog.binding.run {
+                    assertEquals("My SMB Connection", this.connectionET.text.toString())
+                    assertEquals("192.168.1.100", this.ipET.text.toString())
+                    assertEquals("share", this.shareET.text.toString())
+                    assertEquals("user", this.usernameET.text.toString())
+                    assertEquals("password", this.passwordET.text.toString())
+                }
+            },
+        )
+    }
+
+    /**
+     * Test editing an anonymous connection checks the anonymous checkbox.
+     * Regression test for https://github.com/TeamAmaze/AmazeFileManager/issues/4543
+     */
+    @Test
+    fun testEditAnonymousConnectionSetsAnonymousCheckbox() {
+        val listener = spyk<SmbConnectionListener>()
+        doTestWithDialog(
+            listener = listener,
+            arguments =
+                Bundle().also {
+                    it.putString(ARG_NAME, "Anonymous SMB")
+                    it.putString(ARG_PATH, "smb://192.168.1.100/share")
+                    it.putBoolean(ARG_EDIT, true)
+                },
+            withDialog = { dialog, _ ->
+                dialog.binding.run {
+                    assertEquals("Anonymous SMB", this.connectionET.text.toString())
+                    assertEquals("192.168.1.100", this.ipET.text.toString())
+                    assertEquals("share", this.shareET.text.toString())
+                    assertTrue(this.chkSmbAnonymous.isChecked)
+                }
+            },
+        )
+    }
+
     /**
      * Test call to [SmbConnectionListener.addConnection] is encrypted path.
      */


### PR DESCRIPTION
## Description

Fix parsing SMB URL by using `android.net.Uri` instead of `java.net.URL` to fix connection settings persistence.

#### Issue tracker   
Fixes #4543

#### Automatic tests
<!-- remember to do manual testing when making UI changes! -->
- [x] Added test cases
  
#### Manual tests
- [x] Done  
  
- Device: Pixel 4 XL emulator
- OS: Android 9 

Changing SMB connection name shall keep the connection settings intact and working, even across restarts.

https://github.com/user-attachments/assets/e5ca5130-7e7e-4ffc-951e-f690a2cb2e78

#### Build tasks success  
Successfully running following tasks on local:
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`
