### PR TITLE
[ai] android tv: Support ACTION_OPEN_DOCUMENT file picking

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -88,6 +88,13 @@
             </intent-filter>
 
             <intent-filter>
+                <action android:name="android.intent.action.OPEN_DOCUMENT" />
+                <data android:mimeType="*/*" />
+                <category android:name="android.intent.category.OPENABLE" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+
+            <intent-filter>
                 <action android:name="android.intent.action.RINGTONE_PICKER" />
                 <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>

--- a/app/src/main/java/com/amaze/filemanager/ui/activities/MainActivity.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/activities/MainActivity.java
@@ -411,7 +411,7 @@ public class MainActivity extends PermissionsActivity
 
     String actionIntent = intent != null ? intent.getAction() : null;
 
-    if (Intent.ACTION_GET_CONTENT.equals(actionIntent)
+    if (isFilePickerIntent(actionIntent)
         || RingtoneManager.ACTION_RINGTONE_PICKER.equals(actionIntent)
         || Intent.ACTION_VIEW.equals(actionIntent)
         || Intent.ACTION_SEND.equals(actionIntent)
@@ -605,6 +605,11 @@ public class MainActivity extends PermissionsActivity
     return false;
   }
 
+  private static boolean isFilePickerIntent(@Nullable String actionIntent) {
+    return Intent.ACTION_GET_CONTENT.equals(actionIntent)
+        || Intent.ACTION_OPEN_DOCUMENT.equals(actionIntent);
+  }
+
   /** Checks for the action to take when Amaze receives an intent from external source */
   private void checkForExternalIntent(Intent intent) {
     final String actionIntent = intent.getAction();
@@ -614,7 +619,7 @@ public class MainActivity extends PermissionsActivity
 
     final String type = intent.getType();
 
-    if (actionIntent.equals(Intent.ACTION_GET_CONTENT)) {
+    if (isFilePickerIntent(actionIntent)) {
       // file picker intent
       mReturnIntent = true;
       String text =

--- a/app/src/test/java/com/amaze/filemanager/ui/activities/MainActivityTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/ui/activities/MainActivityTest.kt
@@ -20,14 +20,19 @@
 
 package com.amaze.filemanager.ui.activities
 
+import android.content.Intent
+import android.content.pm.PackageManager
 import androidx.lifecycle.Lifecycle
 import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
 import com.amaze.filemanager.application.AppConfig
+import com.amaze.filemanager.ui.icons.MimeTypes
 import com.amaze.filemanager.utils.smb.SmbUtil.getSmbDecryptedPath
 import com.amaze.filemanager.utils.smb.SmbUtil.getSmbEncryptedPath
 import org.awaitility.Awaitility.await
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.robolectric.shadows.ShadowLooper
 import java.util.concurrent.TimeUnit
@@ -37,6 +42,59 @@ import java.util.concurrent.TimeUnit
  */
 @Suppress("StringLiteralDuplication")
 class MainActivityTest : AbstractMainActivityTestBase() {
+    /** Test Amaze is advertised as a document picker. */
+    @Test
+    fun testOpenDocumentIntentResolvesToMainActivity() {
+        val context = ApplicationProvider.getApplicationContext<AppConfig>()
+        val intent =
+            Intent(Intent.ACTION_OPEN_DOCUMENT).apply {
+                addCategory(Intent.CATEGORY_OPENABLE)
+                type = MimeTypes.ALL_MIME_TYPES
+                setPackage(context.packageName)
+            }
+
+        val handlers =
+            context.packageManager.queryIntentActivities(
+                intent,
+                PackageManager.MATCH_DEFAULT_ONLY,
+            )
+
+        assertTrue(
+            "MainActivity must handle ACTION_OPEN_DOCUMENT",
+            handlers.any { it.activityInfo.name == MainActivity::class.java.name },
+        )
+    }
+
+    /** Test OPEN_DOCUMENT starts the existing file-picking flow. */
+    @Test
+    fun testOpenDocumentIntentEnablesFilePicking() {
+        val context = ApplicationProvider.getApplicationContext<AppConfig>()
+        val intent =
+            Intent(context, MainActivity::class.java).apply {
+                action = Intent.ACTION_OPEN_DOCUMENT
+                addCategory(Intent.CATEGORY_OPENABLE)
+                type = MimeTypes.ALL_MIME_TYPES
+            }
+        val scenario = ActivityScenario.launch<MainActivity>(intent)
+
+        try {
+            ShadowLooper.idleMainLooper()
+            scenario.moveToState(Lifecycle.State.STARTED)
+            scenario.onActivity { activity ->
+                assertTrue(
+                    "OPEN_DOCUMENT must enable file-picking mode",
+                    activity.mReturnIntent,
+                )
+                assertFalse(
+                    "OPEN_DOCUMENT must not enable ringtone-picking mode",
+                    activity.mRingtonePickerIntent,
+                )
+            }
+        } finally {
+            scenario.close()
+        }
+    }
+
     /**
      * Test update SMB connection should never throw [NullPointerException] i.e. the correct
      * connection is updated.


### PR DESCRIPTION
Fixes: #4079

## Description

Some Android TV applications use `ACTION_OPEN_DOCUMENT` to find a
file manager, while Amaze only advertised `ACTION_GET_CONTENT`.

Advertise the missing intent and route it through the existing
file-picking flow so selected files are returned to the caller.
The existing `GET_CONTENT` behavior remains unchanged.

Add regression coverage for manifest resolution and file-picker mode
activation.

Amaze was verified as an available file manager alongside Material
Files. Selecting `ALWAYS` made subsequent `OPEN_DOCUMENT` requests
launch Amaze directly without displaying `ResolverActivity`.

#### Issue tracker
Fixes #4079

#### Automatic tests
<!-- remember to do manual testing when making UI changes! -->
- [x] Added unit tests for specific individual functions
- [x] Added headless tests for new app functionality
- [ ] Added emulator tests for new UI elements

Successfully ran:

- [x] `./gradlew :app:testFdroidDebugUnitTest --tests com.amaze.filemanager.ui.activities.MainActivityTest --tests com.amaze.filemanager.ui.fragments.MainFragmentReturnIntentResultsTest`

#### Manual tests
- [x] Done

- Devices:
  - Polytron PLD 43S883MBN
  - Amlogic Media Player Android Box
- OS:
  - Android TV 7.1.2 (API 25)
  - Android 9 (API 28)

Manually verified:

- [x] Amaze appears alongside Material Files in the system resolver
- [x] `ACTION_OPEN_DOCUMENT` with `*/*`
- [x] `ACTION_OPEN_DOCUMENT` with specific MIME types
- [x] Existing `ACTION_GET_CONTENT` flow
- [x] Single-file selection
- [x] Multiple-file selection
- [x] Warm `MainActivity` intent handling
- [x] D-pad navigation
- [x] Cancellation using the Back button
- [x] Selecting `ALWAYS` launches Amaze directly on later requests
- [x] No crashes, ANRs, `SecurityException`, or unintended file viewers

#### Build tasks success
<!-- run these! -->
Successfully running following tasks on local:

- [x] `./gradlew assembledebug`
- [x] `./gradlew assembleFdroidDebug`
- [x] `./gradlew spotlessCheck`

#### Generative code

- [x] This PR used generative code tools (GenAI, LLMs, etc.)

- Model: Codex
- Version: GPT-5
- Provider: OpenAI


#### Additional technical write-up

A more detailed explanation of the root cause, implementation decisions,
and physical Android TV testing is available here:

[Making Amaze Discoverable as a File Manager on Android TV](https://pilkupil.my.id/article/making-amaze-discoverable-as-a-file-manager-on-android-tv)


#### Screenshots

Amaze is now discovered alongside Material Files as an
`ACTION_OPEN_DOCUMENT` handler on an Android Box running Android 9
(API 28).

<img width="900" alt="Amaze Debug and Material Files shown in the Android TV resolver" src="https://github.com/user-attachments/assets/dab3675b-8356-401c-b467-39b62685f423" />

After selecting Amaze, Android provides the `JUST ONCE` and `ALWAYS`
options, allowing Amaze to become the default handler for matching
file-picker requests.

<img width="900" alt="Android TV resolver showing Just Once and Always options for Amaze" src="https://github.com/user-attachments/assets/2f0144c3-d1f6-4401-b3c3-5698baba8970" />

<!-- If there are related PRs please add them here -->
<!--
#### Related PR
Related to PR #
-->