### PR TITLE
Replace AsyncTask with RxJava for file list loading in MainFragment

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/LoadFilesListTask.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/LoadFilesListTask.java
@@ -31,6 +31,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.concurrent.CancellationException;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -58,7 +59,6 @@ import com.amaze.filemanager.ui.fragments.data.MainFragmentViewModel;
 import com.amaze.filemanager.utils.DataUtils;
 import com.amaze.filemanager.utils.GenericExtKt;
 import com.amaze.filemanager.utils.OTGUtil;
-import com.amaze.filemanager.utils.OnAsyncTaskFinished;
 import com.amaze.filemanager.utils.OnFileFound;
 import com.amaze.filemanager.utils.Utils;
 import com.amaze.trashbin.TrashBin;
@@ -72,7 +72,6 @@ import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
 import android.database.Cursor;
 import android.net.Uri;
-import android.os.AsyncTask;
 import android.os.Bundle;
 import android.provider.MediaStore;
 import android.text.format.Formatter;
@@ -88,10 +87,100 @@ import jcifs.smb.SmbException;
 import jcifs.smb.SmbFile;
 import kotlin.collections.CollectionsKt;
 
-public class LoadFilesListTask
-    extends AsyncTask<Void, Throwable, Pair<OpenMode, List<LayoutElementParcelable>>> {
+public class LoadFilesListTask {
 
   private static final Logger LOG = LoggerFactory.getLogger(LoadFilesListTask.class);
+
+  public Pair<OpenMode, List<LayoutElementParcelable>> load() throws Exception {
+
+    final MainFragment mainFragment = this.mainFragmentReference.get();
+    final Context context = this.context.get();
+
+    if (mainFragment == null
+        || context == null
+        || mainFragment.getMainFragmentViewModel() == null
+        || mainFragment.getMainActivityViewModel() == null
+        || path == null) {
+
+      throw new CancellationException();
+    }
+
+    HybridFile hFile = null;
+
+    MainFragmentViewModel mainFragmentViewModel = mainFragment.getMainFragmentViewModel();
+
+    MainActivityViewModel mainActivityViewModel = mainFragment.getMainActivityViewModel();
+
+    if (OpenMode.UNKNOWN.equals(openmode)
+        || OpenMode.CUSTOM.equals(openmode)
+        || OpenMode.TRASH_BIN.equals(openmode)) {
+
+      hFile = new HybridFile(openmode, path);
+
+      hFile.generateMode(mainFragment.getActivity());
+
+      openmode = hFile.getMode();
+
+      if (hFile.isSmb()) {
+        mainFragmentViewModel.setSmbPath(path);
+      }
+    }
+
+    mainFragmentViewModel.setFolderCount(0);
+    mainFragmentViewModel.setFileCount(0);
+
+    final List<LayoutElementParcelable> list;
+
+    switch (openmode) {
+      case SMB:
+        list = listSmb(hFile, mainActivityViewModel, mainFragment);
+        break;
+
+      case FTP:
+      case SFTP:
+        list = listSftp(mainActivityViewModel);
+        break;
+
+      case CUSTOM:
+      case TRASH_BIN:
+        list = getCachedMediaList(mainActivityViewModel);
+        break;
+
+      case OTG:
+        list = listOtg();
+        openmode = OpenMode.OTG;
+        break;
+
+      case DOCUMENT_FILE:
+        list = listDocumentFiles(mainActivityViewModel);
+        openmode = OpenMode.DOCUMENT_FILE;
+        break;
+
+      case DROPBOX:
+      case BOX:
+      case GDRIVE:
+      case ONEDRIVE:
+        list = listCloud(mainActivityViewModel);
+        break;
+
+      case ANDROID_DATA:
+        list = listAppDataDirectories(path);
+        break;
+
+      default:
+        list = listDefault(mainActivityViewModel, mainFragment);
+        break;
+    }
+
+    if (list != null
+        && !(openmode == OpenMode.CUSTOM
+            && ("5".equals(path) || "6".equals(path) || "7".equals(path)))) {
+
+      postListCustomPathProcess(list, mainFragmentViewModel);
+    }
+
+    return new Pair<>(openmode, list);
+  }
 
   private String path;
   private WeakReference<MainFragment> mainFragmentReference;
@@ -99,7 +188,6 @@ public class LoadFilesListTask
   private OpenMode openmode;
   private boolean showHiddenFiles, showThumbs;
   private DataUtils dataUtils = DataUtils.getInstance();
-  private OnAsyncTaskFinished<Pair<OpenMode, List<LayoutElementParcelable>>> listener;
   private boolean forceReload;
 
   public LoadFilesListTask(
@@ -109,112 +197,17 @@ public class LoadFilesListTask
       OpenMode openmode,
       boolean showThumbs,
       boolean showHiddenFiles,
-      boolean forceReload,
-      OnAsyncTaskFinished<Pair<OpenMode, List<LayoutElementParcelable>>> l) {
+      boolean forceReload) {
     this.path = path;
     this.mainFragmentReference = new WeakReference<>(mainFragment);
     this.openmode = openmode;
     this.context = new WeakReference<>(context);
     this.showThumbs = showThumbs;
     this.showHiddenFiles = showHiddenFiles;
-    this.listener = l;
     this.forceReload = forceReload;
   }
 
-  @Override
-  @SuppressWarnings({"PMD.NPathComplexity", "ComplexMethod", "LongMethod"})
-  protected @Nullable Pair<OpenMode, List<LayoutElementParcelable>> doInBackground(Void... p) {
-    final MainFragment mainFragment = this.mainFragmentReference.get();
-    final Context context = this.context.get();
-
-    if (mainFragment == null
-        || context == null
-        || mainFragment.getMainFragmentViewModel() == null
-        || mainFragment.getMainActivityViewModel() == null
-        || path == null) {
-      cancel(true);
-      return null;
-    }
-
-    HybridFile hFile = null;
-    MainFragmentViewModel mainFragmentViewModel = mainFragment.getMainFragmentViewModel();
-    MainActivityViewModel mainActivityViewModel = mainFragment.getMainActivityViewModel();
-
-    if (OpenMode.UNKNOWN.equals(openmode)
-        || OpenMode.CUSTOM.equals(openmode)
-        || OpenMode.TRASH_BIN.equals(openmode)) {
-      hFile = new HybridFile(openmode, path);
-      hFile.generateMode(mainFragment.getActivity());
-      openmode = hFile.getMode();
-
-      if (hFile.isSmb()) {
-        mainFragmentViewModel.setSmbPath(path);
-      }
-    }
-
-    if (isCancelled()) return null;
-
-    mainFragmentViewModel.setFolderCount(0);
-    mainFragmentViewModel.setFileCount(0);
-    final List<LayoutElementParcelable> list;
-
-    switch (openmode) {
-      case SMB:
-        list = listSmb(hFile, mainActivityViewModel, mainFragment);
-        break;
-      case FTP:
-      case SFTP:
-        list = listSftp(mainActivityViewModel);
-        break;
-      case CUSTOM:
-      case TRASH_BIN:
-        list = getCachedMediaList(mainActivityViewModel);
-        break;
-      case OTG:
-        list = listOtg();
-        openmode = OpenMode.OTG;
-        break;
-      case DOCUMENT_FILE:
-        list = listDocumentFiles(mainActivityViewModel);
-        openmode = OpenMode.DOCUMENT_FILE;
-        break;
-      case DROPBOX:
-      case BOX:
-      case GDRIVE:
-      case ONEDRIVE:
-        try {
-          list = listCloud(mainActivityViewModel);
-        } catch (CloudPluginException e) {
-          LOG.warn("failed to load cloud files", e);
-          AppConfig.toast(context, context.getResources().getString(R.string.failed_no_connection));
-          return new Pair<>(openmode, Collections.emptyList());
-        }
-        break;
-      case ANDROID_DATA:
-        list = listAppDataDirectories(path);
-        break;
-      default:
-        // we're neither in OTG not in SMB, load the list based on root/general filesystem
-        list = listDefault(mainActivityViewModel, mainFragment);
-        break;
-    }
-
-    if (list != null
-        && !(openmode == OpenMode.CUSTOM
-            && (("5").equals(path) || ("6").equals(path) || ("7").equals(path)))) {
-      postListCustomPathProcess(list, mainFragmentViewModel);
-    }
-
-    return new Pair<>(openmode, list);
-  }
-
-  @Override
-  protected void onCancelled() {
-    listener.onAsyncTaskFinished(null);
-  }
-
-  @Override
-  protected void onProgressUpdate(Throwable... values) {
+  public void onProgressUpdate(Throwable... values) {
     for (Throwable exception : values) {
       if (exception instanceof SmbException) {
         if ("/".equals(Uri.parse(path).getPath())) {
@@ -246,11 +239,6 @@ public class LoadFilesListTask
         }
       }
     }
-  }
-
-  @Override
-  protected void onPostExecute(@Nullable Pair<OpenMode, List<LayoutElementParcelable>> list) {
-    listener.onAsyncTaskFinished(list);
   }
 
   private List<LayoutElementParcelable> getCachedMediaList(
@@ -339,8 +327,7 @@ public class LoadFilesListTask
     final Context context = this.context.get();
 
     if (mainFragment == null || context == null) {
-      cancel(true);
-      return null;
+      throw new CancellationException();
     }
 
     String size = "";
@@ -410,8 +397,7 @@ public class LoadFilesListTask
     final Context context = this.context.get();
 
     if (context == null) {
-      cancel(true);
-      return null;
+      throw new CancellationException();
     }
 
     Cursor cursor =
@@ -437,8 +423,7 @@ public class LoadFilesListTask
     final Context context = this.context.get();
 
     if (context == null) {
-      cancel(true);
-      return null;
+      throw new CancellationException();
     }
 
     ArrayList<LayoutElementParcelable> docs = new ArrayList<>();
@@ -499,8 +484,7 @@ public class LoadFilesListTask
     final Context context = this.context.get();
 
     if (context == null) {
-      cancel(true);
-      return null;
+      throw new CancellationException();
     }
 
     ArrayList<LayoutElementParcelable> apks = new ArrayList<>();
@@ -537,8 +521,7 @@ public class LoadFilesListTask
   private @Nullable List<LayoutElementParcelable> listRecent() {
     final MainFragment mainFragment = this.mainFragmentReference.get();
     if (mainFragment == null) {
-      cancel(true);
-      return null;
+      throw new CancellationException();
     }
 
     UtilsHandler utilsHandler = AppConfig.getInstance().getUtilsHandler();
@@ -566,8 +549,7 @@ public class LoadFilesListTask
     final Context context = this.context.get();
 
     if (context == null) {
-      cancel(true);
-      return null;
+      throw new CancellationException();
     }
 
     List<LayoutElementParcelable> recentFiles = new ArrayList<>(20);
@@ -634,8 +616,7 @@ public class LoadFilesListTask
     final Context context = this.context.get();
 
     if (context == null) {
-      cancel(true);
-      return null;
+      throw new CancellationException();
     }
 
     TrashBin trashBin = AppConfig.getInstance().getTrashBinInstance();
@@ -729,7 +710,6 @@ public class LoadFilesListTask
           mainFragment.reauthenticateSmb();
         }
         LOG.warn("failed to load smb list, authentication issue: ", e);
-        publishProgress(e);
         return null;
       } catch (SmbException | NullPointerException e) {
         LOG.warn("Failed to load smb files for path: " + path, e);
@@ -863,8 +843,7 @@ public class LoadFilesListTask
     final Context context = this.context.get();
 
     if (context == null) {
-      cancel(true);
-      return;
+      throw new CancellationException();
     }
 
     OTGUtil.getDocumentFiles(path, context, fileFound);
@@ -874,8 +853,7 @@ public class LoadFilesListTask
     final Context context = this.context.get();
 
     if (context == null) {
-      cancel(true);
-      return;
+      throw new CancellationException();
     }
 
     OTGUtil.getDocumentFiles(
@@ -888,8 +866,7 @@ public class LoadFilesListTask
     final Context context = this.context.get();
 
     if (context == null) {
-      cancel(true);
-      return;
+      throw new CancellationException();
     }
 
     if (!CloudSheetFragment.isCloudProviderAvailable(context)) {

--- a/app/src/main/java/com/amaze/filemanager/ui/fragments/MainFragment.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/fragments/MainFragment.java
@@ -37,6 +37,8 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -98,7 +100,6 @@ import android.content.UriPermission;
 import android.graphics.Color;
 import android.media.RingtoneManager;
 import android.net.Uri;
-import android.os.AsyncTask;
 import android.os.Bundle;
 import android.provider.DocumentsContract;
 import android.text.TextUtils;
@@ -122,6 +123,7 @@ import androidx.core.content.ContextCompat;
 import androidx.core.content.pm.ShortcutInfoCompat;
 import androidx.core.content.pm.ShortcutManagerCompat;
 import androidx.core.graphics.drawable.IconCompat;
+import androidx.core.util.Pair;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentActivity;
 import androidx.fragment.app.FragmentManager;
@@ -133,6 +135,10 @@ import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 
+import io.reactivex.Single;
+import io.reactivex.android.schedulers.AndroidSchedulers;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.schedulers.Schedulers;
 import jcifs.smb.SmbException;
 import jcifs.smb.SmbFile;
 import kotlin.collections.ArraysKt;
@@ -176,6 +182,7 @@ public class MainFragment extends Fragment
   private MainActivityViewModel mainActivityViewModel;
 
   private boolean hideFab = false;
+  private Disposable loadFilesDisposable;
 
   private final ActivityResultLauncher<Intent> handleDocumentUriForRestrictedDirectories =
       registerForActivityResult(
@@ -388,7 +395,7 @@ public class MainFragment extends Fragment
 
   void loadViews() {
     if (!isAdded() || getView() == null) return;
-
+    if (loadFilesDisposable != null && !loadFilesDisposable.isDisposed()) return;
     if (mainFragmentViewModel.getCurrentPath() != null) {
       if (mainFragmentViewModel.getListElements().size() == 0) {
         loadlist(
@@ -640,8 +647,6 @@ public class MainFragment extends Fragment
     requireActivity().finish();
   }
 
-  LoadFilesListTask loadFilesListTask;
-
   /**
    * This loads a path into the MainFragment.
    *
@@ -668,9 +673,9 @@ public class MainFragment extends Fragment
 
     mSwipeRefreshLayout.setRefreshing(true);
 
-    if (loadFilesListTask != null && loadFilesListTask.getStatus() == AsyncTask.Status.RUNNING) {
+    if (loadFilesDisposable != null && !loadFilesDisposable.isDisposed()) {
       LOG.warn("Existing load list task running, cancel current");
-      loadFilesListTask.cancel(true);
+      loadFilesDisposable.dispose();
     }
 
     OpenMode openMode = providedOpenMode;
@@ -686,27 +691,68 @@ public class MainFragment extends Fragment
       openMode = OpenMode.FILE;
     }
 
-    loadFilesListTask =
-        new LoadFilesListTask(
-            getActivity(),
-            actualPath,
-            this,
-            openMode,
-            getBoolean(PREFERENCE_SHOW_THUMB),
-            getBoolean(PREFERENCE_SHOW_HIDDENFILES),
-            forceReload,
-            (data) -> {
-              mSwipeRefreshLayout.setRefreshing(false);
-              if (data != null && data.second != null) {
-                boolean isPathLayoutGrid =
-                    DataUtils.getInstance().getListOrGridForPath(providedPath, DataUtils.LIST)
-                        == DataUtils.GRID;
-                setListElements(data.second, back, providedPath, data.first, isPathLayoutGrid);
-              } else {
-                LOG.warn("Load list operation cancelled");
-              }
-            });
-    loadFilesListTask.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
+    startLoadFiles(openMode, forceReload, actualPath, providedPath, back);
+  }
+
+  private void startLoadFiles(
+      OpenMode openMode,
+      boolean forceReload,
+      String actualPath,
+      final String providedPath,
+      final boolean back) {
+    AtomicReference<LoadFilesListTask> task = new AtomicReference<>();
+    loadFilesDisposable =
+        Single.<Pair<OpenMode, List<LayoutElementParcelable>>>create(
+                emitter -> {
+                  task.set(
+                      new LoadFilesListTask(
+                          getActivity(),
+                          actualPath,
+                          this,
+                          openMode,
+                          getBoolean(PREFERENCE_SHOW_THUMB),
+                          getBoolean(PREFERENCE_SHOW_HIDDENFILES),
+                          forceReload));
+
+                  try {
+
+                    Pair<OpenMode, List<LayoutElementParcelable>> result = task.get().load();
+
+                    if (!emitter.isDisposed()) {
+                      emitter.onSuccess(result);
+                    }
+
+                  } catch (Throwable e) {
+
+                    if (!emitter.isDisposed()) {
+                      emitter.onError(e);
+                    }
+                  }
+                })
+            .subscribeOn(Schedulers.io())
+            .observeOn(AndroidSchedulers.mainThread())
+            .subscribe(
+                data -> {
+                  mSwipeRefreshLayout.setRefreshing(false);
+                  if (data != null && data.second != null) {
+                    boolean isPathLayoutGrid =
+                        DataUtils.getInstance().getListOrGridForPath(providedPath, DataUtils.LIST)
+                            == DataUtils.GRID;
+
+                    setListElements(data.second, back, providedPath, data.first, isPathLayoutGrid);
+                  }
+                },
+                error -> {
+                  mSwipeRefreshLayout.setRefreshing(false);
+                  if (task.get() != null) {
+                    task.get().onProgressUpdate(error);
+                  }
+                  if (error instanceof CancellationException) {
+                    LOG.warn("Load list operation cancelled");
+                  } else {
+                    LOG.error("Failed to load files", error);
+                  }
+                });
   }
 
   @RequiresApi(api = Q)
@@ -814,7 +860,6 @@ public class MainFragment extends Fragment
    * @param back if we're coming back from any directory and want the scroll to be restored
    * @param path the path for the adapter
    * @param openMode the type of file being created
-   * @param results is the list of elements a result from search
    * @param grid whether to set grid view or list view
    */
   public void setListElements(
@@ -1381,6 +1426,14 @@ public class MainFragment extends Fragment
 
     // not guaranteed to be called unless we call #finish();
     // please move code to onStop
+  }
+
+  @Override
+  public void onDestroyView() {
+    if (loadFilesDisposable != null) {
+      loadFilesDisposable.dispose();
+    }
+    super.onDestroyView();
   }
 
   public void hide(String path) {


### PR DESCRIPTION
- Refactor LoadFilesListTask to remove AsyncTask dependency and expose a standalone load() method
- Use RxJava Single in MainFragment for asynchronous file loading and lifecycle-aware cancellation
- Track loading Disposable and dispose it when starting a new load or destroying the view
- Move error handling and progress updates to the reactive flow
- Remove manual task state checks and rely on RxJava cancellation handling

Fixes #4670: New tab doubles file count

<!-- 
Read this first:
To open a pull request read this file,
uncomment the corresponding lines and 
complete them.
-->

## Description

#### Issue tracker   
Fixes #4670 
Addresses New tab doubles file count

#### Automatic tests
<!-- remember to do manual testing when making UI changes! -->
- [ ] Added unit tests for specific individual functions
- [ ] Added headless tests for new app functionality
- [ ] Added emulator tests for new UI elements
  
#### Manual tests
- [x] Done
  
- Device: poco x60 pro
- OS: 16

#### Build tasks success  
<!-- run these! -->
Successfully running following tasks on local:
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`

#### Generative code

- [ ] This PR used generative code tools (GenAI, LLMs, etc.)

    
- Model:
- Version:
- Provider:



<!-- If there are related PRs please add them here -->
<!--
#### Related PR  
Related to PR #
-->
