### PR TITLE
Fix IllegalArgumentException: list[n] is a repetition in getLocaleListFromXml

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/utils/ContextLocaleExt.kt
+++ b/app/src/main/java/com/amaze/filemanager/utils/ContextLocaleExt.kt
@@ -58,7 +58,26 @@ fun Context.getLocaleListFromXml(): LocaleListCompat {
         tagsList.remove("he")
     }
 
-    return LocaleListCompat.forLanguageTags(tagsList.joinToString(","))
+    return try {
+        val seenLocales = LinkedHashSet<Locale>()
+        val dedupedTags = mutableListOf<String>()
+
+        for (tag in tagsList) {
+            val resolvedLocale = Locale.forLanguageTag(tag.toString())
+            // add() returns false if an equal Locale was already seen -
+            // this mirrors exactly what LocaleList's own dedupe check does,
+            // so anything that would crash it gets filtered out here first.
+            if (seenLocales.add(resolvedLocale)) {
+                dedupedTags.add(tag.toString())
+            }
+        }
+
+        LocaleListCompat.forLanguageTags(dedupedTags.joinToString(","))
+    } catch (e: IllegalArgumentException) {
+        // Last-resort safety net for any OEM ICU quirk we didn't anticipate above.
+        e.printStackTrace()
+        LocaleListCompat.getEmptyLocaleList()
+    }
 }
 
 /**
@@ -91,9 +110,9 @@ fun Context.getLangPreferenceDropdownEntries(): Map<String, Locale> {
                 xmlLocale.getDisplayName(Locale.getDefault())
             } else {
                 val nameInCurrentLocale =
-                    currentLocaleList.first { locale ->
+                    currentLocaleList.firstOrNull { locale ->
                         xmlLocale.getDisplayName(locale).isNotEmpty()
-                    }
+                    } ?: Locale.getDefault()
 
                 xmlLocale.getDisplayName(nameInCurrentLocale)
             }


### PR DESCRIPTION
Fixes #4654

## Problem
On certain OEM Android TV firmwares (e.g. Kunft/AI PONT DVB91KT, Android 9),
opening Settings → Interface crashes with:

java.lang.IllegalArgumentException: list[49] is a repetition
at android.os.LocaleList.<init>

## Root cause
These devices ship a customized/older ICU implementation that canonicalizes
two different BCP-47 tags from locales_config.xml down to the exact same
java.util.Locale object. android.os.LocaleList's constructor rejects any
duplicate Locale in its input, so the crash only reproduces on this specific
firmware's ICU — stock/Pixel-like devices resolve every tag to a distinct
Locale and never hit this path.

## Fix
- getLocaleListFromXml() now resolves every tag to its actual Locale first
  and drops any tag whose resolved Locale has already been seen, pre-empting
  the exact condition LocaleList itself rejects — regardless of which tags
  collide on a given device/ICU build.
- Added a try/catch safety net around LocaleList construction, falling back
  to the empty locale list (system default) instead of crashing.
- Minor related hardening in getLangPreferenceDropdownEntries (firstOrNull
  instead of first, to avoid a similar NoSuchElementException edge case).

## Files changed
- `app/src/main/java/com/amaze/filemanager/utils/ContextLocaleExt.kt`
  - `getLocaleListFromXml()`: added dedup logic (`LinkedHashSet<Locale>` +
    filtered `dedupedTags` list) before calling
    `LocaleListCompat.forLanguageTags(...)`, wrapped in try/catch.
  - `getLangPreferenceDropdownEntries()`: changed `.first { }` to
    `.firstOrNull { } ?: Locale.getDefault()` in the display-name lookup.

## Testing
Verified locally that the dedup logic correctly filters resolved-duplicate
tags before they reach LocaleListCompat.forLanguageTags(). Could not
reproduce the exact colliding tag pair on stock JDK/Pixel ICU since it's
firmware-specific — the fix is intentionally defensive rather than removing
a specific hardcoded tag pair, since the offending pair will differ across
OEM ICU builds.