### PR TITLE
Fix crash when rotating modify bookmark dialog

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/ui/activities/MainActivity.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/activities/MainActivity.java
@@ -2025,7 +2025,7 @@ public class MainActivity extends PermissionsActivity
   public void renameBookmark(final String title, final String path) {
     if (dataUtils.containsBooks(new String[] {title, path}) != -1) {
       RenameBookmark renameBookmark = RenameBookmark.getInstance(title, path, getAccent());
-      if (renameBookmark != null) renameBookmark.show(getFragmentManager(), "renamedialog");
+      if (renameBookmark != null) renameBookmark.show(getSupportFragmentManager(), "renamedialog");
     }
   }
 

--- a/app/src/main/java/com/amaze/filemanager/ui/dialogs/RenameBookmark.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/dialogs/RenameBookmark.java
@@ -29,7 +29,6 @@ import com.amaze.filemanager.utils.SimpleTextWatcher;
 import com.google.android.material.textfield.TextInputLayout;
 
 import android.app.Dialog;
-import android.app.DialogFragment;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.Bundle;
@@ -37,6 +36,7 @@ import android.text.Editable;
 import android.view.View;
 
 import androidx.appcompat.widget.AppCompatEditText;
+import androidx.fragment.app.DialogFragment;
 import androidx.preference.PreferenceManager;
 
 public class RenameBookmark extends DialogFragment {


### PR DESCRIPTION
## Description
Migrate RenameBookmark to AndroidX DialogFragment and update the launch path to use `getSupportFragmentManager()`.

This fixes a crash that could occur when the device is rotated while the Modify Bookmark dialog is open. After the migration, the dialog restores successfully after rotation and bookmark functionality continues to work as expected.

#### Issue tracker

Fixes #4433

#### Automatic tests

* [ ] Added unit tests for specific individual functions
* [ ] Added headless tests for new app functionality
* [ ] Added emulator tests for new UI elements

#### Manual tests

- [x] Done

* Device: Pixel 9 Pro emulator
* OS: Android 16

Verified manually:

* Modify Bookmark dialog restores after rotation without crashing
* Activity recreation completes successfully
* Rename works
* Delete works
* Cancel works
* Drawer refreshes correctly
* Bookmark changes persist after dialog restoration

Attached video demonstrates:

* Modify Bookmark dialog open during rotation
* Dialog restoration after activity recreation
* Successful bookmark rename after rotation
* No crash during the reproduction scenario

https://github.com/user-attachments/assets/87016f14-2fbf-417c-93fb-d796ec49fd9c

#### Build tasks success

Successfully running following tasks on local:

- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`

#### Generative code

- [x] This PR used generative code tools (GenAI, LLMs, etc.)

* Model: GPT-5.5
* Version: ChatGPT
* Provider: OpenAI