### PR TITLE
Notify user when renaming a file/folder to its original name

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/ui/fragments/MainFragment.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/fragments/MainFragment.java
@@ -1084,8 +1084,10 @@ public class MainFragment extends Fragment
               } else if (text.length() < 1) {
                 return new WarnableTextInputValidator.ReturnState(
                     WarnableTextInputValidator.ReturnState.STATE_ERROR, R.string.field_empty);
-              } else if (text.equals(f.getName(getMainActivity()))) {       
-                return new WarnableTextInputValidator.ReturnState(WarnableTextInputValidator.ReturnState.STATE_WARNING,R.string.no_changes_while_rename);                       
+              } else if (text.equals(f.getName(getMainActivity()))) {
+                return new WarnableTextInputValidator.ReturnState(
+                    WarnableTextInputValidator.ReturnState.STATE_WARNING,
+                    R.string.no_changes_while_rename);
               }
 
               return new WarnableTextInputValidator.ReturnState();

--- a/app/src/main/java/com/amaze/filemanager/ui/fragments/MainFragment.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/fragments/MainFragment.java
@@ -1084,6 +1084,8 @@ public class MainFragment extends Fragment
               } else if (text.length() < 1) {
                 return new WarnableTextInputValidator.ReturnState(
                     WarnableTextInputValidator.ReturnState.STATE_ERROR, R.string.field_empty);
+              } else if (text.equals(f.getName(getMainActivity()))) {       
+                return new WarnableTextInputValidator.ReturnState(WarnableTextInputValidator.ReturnState.STATE_WARNING,R.string.no_changes_while_rename);                       
               }
 
               return new WarnableTextInputValidator.ReturnState();


### PR DESCRIPTION
### **Problem**
  Opening the rename dialog and leaving the EditText value untouched
  (typing nothing, or simply not editing) provides no inline feedback
  that the operation is a no-op. The user must tap submit, the dialog
  closes, and a backend-side Toast appears — or, on plain local files,
  nothing visible happens at all. The user has already committed to
  tapping a destructive-looking button before being told the rename
  will do nothing.

###   **Root cause**
  The `rename` dialog's validator lambda in `MainFragment.rename(...)`
  covers only the invalid-filename, leading-space, and empty-text
  states. There is no branch that compares the typed text against the
  source file's current name and surfaces a result for that condition;
  the dialog relies on `MainActivityHelper.rename(...)` to detect
  the no-change case after the user has already submitted.

###   **Fix to** #4660 
  Added an additional branch to the validator lambda that returns
  `STATE_WARNING` carrying `R.string.no_changes_while_rename` whenever
  the typed text equals the source file's name. This renders inline
  beneath the EditText through the existing `WarnableTextInputLayout`
  helper-text area — the same surface used by `mkfile()` for its
  hidden-file and `.txt`-extension warnings — so no new UI elements
  are introduced and the layout matches the project's established
  pattern for inline dialog warnings.

###   **Files changed**
  app/src/main/java/com/amaze/filemanager/ui/fragments/MainFragment.java
  `rename(HybridFileParcelable f)` validator lambda: added an
  `else if (text.equals(f.getName(getMainActivity())))` branch that
  returns `WarnableTextInputValidator.ReturnState.STATE_WARNING` with
  `R.string.no_changes_while_rename`, then formatting pass via Spotless.
  No changes to `MainActivityHelper`, `Operations`, string resources,
  dialog layouts, or `WarnableTextInputValidator` itself.

###   **Testing**
  1. Long-press a folder/file → Rename.
  2. Leave the EditText value as the current name → verify the helper
     text "No changes were made as the new name matches the old name."
     appears below the EditText in the warning helper-text style.
  3. Type any extra character → warning disappears; revert → warning
     reappears.
     
  - Device: Vivo V27
  - OS: Android 14