### PR TITLE
Make `getPathsInPath` function more robust, including null handling

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/filesystem/files/FileUtils.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/files/FileUtils.java
@@ -586,7 +586,7 @@ public class FileUtils {
    * ["smb://user;workgroup:passw0rd@12.3.4", "smb://user;workgroup:passw0rd@12.3.4/user", "smb://user;workgroup:passw0rd@12.3.4/user/Documents", "smb://user;workgroup:passw0rd@12.3.4/user/Documents/flare.doc"]
    * </code>
    *
-   * @param path
+   * @param pathParam
    * @return string array of incremental path segments
    */
   public static String[] getPathsInPath(String pathParam) {

--- a/app/src/main/java/com/amaze/filemanager/filesystem/files/FileUtils.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/files/FileUtils.java
@@ -589,12 +589,12 @@ public class FileUtils {
    * @param path
    * @return string array of incremental path segments
    */
-  public static String[] getPathsInPath(String path) {
-
+  public static String[] getPathsInPath(String pathParam) {
+    String path = pathParam;
     path = path.trim();
-    if (path == "") {
+    if (path.equals("")) {
       return new String[0];
-    } else if (path == "/") {
+    } else if (path.equals("/")) {
       return new String[] {"/"};
     }
     if (path.endsWith("/")) {

--- a/app/src/main/java/com/amaze/filemanager/filesystem/files/FileUtils.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/files/FileUtils.java
@@ -590,22 +590,34 @@ public class FileUtils {
    * @return string array of incremental path segments
    */
   public static String[] getPathsInPath(String path) {
+
+    path = path.trim();
+    if (path == "") {
+      return new String[0];
+    } else if (path == "/") {
+      return new String[] {"/"};
+    }
     if (path.endsWith("/")) {
       path = path.substring(0, path.length() - 1);
     }
     path = path.trim();
 
-    ArrayList<String> paths = new ArrayList<>();
     @Nullable String urlPrefix = null;
     @Nullable Pair<String, String> splitUri = splitUri(path);
     if (splitUri != null) {
       urlPrefix = splitUri.first;
       path = splitUri.second;
+
+      if (path == null) {
+        return new String[] {urlPrefix};
+      }
     }
 
     if (!path.startsWith("/")) {
       path = "/" + path;
     }
+
+    ArrayList<String> paths = new ArrayList<>();
 
     while (path.length() > 0) {
       if (urlPrefix != null) {

--- a/app/src/main/java/com/amaze/filemanager/filesystem/files/FileUtils.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/files/FileUtils.java
@@ -592,9 +592,10 @@ public class FileUtils {
   public static String[] getPathsInPath(String pathParam) {
     String path = pathParam;
     path = path.trim();
-    if (path.equals("")) {
+    if (path.isEmpty()) {
       return new String[0];
-    } else if (path.equals("/")) {
+    }
+    if (path.equals("/")) {
       return new String[] {"/"};
     }
     if (path.endsWith("/")) {
@@ -617,8 +618,23 @@ public class FileUtils {
       path = "/" + path;
     }
 
-    ArrayList<String> paths = new ArrayList<>();
+    ArrayList<String> paths = buildPaths(path, urlPrefix);
 
+    paths.add(urlPrefix != null ? urlPrefix : "/");
+    Collections.reverse(paths);
+
+    return paths.toArray(new String[0]);
+  }
+
+  /**
+   * Splits a given path to URI prefix (if exists) and path.
+   *
+   * @param pathParam
+   * @return string array of incremental path segments
+   */
+  public static ArrayList<String> buildPaths(String pathParam, String urlPrefix) {
+    ArrayList<String> paths = new ArrayList<>();
+    String path = pathParam;
     while (path.length() > 0) {
       if (urlPrefix != null) {
         paths.add(urlPrefix + path);
@@ -631,15 +647,7 @@ public class FileUtils {
         break;
       }
     }
-
-    if (urlPrefix != null) {
-      paths.add(urlPrefix);
-    } else {
-      paths.add("/");
-    }
-    Collections.reverse(paths);
-
-    return paths.toArray(new String[0]);
+    return paths;
   }
 
   /**

--- a/app/src/test/java/com/amaze/filemanager/filesystem/files/FileUtilsTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/filesystem/files/FileUtilsTest.kt
@@ -42,7 +42,7 @@ import java.util.TimeZone
 @Suppress("TooManyFunctions", "StringLiteralDuplication")
 class FileUtilsTest {
     /**
-     * Test FileUtils.getPathsInPath() for directory
+     * Test FileUtils.getPathsInPath() with empty
      *
      * @see FileUtils.getPathsInPath
      */
@@ -57,6 +57,11 @@ class FileUtilsTest {
         }
     }
 
+    /**
+     * Test FileUtils.getPathsInPath() with just whitespace
+     *
+     * @see FileUtils.getPathsInPath
+     */
     @Test
     fun testGetPathsInPathForWhitespace() {
         getPathsInPath(" ").run {
@@ -68,6 +73,11 @@ class FileUtilsTest {
         }
     }
 
+    /**
+     * Test FileUtils.getPathsInPath() with single slash
+     *
+     * @see FileUtils.getPathsInPath
+     */
     @Test
     fun testGetPathsInPathForSingleSlash() {
         getPathsInPath("/").run {
@@ -81,6 +91,11 @@ class FileUtilsTest {
         }
     }
 
+    /**
+     * Test FileUtils.getPathsInPath() for folder with slash at end
+     *
+     * @see FileUtils.getPathsInPath
+     */
     @Test
     fun testGetPathsInPathForSingleFolderWithSlashAtEnd() {
         getPathsInPath("/dir/").run {
@@ -95,6 +110,11 @@ class FileUtilsTest {
         }
     }
 
+    /**
+     * Test FileUtils.getPathsInPath() for directory
+     *
+     * @see FileUtils.getPathsInPath
+     */
     @Test
     fun testGetPathsInPathForFolder() {
         getPathsInPath("/etc/default/grub/2/conf.d").run {

--- a/app/src/test/java/com/amaze/filemanager/filesystem/files/FileUtilsTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/filesystem/files/FileUtilsTest.kt
@@ -256,6 +256,25 @@ class FileUtilsTest {
     }
 
     /**
+     * Test FileUtils.getPathsInPath() with an URI that is just a scheme.
+     *
+     * @see FileUtils.getPathsInPath
+     */
+    @Test
+    fun testGetPathsInPathOnlyScheme() {
+        getPathsInPath("file:///").run {
+            assertEquals(2, size)
+            assertArrayEquals(
+                arrayOf(
+                    "file://",
+                    "file:///",
+                ),
+                this,
+            )
+        }
+    }
+
+    /**
      * Test FileUtils.getPathsInPath() with SMB URI
      *
      * @see FileUtils.getPathsInPath

--- a/app/src/test/java/com/amaze/filemanager/filesystem/files/FileUtilsTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/filesystem/files/FileUtilsTest.kt
@@ -47,6 +47,55 @@ class FileUtilsTest {
      * @see FileUtils.getPathsInPath
      */
     @Test
+    fun testGetPathsInPathForEmpty() {
+        getPathsInPath("").run {
+            assertEquals(0, size)
+            assertArrayEquals(
+                arrayOf(),
+                this,
+            )
+        }
+    }
+
+    @Test
+    fun testGetPathsInPathForWhitespace() {
+        getPathsInPath(" ").run {
+            assertEquals(0, size)
+            assertArrayEquals(
+                arrayOf(),
+                this,
+            )
+        }
+    }
+
+    @Test
+    fun testGetPathsInPathForSingleSlash() {
+        getPathsInPath("/").run {
+            assertEquals(1, size)
+            assertArrayEquals(
+                arrayOf(
+                    "/",
+                ),
+                this,
+            )
+        }
+    }
+
+    @Test
+    fun testGetPathsInPathForSingleFolderWithSlashAtEnd() {
+        getPathsInPath("/dir/").run {
+            assertEquals(2, size)
+            assertArrayEquals(
+                arrayOf(
+                    "/",
+                    "/dir",
+                ),
+                this,
+            )
+        }
+    }
+
+    @Test
     fun testGetPathsInPathForFolder() {
         getPathsInPath("/etc/default/grub/2/conf.d").run {
             assertEquals(6, size)


### PR DESCRIPTION
## Description
Make getPathsInPath function more robust, including null handling

#### Issue tracker   
Fixes #4476

#### Automatic tests
- [x] Added unit tests for getPathsInPath function

#### Build tasks success  
Successfully running following tasks on local:
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`