### PR TITLE
[ai] Mark Wi-Fi hardware as optional for Play Store.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -53,6 +53,10 @@
     <uses-feature android:name="android.software.leanback"
         android:required="false" />
 
+    <uses-feature
+        android:name="android.hardware.wifi"
+        android:required="false" />
+
     <application
         android:name=".application.AppConfig"
         android:icon="@mipmap/ic_launcher"


### PR DESCRIPTION
## Description

Amaze stopped appearing as compatible for some Android TV devices after
v3.10. `aapt2 dump badging` showed that the Play flavor required
`android.hardware.wifi`, even though Wi-Fi is only needed for SMB
discovery and not for the file manager itself to run.

Declare Wi-Fi hardware as optional so Google Play does not unnecessarily
filter Android TV devices that do not report Wi-Fi support.

#### Issue tracker

Fixes #4556

#### Automatic tests

- [ ] Added unit tests for specific individual functions
- [ ] Added headless tests for new app functionality
- [ ] Added emulator tests for new UI elements

#### Manual tests

- [x] Done

- Device: local build artifact verification
- OS: Linux

Verified with `aapt2 dump badging` that the Play debug APK reports:

- `android.hardware.touchscreen` as not required
- `android.hardware.wifi` as not required
- `android.software.leanback` as not required
- native code includes `arm64-v8a`, `armeabi-v7a`, `x86`, and `x86_64`

#### Build tasks success

Successfully running following tasks on local:

- [x] `./gradlew :app:processPlayReleaseManifest`
- [x] `./gradlew :app:assemblePlayDebug`
- [x] `./gradlew spotlessCheck` — passed; emitted an existing Spotless warning for `FtpServerFragment.kt`

#### Generative code

- [x] This PR used generative code tools (GenAI, LLMs, etc.)

- Model: GPT-5 / Codex
- Version: ChatGPT Codex
- Provider: OpenAI